### PR TITLE
Feat/omni cli

### DIFF
--- a/tools/omni/CMakeLists.txt
+++ b/tools/omni/CMakeLists.txt
@@ -94,6 +94,13 @@ endif()
 target_link_libraries  (${TARGET} PRIVATE common omni Threads::Threads)
 target_compile_features(${TARGET} PRIVATE cxx_std_17)
 
+# 单工模式测试（批量 prefill + 单次 decode）
+set(TARGET_SINGLEPLEX_TEST llama-omni-test-singleplex)
+add_executable         (${TARGET_SINGLEPLEX_TEST} test/test-singleplex.cpp)
+set_target_properties  (${TARGET_SINGLEPLEX_TEST} PROPERTIES OUTPUT_NAME llama-omni-test-singleplex)
+target_link_libraries  (${TARGET_SINGLEPLEX_TEST} PRIVATE common omni Threads::Threads)
+target_compile_features(${TARGET_SINGLEPLEX_TEST} PRIVATE cxx_std_17)
+
 # 双工模式测试
 set(TARGET_DUPLEX_TEST llama-omni-test-duplex)
 add_executable         (${TARGET_DUPLEX_TEST} test/test-duplex.cpp)

--- a/tools/omni/CMakeLists.txt
+++ b/tools/omni/CMakeLists.txt
@@ -94,12 +94,19 @@ endif()
 target_link_libraries  (${TARGET} PRIVATE common omni Threads::Threads)
 target_compile_features(${TARGET} PRIVATE cxx_std_17)
 
-# 单工模式测试（批量 prefill + 单次 decode）
-set(TARGET_SINGLEPLEX_TEST llama-omni-test-singleplex)
-add_executable         (${TARGET_SINGLEPLEX_TEST} test/test-singleplex.cpp)
-set_target_properties  (${TARGET_SINGLEPLEX_TEST} PROPERTIES OUTPUT_NAME llama-omni-test-singleplex)
-target_link_libraries  (${TARGET_SINGLEPLEX_TEST} PRIVATE common omni Threads::Threads)
-target_compile_features(${TARGET_SINGLEPLEX_TEST} PRIVATE cxx_std_17)
+# 单工模式 - 纯音频测试（批量 prefill + 单次 decode）
+set(TARGET_SINGLE_TEST_AUDIO llama-omni-single-test-audio)
+add_executable         (${TARGET_SINGLE_TEST_AUDIO} test/single_test_audio.cpp)
+set_target_properties  (${TARGET_SINGLE_TEST_AUDIO} PROPERTIES OUTPUT_NAME llama-omni-single-test-audio)
+target_link_libraries  (${TARGET_SINGLE_TEST_AUDIO} PRIVATE common omni Threads::Threads)
+target_compile_features(${TARGET_SINGLE_TEST_AUDIO} PRIVATE cxx_std_17)
+
+# 单工模式 - Omni (audio+vision) 测试
+set(TARGET_SINGLE_TEST_OMNI llama-omni-single-test-omni)
+add_executable         (${TARGET_SINGLE_TEST_OMNI} test/single_test_omni.cpp)
+set_target_properties  (${TARGET_SINGLE_TEST_OMNI} PROPERTIES OUTPUT_NAME llama-omni-single-test-omni)
+target_link_libraries  (${TARGET_SINGLE_TEST_OMNI} PRIVATE common omni Threads::Threads)
+target_compile_features(${TARGET_SINGLE_TEST_OMNI} PRIVATE cxx_std_17)
 
 # 双工模式测试
 set(TARGET_DUPLEX_TEST llama-omni-test-duplex)

--- a/tools/omni/merge_wav.sh
+++ b/tools/omni/merge_wav.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# 合并 tts_wav 目录下的 wav_0.wav, wav_1.wav, ... 为一个完整音频。
+# 按数字顺序排序（避免 wav_10 排到 wav_2 前面），用 ffmpeg concat 无损拼接。
+#
+# 用法:
+#   ./merge_wav.sh [wav_dir] [output_file]
+# 示例:
+#   ./tools/omni/merge_wav.sh
+#   ./tools/omni/merge_wav.sh tools/omni/output/round_000/tts_wav merged.wav
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WAV_DIR="${1:-$SCRIPT_DIR/output/round_000/tts_wav}"
+OUT="${2:-${WAV_DIR%/}/merged.wav}"
+
+if [[ ! -d "$WAV_DIR" ]]; then
+    echo "Error: 目录不存在: $WAV_DIR" >&2
+    exit 1
+fi
+
+count=$(find "$WAV_DIR" -maxdepth 1 -name 'wav_*.wav' | wc -l)
+if [[ "$count" -eq 0 ]]; then
+    echo "Error: $WAV_DIR 下没有 wav_*.wav 文件" >&2
+    exit 1
+fi
+
+LIST_FILE="$(mktemp --suffix=.txt)"
+trap 'rm -f "$LIST_FILE"' EXIT
+
+find "$WAV_DIR" -maxdepth 1 -name 'wav_*.wav' -printf '%f\n' \
+    | awk -F'wav_|\\.wav' '{print $2"\t"$0}' \
+    | sort -n \
+    | cut -f2 \
+    | while read -r fname; do
+        printf "file '%s'\n" "$(readlink -f "$WAV_DIR/$fname")" >> "$LIST_FILE"
+    done
+
+echo "Merging $count wav files -> $OUT"
+ffmpeg -y -hide_banner -loglevel warning -f concat -safe 0 -i "$LIST_FILE" -c copy "$OUT"
+echo "Done: $OUT ($(du -h "$OUT" | cut -f1), $(ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "$OUT")s)"

--- a/tools/omni/omni-cli.cpp
+++ b/tools/omni/omni-cli.cpp
@@ -18,7 +18,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <vector>
 
 #if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
 #include <signal.h>
@@ -32,84 +31,66 @@
 #include <signal.h>
 #endif
 
-// volatile, because of signal being an interrupt
-static volatile bool g_is_generating = false;
-static volatile bool g_is_interrupted = false;
-
 /**
- * Please note that this is NOT a production-ready stuff.
- * It is a playground for trying multimodal support in llama.cpp.
- * For contributors: please keep this code simple and easy to understand.
+ * MiniCPM-o Omni 单轮 CLI（同步）
+ *
+ * 设计：
+ *   - 同步单轮：prefill 与 decode 串行，阻塞直到全部产出完成后退出。
+ *   - 三类输入（audio / image / text）均可选，至少给一个。
+ *   - --omni 控制是否加载视觉模型；没开就拒绝 -i。
+ *   - 启用 TTS 时把生成的 wav 写入 -o 指定（或默认）的输出目录；
+ *     禁用 TTS 时不起 TTS 线程，仅把文字回复打到 stdout。
  */
 
 static void show_usage(const char * prog_name) {
     printf(
-        "MiniCPM-o Omni CLI - Multimodal inference tool\n\n"
-        "Usage: %s -m <llm_model_path> [options]\n\n"
-        "Required:\n"
-        "  -m <path>           Path to LLM GGUF model (e.g., MiniCPM-o-4_5-Q4_K_M.gguf)\n"
-        "                      Other model paths will be auto-detected from directory structure:\n"
-        "                        {dir}/vision/MiniCPM-o-4_5-vision-F16.gguf\n"
-        "                        {dir}/audio/MiniCPM-o-4_5-audio-F16.gguf\n"
-        "                        {dir}/tts/MiniCPM-o-4_5-tts-F16.gguf\n"
-        "                        {dir}/tts/MiniCPM-o-4_5-projector-F16.gguf\n\n"
-        "Options:\n"
-        "  --vision <path>     Override vision model path\n"
-        "  --audio <path>      Override audio model path\n"
-        "  --tts <path>        Override TTS model path\n"
-        "  --projector <path>  Override projector model path\n"
-        "  --ref-audio <path>  Reference audio for voice cloning (default: tools/omni/assets/default_ref_audio/default_ref_audio.wav)\n"
-        "  -c, --ctx-size <n>  Context size (default: 4096)\n"
-        "  -ngl <n>            Number of GPU layers (default: 99)\n"
-        "  --no-tts            Disable TTS output\n"
-        "  --omni              Enable omni mode (audio + vision, media_type=2)\n"
-        "  --vision-backend <mode>  Vision compute backend: 'metal' (default) or 'coreml' (ANE)\n"
-        "  --vision-coreml <path>   Path to CoreML model (.mlmodelc), required when backend=coreml\n"
-        "  --test <prefix> <n> Run test case with data prefix and count\n"
-        "  -h, --help          Show this help message\n\n"
-        "Example:\n"
-        "  %s -m ./models/MiniCPM-o-4_5-gguf/MiniCPM-o-4_5-Q4_K_M.gguf\n"
-        "  %s -m ./models/MiniCPM-o-4_5-gguf/MiniCPM-o-4_5-F16.gguf --no-tts\n"
-        "  %s -m ./models/MiniCPM-o-4_5-gguf/MiniCPM-o-4_5-Q4_K_M.gguf --omni --test tools/omni/assets/test_case/omni_test_case/omni_test_case_ 9\n",
-        prog_name, prog_name, prog_name, prog_name
+        "MiniCPM-o Omni CLI - 单轮同步多模态推理\n\n"
+        "Usage: %s -m <llm_model_path> [-a <audio>] [-i <image>] [-p <text>] [options]\n\n"
+        "必需:\n"
+        "  -m <path>                LLM GGUF 模型路径 (e.g., MiniCPM-o-4_5-Q4_K_M.gguf)\n"
+        "                           其他模型路径从目录结构自动推断:\n"
+        "                             {dir}/vision/MiniCPM-o-4_5-vision-F16.gguf (仅 --omni)\n"
+        "                             {dir}/audio/MiniCPM-o-4_5-audio-F16.gguf\n"
+        "                             {dir}/tts/MiniCPM-o-4_5-tts-F16.gguf       (默认启用 TTS)\n"
+        "                             {dir}/tts/MiniCPM-o-4_5-projector-F16.gguf\n\n"
+        "输入 (至少提供一项):\n"
+        "  -a, --audio-input <path> 输入音频 (.wav)\n"
+        "  -i, --image <path>       输入图片 (.jpg/.png) —— 需同时开启 --omni\n"
+        "  -p, --prompt <text>      输入文字\n\n"
+        "选项:\n"
+        "      --omni               加载视觉模型，允许 -i；不设则不加载视觉\n"
+        "      --no-tts             关闭 TTS，只输出文字回复\n"
+        "  -o, --output-dir <path>  TTS 音频输出根目录 (默认: ./tools/omni/output)\n"
+        "      --ref-audio <path>   参考音频（声音克隆）\n"
+        "                           默认: tools/omni/assets/default_ref_audio/default_ref_audio.wav\n"
+        "  -c, --ctx-size <n>       上下文长度 (默认 4096)\n"
+        "  -ngl <n>                 GPU 层数 (默认 99)\n"
+        "      --vision <path>      覆盖 vision 模型路径\n"
+        "      --audio <path>       覆盖 audio 模型路径\n"
+        "      --tts <path>         覆盖 TTS 模型路径\n"
+        "      --projector <path>   覆盖 projector 模型路径\n"
+        "      --vision-backend <mode>  metal (默认) 或 coreml\n"
+        "      --vision-coreml <path>   CoreML 模型路径 (backend=coreml 时需要)\n"
+        "  -h, --help               显示帮助\n\n"
+        "示例:\n"
+        "  纯文字 QA:\n"
+        "    %s -m ./models/MiniCPM-o-4_5-Q4_K_M.gguf -p \"介绍一下你自己\" --no-tts\n"
+        "  音频 + 文字 + 视觉 + TTS 输出:\n"
+        "    %s -m ./models/MiniCPM-o-4_5-Q4_K_M.gguf --omni \\\n"
+        "       -a ./input.wav -i ./input.jpg -p \"描述一下图片里的场景\" \\\n"
+        "       -o ./out\n",
+        prog_name, prog_name, prog_name
     );
 }
 
-#if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__)) || defined (_WIN32)
-static void sigint_handler(int signo) {
-    if (signo == SIGINT) {
-        if (g_is_generating) {
-            g_is_generating = false;
-        } else {
-            console::cleanup();
-            if (g_is_interrupted) {
-                _exit(1);
-            }
-            g_is_interrupted = true;
-        }
-    }
-}
-#endif
-
-// 从 LLM 模型路径推断其他模型路径
-// 目录结构:
-// MiniCPM-o-4_5-gguf/
-// ├── MiniCPM-o-4_5-{量化}.gguf          (LLM)
-// ├── audio/
-// │   └── MiniCPM-o-4_5-audio-F16.gguf
-// ├── tts/
-// │   ├── MiniCPM-o-4_5-projector-F16.gguf
-// │   └── MiniCPM-o-4_5-tts-F16.gguf
-// └── vision/
-//     └── MiniCPM-o-4_5-vision-F16.gguf
 struct OmniModelPaths {
-    std::string llm;           // LLM 模型路径
-    std::string vision;        // 视觉模型路径
-    std::string audio;         // 音频模型路径
-    std::string tts;           // TTS 模型路径
-    std::string projector;     // Projector 模型路径
-    std::string vision_coreml; // CoreML 视觉模型路径 (.mlmodelc)
-    std::string base_dir;      // 模型根目录
+    std::string llm;
+    std::string vision;
+    std::string audio;
+    std::string tts;
+    std::string projector;
+    std::string vision_coreml;
+    std::string base_dir;
 };
 
 static std::string get_parent_dir(const std::string & path) {
@@ -133,126 +114,57 @@ static OmniModelPaths resolve_model_paths(const std::string & llm_path) {
     OmniModelPaths paths;
     paths.llm = llm_path;
     paths.base_dir = get_parent_dir(llm_path);
-    
-    // 自动推断其他模型路径
-    paths.vision = paths.base_dir + "/vision/MiniCPM-o-4_5-vision-F16.gguf";
-    paths.audio = paths.base_dir + "/audio/MiniCPM-o-4_5-audio-F16.gguf";
-    paths.tts = paths.base_dir + "/tts/MiniCPM-o-4_5-tts-F16.gguf";
-    paths.projector = paths.base_dir + "/tts/MiniCPM-o-4_5-projector-F16.gguf";
+
+    paths.vision        = paths.base_dir + "/vision/MiniCPM-o-4_5-vision-F16.gguf";
+    paths.audio         = paths.base_dir + "/audio/MiniCPM-o-4_5-audio-F16.gguf";
+    paths.tts           = paths.base_dir + "/tts/MiniCPM-o-4_5-tts-F16.gguf";
+    paths.projector     = paths.base_dir + "/tts/MiniCPM-o-4_5-projector-F16.gguf";
     paths.vision_coreml = paths.base_dir + "/vision/coreml_minicpmo45_vit_all_f16.mlmodelc";
-    
+
     return paths;
-}
-
-static void print_model_paths(const OmniModelPaths & paths) {
-    printf("=== Model Paths ===\n");
-    printf("  Base dir:   %s\n", paths.base_dir.c_str());
-    printf("  LLM:        %s %s\n", paths.llm.c_str(), file_exists(paths.llm) ? "[OK]" : "[NOT FOUND]");
-    printf("  Vision:     %s %s\n", paths.vision.c_str(), file_exists(paths.vision) ? "[OK]" : "[NOT FOUND]");
-    printf("  Audio:      %s %s\n", paths.audio.c_str(), file_exists(paths.audio) ? "[OK]" : "[NOT FOUND]");
-    printf("  TTS:        %s %s\n", paths.tts.c_str(), file_exists(paths.tts) ? "[OK]" : "[NOT FOUND]");
-    printf("  Projector:  %s %s\n", paths.projector.c_str(), file_exists(paths.projector) ? "[OK]" : "[NOT FOUND]");
-    printf("===================\n");
-}
-
-void test_case(struct omni_context *ctx_omni, common_params& params, std::string data_path_prefix, int cnt){
-    // 🔧 单工模式：先 prefill 所有输入，然后 decode 一次生成完整回复
-    // 使用同步模式 prefill，避免 async 模式下的竞态条件
-    ctx_omni->system_prompt_initialized = false;
-    bool orig_async = ctx_omni->async;
-    ctx_omni->async = false;  // 使用同步模式 prefill，确保所有数据被处理
-    
-    for (int il = 0; il < cnt; ++il) {
-        char idx_str[16];
-        snprintf(idx_str, sizeof(idx_str), "%04d", il);  // 格式化为4位数字，如 0000, 0001
-        std::string aud_fname = data_path_prefix + idx_str + ".wav";
-
-        // omni 模式：自动检测同名 .jpg 图片
-        std::string img_fname;
-        std::string img_candidate = data_path_prefix + idx_str + ".jpg";
-        if (file_exists(img_candidate)) {
-            img_fname = img_candidate;
-        }
-
-        auto t0 = std::chrono::high_resolution_clock::now();
-        // index 从 0 开始，第一次 prefill (index=0) 初始化系统 prompt
-        // 后续 prefill 在同步模式下直接添加到 KV cache
-        stream_prefill(ctx_omni, aud_fname, img_fname, il);
-        auto t1 = std::chrono::high_resolution_clock::now();
-        std::chrono::duration<double> elapsed_seconds = t1 - t0;
-        double dt = elapsed_seconds.count();
-        if (img_fname.empty()) {
-            std::cout << "prefill " << il << " (audio) : " << dt << " s" << std::endl;
-        } else {
-            std::cout << "prefill " << il << " (audio+vision) : " << dt << " s" << std::endl;
-        }
-    }
-    
-    // 所有数据同步 prefill 完成后，恢复 async 模式并调用 decode
-    // 注意：同步 prefill 不会启动线程，需要用 async=true 的方式调用 decode
-    // stream_decode 内部会检查 async 并启动 TTS/T2W 线程
-    ctx_omni->async = orig_async;
-    stream_decode(ctx_omni, "./");
 }
 
 int main(int argc, char ** argv) {
     ggml_time_init();
 
-    // 命令行参数
     std::string llm_path;
+    std::string audio_input;
+    std::string image_input;
+    std::string text_input;
     std::string vision_path_override;
     std::string audio_path_override;
     std::string tts_path_override;
     std::string projector_path_override;
-    std::string vision_backend = "metal";  // vision backend: "metal" (default) or "coreml"
-    std::string vision_coreml_model_path;  // CoreML model path (required when vision_backend=coreml)
+    std::string vision_backend = "metal";
+    std::string vision_coreml_model_path;
     std::string ref_audio_path = "tools/omni/assets/default_ref_audio/default_ref_audio.wav";
-    int n_ctx = 4096;
-    int n_gpu_layers = 99;  // GPU 层数，默认 99
-    int media_type = 1;     // 1=audio only, 2=omni (audio+vision)
-    bool use_tts = true;
-    bool run_test = false;
-    std::string test_audio_prefix;
-    int test_count = 0;
-    
-    // 解析命令行参数
+    std::string output_dir = "./tools/omni/output";
+    int  n_ctx        = 4096;
+    int  n_gpu_layers = 99;
+    bool use_omni     = false;   // 是否加载视觉模型
+    bool use_tts      = true;    // 是否生成 TTS 音频
+
     for (int i = 1; i < argc; i++) {
         std::string arg = argv[i];
-        
+
         if (arg == "-h" || arg == "--help") {
             show_usage(argv[0]);
             return 0;
         }
-        else if (arg == "-m" && i + 1 < argc) {
-            llm_path = argv[++i];
-        }
-        else if (arg == "--vision" && i + 1 < argc) {
-            vision_path_override = argv[++i];
-        }
-        else if (arg == "--audio" && i + 1 < argc) {
-            audio_path_override = argv[++i];
-        }
-        else if (arg == "--tts" && i + 1 < argc) {
-            tts_path_override = argv[++i];
-        }
-        else if (arg == "--projector" && i + 1 < argc) {
-            projector_path_override = argv[++i];
-        }
-        else if (arg == "--ref-audio" && i + 1 < argc) {
-            ref_audio_path = argv[++i];
-        }
-        else if ((arg == "-c" || arg == "--ctx-size") && i + 1 < argc) {
-            n_ctx = std::atoi(argv[++i]);
-        }
-        else if (arg == "-ngl" && i + 1 < argc) {
-            n_gpu_layers = std::atoi(argv[++i]);
-        }
-        else if (arg == "--no-tts") {
-            use_tts = false;
-        }
-        else if (arg == "--omni") {
-            media_type = 2;
-        }
+        else if (arg == "-m" && i + 1 < argc)                               { llm_path = argv[++i]; }
+        else if ((arg == "-a" || arg == "--audio-input") && i + 1 < argc)   { audio_input = argv[++i]; }
+        else if ((arg == "-i" || arg == "--image") && i + 1 < argc)         { image_input = argv[++i]; }
+        else if ((arg == "-p" || arg == "--prompt") && i + 1 < argc)        { text_input = argv[++i]; }
+        else if (arg == "--omni")                                           { use_omni = true; }
+        else if (arg == "--no-tts")                                         { use_tts = false; }
+        else if ((arg == "-o" || arg == "--output-dir") && i + 1 < argc)    { output_dir = argv[++i]; }
+        else if (arg == "--ref-audio" && i + 1 < argc)                      { ref_audio_path = argv[++i]; }
+        else if ((arg == "-c" || arg == "--ctx-size") && i + 1 < argc)      { n_ctx = std::atoi(argv[++i]); }
+        else if (arg == "-ngl" && i + 1 < argc)                             { n_gpu_layers = std::atoi(argv[++i]); }
+        else if (arg == "--vision" && i + 1 < argc)                         { vision_path_override = argv[++i]; }
+        else if (arg == "--audio" && i + 1 < argc)                          { audio_path_override = argv[++i]; }
+        else if (arg == "--tts" && i + 1 < argc)                            { tts_path_override = argv[++i]; }
+        else if (arg == "--projector" && i + 1 < argc)                      { projector_path_override = argv[++i]; }
         else if (arg == "--vision-backend" && i + 1 < argc) {
             vision_backend = argv[++i];
             if (vision_backend != "metal" && vision_backend != "coreml") {
@@ -260,127 +172,208 @@ int main(int argc, char ** argv) {
                 return 1;
             }
         }
-        else if (arg == "--vision-coreml" && i + 1 < argc) {
-            vision_coreml_model_path = argv[++i];
-        }
-        else if (arg == "--test" && i + 2 < argc) {
-            run_test = true;
-            test_audio_prefix = argv[++i];
-            test_count = std::atoi(argv[++i]);
-        }
+        else if (arg == "--vision-coreml" && i + 1 < argc)                  { vision_coreml_model_path = argv[++i]; }
         else {
             fprintf(stderr, "Unknown argument: %s\n", arg.c_str());
             show_usage(argv[0]);
             return 1;
         }
     }
-    
-    // 检查必需参数
+
+    // ===== 参数校验 =====
     if (llm_path.empty()) {
         fprintf(stderr, "Error: -m <llm_model_path> is required\n\n");
         show_usage(argv[0]);
         return 1;
     }
-    
-    // 解析模型路径
-    OmniModelPaths paths = resolve_model_paths(llm_path);
-    
-    // 应用覆盖路径
-    if (!vision_path_override.empty()) paths.vision = vision_path_override;
-    if (!audio_path_override.empty()) paths.audio = audio_path_override;
-    if (!tts_path_override.empty()) paths.tts = tts_path_override;
-    if (!projector_path_override.empty()) paths.projector = projector_path_override;
-    
-    // 打印模型路径
-    print_model_paths(paths);
-    
-    // 检查必需文件
-    if (!file_exists(paths.llm)) {
-        fprintf(stderr, "Error: LLM model not found: %s\n", paths.llm.c_str());
+
+    const bool has_audio = !audio_input.empty();
+    const bool has_image = !image_input.empty();
+    const bool has_text  = !text_input.empty();
+    if (!has_audio && !has_image && !has_text) {
+        fprintf(stderr, "Error: 至少提供 -a / -i / -p 中的一项输入\n\n");
+        show_usage(argv[0]);
         return 1;
     }
-    if (!file_exists(paths.audio)) {
-        fprintf(stderr, "Error: Audio model not found: %s\n", paths.audio.c_str());
+    if (has_image && !use_omni) {
+        fprintf(stderr, "Error: 使用 -i 必须同时加上 --omni 来加载视觉模型\n");
         return 1;
+    }
+    if (has_audio && !file_exists(audio_input)) {
+        fprintf(stderr, "Error: 音频文件不存在: %s\n", audio_input.c_str()); return 1;
+    }
+    if (has_image && !file_exists(image_input)) {
+        fprintf(stderr, "Error: 图片文件不存在: %s\n", image_input.c_str()); return 1;
+    }
+
+    // ===== 解析模型路径 =====
+    OmniModelPaths paths = resolve_model_paths(llm_path);
+    if (!vision_path_override.empty())    paths.vision    = vision_path_override;
+    if (!audio_path_override.empty())     paths.audio     = audio_path_override;
+    if (!tts_path_override.empty())       paths.tts       = tts_path_override;
+    if (!projector_path_override.empty()) paths.projector = projector_path_override;
+
+    if (!file_exists(paths.llm)) {
+        fprintf(stderr, "Error: LLM model not found: %s\n", paths.llm.c_str()); return 1;
+    }
+    // audio encoder 一直需要，因为系统 prompt 里会塞参考音频做声音克隆
+    if (!file_exists(paths.audio)) {
+        fprintf(stderr, "Error: Audio model not found: %s\n", paths.audio.c_str()); return 1;
+    }
+    if (use_omni && !file_exists(paths.vision)) {
+        fprintf(stderr, "Error: --omni 开启但 vision 模型不存在: %s\n", paths.vision.c_str()); return 1;
     }
     if (use_tts && !file_exists(paths.tts)) {
-        fprintf(stderr, "Warning: TTS model not found: %s, disabling TTS\n", paths.tts.c_str());
+        fprintf(stderr, "Warning: TTS 模型不存在，自动禁用 TTS: %s\n", paths.tts.c_str());
         use_tts = false;
     }
-    
-    // 设置参数
+    if (!file_exists(ref_audio_path)) {
+        fprintf(stderr, "Warning: ref_audio 不存在，系统 prompt 的声音克隆步骤可能失败: %s\n", ref_audio_path.c_str());
+    }
+
+    const int media_type = use_omni ? 2 : 1;
+
+    // ===== 组装 params =====
     common_params params;
     params.model.path = paths.llm;
-    params.vpm_model = paths.vision;
-    params.apm_model = paths.audio;
-    params.tts_model = paths.tts;
-    // 只有显式选择 coreml 后端时才设置 CoreML 模型路径
-    if (vision_backend == "coreml") {
+    params.vpm_model  = use_omni ? paths.vision : std::string();
+    params.apm_model  = paths.audio;
+    params.tts_model  = use_tts ? paths.tts : std::string();
+    if (use_omni && vision_backend == "coreml") {
         if (vision_coreml_model_path.empty()) {
             vision_coreml_model_path = paths.vision_coreml;
         }
         params.vision_coreml_model_path = vision_coreml_model_path;
     }
-    params.n_ctx = n_ctx;
+    params.n_ctx        = n_ctx;
     params.n_gpu_layers = n_gpu_layers;
-    
-    // Projector 路径需要通过 tts_bin_dir 传递
-    // omni.cpp 中 projector 路径计算: gguf_root_dir + "/projector.gguf"
-    // 其中 gguf_root_dir = tts_bin_dir 的父目录
-    // 但我们的结构是 projector 在 tts/ 目录下
-    // 所以需要修改 omni.cpp 或者创建符号链接
-    // 这里暂时使用 tts 目录作为 tts_bin_dir
-    std::string tts_bin_dir = get_parent_dir(paths.tts);
-    
+
+    const std::string tts_bin_dir = get_parent_dir(paths.tts);
+
     common_init();
-    
-    printf("=== Initializing Omni Context ===\n");
-    printf("  Media type: %d (%s)\n", media_type, media_type == 2 ? "omni: audio+vision" : "audio only");
-    printf("  TTS enabled: %s\n", use_tts ? "yes" : "no");
-    printf("  Context size: %d\n", n_ctx);
-    printf("  GPU layers: %d\n", n_gpu_layers);
-    printf("  Vision backend: %s\n", vision_backend.c_str());
-    if (vision_backend == "coreml") {
-        printf("  Vision CoreML: %s\n", vision_coreml_model_path.c_str());
+
+    printf("=== Config ===\n");
+    printf("  Omni (vision) : %s\n", use_omni ? "on" : "off");
+    printf("  TTS           : %s\n", use_tts  ? "on" : "off");
+    printf("  Context size  : %d\n", n_ctx);
+    printf("  GPU layers    : %d\n", n_gpu_layers);
+    if (use_omni) {
+        printf("  Vision backend: %s\n", vision_backend.c_str());
+        if (vision_backend == "coreml") {
+            printf("  Vision CoreML : %s\n", vision_coreml_model_path.c_str());
+        }
     }
-    printf("  TTS bin dir: %s\n", tts_bin_dir.c_str());
-    printf("  Ref audio: %s\n", ref_audio_path.c_str());
-    
-    // 🔧 Token2Wav 使用 GPU（Metal），已用 ggml_add+ggml_repeat 替代不支持的 ggml_add1
-    auto ctx_omni = omni_init(&params, media_type, use_tts, tts_bin_dir, -1, "gpu:0");
+    if (use_tts) {
+        printf("  Output dir    : %s\n", output_dir.c_str());
+        printf("  Ref audio     : %s\n", ref_audio_path.c_str());
+    }
+    printf("  Inputs        : audio=%s  image=%s  text=%s\n",
+           has_audio ? audio_input.c_str() : "(none)",
+           has_image ? image_input.c_str() : "(none)",
+           has_text  ? "(provided)"        : "(none)");
+
+    // ===== 初始化 omni ctx =====
+    auto * ctx_omni = omni_init(&params, media_type, use_tts, tts_bin_dir,
+                                /*tts_gpu_layers=*/ -1,
+                                /*token2wav_device=*/ "gpu:0",
+                                /*duplex_mode=*/ false,
+                                /*existing_model=*/ nullptr,
+                                /*existing_ctx=*/ nullptr,
+                                /*base_output_dir=*/ output_dir);
     if (ctx_omni == nullptr) {
         fprintf(stderr, "Error: Failed to initialize omni context\n");
         return 1;
     }
-    ctx_omni->async = true;
-    ctx_omni->ref_audio_path = ref_audio_path;  // 设置参考音频路径
+    ctx_omni->ref_audio_path = ref_audio_path;
+    ctx_omni->system_prompt_initialized = false;
 
-    if (run_test) {
-        printf("=== Running test case ===\n");
-        printf("  Audio prefix: %s\n", test_audio_prefix.c_str());
-        printf("  Count: %d\n", test_count);
-        test_case(ctx_omni, params, test_audio_prefix, test_count);
-    } else {
-        // 默认测试用例
-        test_case(ctx_omni, params, std::string("tools/omni/assets/test_case/audio_test_case/audio_test_case_"), 2);
+    // ===== Prefill 阶段：始终同步 =====
+    // 说明：stream_prefill(index=0) 在 async=true 时会 spawn LLM/TTS/T2W 线程，
+    // 会与同步 prefill 产生竞态；所以 prefill 阶段固定 async=false。
+    ctx_omni->async = false;
+
+    auto t0 = std::chrono::high_resolution_clock::now();
+
+    // 1) 系统 prompt + ref_audio 初始化（无论输入组合如何都要走这一步）
+    if (!stream_prefill(ctx_omni, /*aud=*/ "", /*img=*/ "", /*index=*/ 0)) {
+        fprintf(stderr, "Error: stream_prefill(index=0) failed\n");
+        omni_free(ctx_omni);
+        return 1;
     }
 
-    // 等待 T2W 完成所有音频生成后再停止线程
-    if(ctx_omni->async && ctx_omni->use_tts) {
-        std::string done_flag = std::string(ctx_omni->base_output_dir) + "/round_000/tts_wav/generation_done.flag";
-        fprintf(stderr, "Waiting for audio generation to complete...\n");
-        for (int i = 0; i < 1200; ++i) {  // 最多等 120 秒
-            FILE * f = fopen(done_flag.c_str(), "r");
-            if (f) { fclose(f); fprintf(stderr, "Audio generation completed.\n"); break; }
-            usleep(100000);  // 100ms
+    // 2) 用户多模态输入（index=1）：有音频或图片才调用
+    if (has_audio || has_image) {
+        if (!stream_prefill(ctx_omni, audio_input, image_input, /*index=*/ 1)) {
+            fprintf(stderr, "Error: stream_prefill(index=1) failed\n");
+            omni_free(ctx_omni);
+            return 1;
         }
     }
 
-    if(ctx_omni->async) {
+    // 3) 用户文字输入：eval_string 到当前 user turn 里
+    if (has_text) {
+        if (!omni_prefill_text(ctx_omni, text_input)) {
+            fprintf(stderr, "Error: omni_prefill_text failed\n");
+            omni_free(ctx_omni);
+            return 1;
+        }
+    }
+
+    auto t1 = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> prefill_elapsed = t1 - t0;
+    printf("\nprefill 耗时: %.3f s\n", prefill_elapsed.count());
+
+    // ===== Decode 阶段 =====
+    // 开 TTS 时 async=true：stream_decode 会起 tts/t2w 线程把 wav 写到 base_output_dir；
+    // 不开 TTS 时保持 async=false：stream_decode 走纯同步路径生成文字。
+    ctx_omni->async = use_tts;
+
+    auto decode_t0 = std::chrono::high_resolution_clock::now();
+    if (!stream_decode(ctx_omni, output_dir)) {
+        fprintf(stderr, "Error: stream_decode failed\n");
+        omni_free(ctx_omni);
+        return 1;
+    }
+    auto decode_t1 = std::chrono::high_resolution_clock::now();
+
+    // 读取 text_queue 打印完整文本回复
+    std::string full_text;
+    {
+        std::lock_guard<std::mutex> lock(ctx_omni->text_mtx);
+        for (const auto & frag : ctx_omni->text_queue) full_text += frag;
+    }
+
+    printf("\n=== Assistant ===\n%s\n", full_text.c_str());
+    printf("decode 耗时: %.3f s\n",
+           std::chrono::duration<double>(decode_t1 - decode_t0).count());
+
+    // ===== TTS 收尾 =====
+    if (use_tts) {
+        // tts/t2w 在独立线程里跑，等 flag 文件表示音频全部写完再收摊
+        std::string done_flag = std::string(ctx_omni->base_output_dir) +
+                                "/round_000/tts_wav/generation_done.flag";
+        fprintf(stderr, "Waiting for audio generation to complete...\n");
+        bool tts_done = false;
+        for (int i = 0; i < 1200; ++i) {  // 最多等 120s
+            FILE * f = fopen(done_flag.c_str(), "r");
+            if (f) {
+                fclose(f);
+                tts_done = true;
+                break;
+            }
+            usleep(100000);
+        }
+        if (tts_done) {
+            fprintf(stderr, "Audio generation completed.\n");
+            printf("音频输出目录: %s/round_000/tts_wav/\n", ctx_omni->base_output_dir.c_str());
+        } else {
+            fprintf(stderr, "Warning: TTS 超时 (120s) 未完成，可能有音频未落盘\n");
+        }
+
         omni_stop_threads(ctx_omni);
-        if(ctx_omni->llm_thread.joinable()) { ctx_omni->llm_thread.join(); printf("llm thread end\n"); }
-        if(ctx_omni->use_tts && ctx_omni->tts_thread.joinable()) { ctx_omni->tts_thread.join(); printf("tts thread end\n"); }
-        if(ctx_omni->use_tts && ctx_omni->t2w_thread.joinable()) { ctx_omni->t2w_thread.join(); printf("t2w thread end\n"); }
+        if (ctx_omni->llm_thread.joinable()) { ctx_omni->llm_thread.join(); }
+        if (ctx_omni->tts_thread.joinable()) { ctx_omni->tts_thread.join(); }
+        if (ctx_omni->t2w_thread.joinable()) { ctx_omni->t2w_thread.join(); }
     }
 
     llama_perf_context_print(ctx_omni->ctx_llama);

--- a/tools/omni/omni.cpp
+++ b/tools/omni/omni.cpp
@@ -8978,6 +8978,18 @@ bool stream_prefill(struct omni_context * ctx_omni, std::string aud_fname, std::
     return true;
 }
 
+// 纯文本 prefill：把 text 以 UTF-8 字符串形式评估进 LLM KV cache。
+// 约定调用方已经先调用过 stream_prefill(index=0) 完成系统 prompt 初始化，
+// 此时 KV cache 末尾恰好处于 "<|im_start|>user\n..." 的 user turn 内部，
+// 可直接追加文字内容。stream_decode 会在 decode 前补上 <|im_end|> 和 assistant prompt。
+bool omni_prefill_text(struct omni_context * ctx_omni, const std::string & text) {
+    if (ctx_omni == nullptr || text.empty()) {
+        return true;
+    }
+    return eval_string(ctx_omni, ctx_omni->params, text.c_str(),
+                       ctx_omni->params->n_batch, &ctx_omni->n_past, false);
+}
+
 bool stream_decode(struct omni_context * ctx_omni, std::string debug_dir, int round_idx) {
     // NOTE: 不再自动归档旧输出目录，因为这会导致同一 session 中每轮对话的输出被移走
     // 如果需要归档，可以在新 session 开始时（omni_init）手动调用

--- a/tools/omni/omni.h
+++ b/tools/omni/omni.h
@@ -428,6 +428,11 @@ bool stream_prefill(struct omni_context * ctx_omni,
                             int index = 0,
                             int max_slice_nums = -1);  // -1 表示使用全局设置，>=1 表示本次 prefill 的 slice 数量
 
+// 将一段纯文本以同步方式 prefill 进 LLM 的 KV cache，
+// 用于在已经走过 stream_prefill(index=0) 系统 prompt 初始化后，
+// 把用户的文字内容追加到当前 user turn 里。
+bool omni_prefill_text(struct omni_context * ctx_omni, const std::string & text);
+
 bool stream_decode(struct omni_context * ctx_omni,
                         std::string debug_dir,
                         int round_idx = -1);  // round_idx: 由调用方指定的轮次索引，-1 表示使用内部计数

--- a/tools/omni/test/single_test_audio.cpp
+++ b/tools/omni/test/single_test_audio.cpp
@@ -1,0 +1,304 @@
+/**
+ * 单工 (Singleplex) 纯音频批量测试
+ *
+ * 测试数据格式: <prefix>0000.wav, <prefix>0001.wav, ...
+ * 只处理音频，不做图像检测。典型数据集：
+ *   tools/omni/assets/test_case/audio_test_case/audio_test_case_XXXX.wav
+ *
+ * 流程：所有 audio chunk 同步 prefill 完成后，统一 decode 一次生成完整回复。
+ *
+ * 用法:
+ *   llama-omni-single-test-audio -m <llm_model_path> --test <prefix> <n> [options]
+ *
+ * 示例:
+ *   llama-omni-single-test-audio \
+ *       -m /path/to/MiniCPM-o-4_5-gguf/MiniCPM-o-4_5-Q4_K_M.gguf \
+ *       --test tools/omni/assets/test_case/audio_test_case/audio_test_case_ 2
+ */
+
+#include "omni-impl.h"
+#include "omni.h"
+
+#include "arg.h"
+#include "log.h"
+#include "sampling.h"
+#include "llama.h"
+#include "ggml.h"
+
+#include <iostream>
+#include <chrono>
+#include <vector>
+#include <string>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+#include <signal.h>
+#include <unistd.h>
+#elif defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#include <signal.h>
+#endif
+
+static volatile bool g_is_interrupted = false;
+
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__)) || defined(_WIN32)
+static void sigint_handler(int signo) {
+    if (signo == SIGINT) {
+        if (g_is_interrupted) {
+            _exit(1);
+        }
+        g_is_interrupted = true;
+    }
+}
+#endif
+
+// ==================== 模型路径解析 ====================
+
+struct OmniModelPaths {
+    std::string llm;
+    std::string audio;
+    std::string tts;
+    std::string projector;
+    std::string base_dir;
+};
+
+static std::string get_parent_dir(const std::string & path) {
+    size_t last_slash = path.find_last_of("/\\");
+    if (last_slash != std::string::npos) {
+        return path.substr(0, last_slash);
+    }
+    return ".";
+}
+
+static bool file_exists(const std::string & path) {
+    FILE * f = fopen(path.c_str(), "rb");
+    if (f) {
+        fclose(f);
+        return true;
+    }
+    return false;
+}
+
+static OmniModelPaths resolve_model_paths(const std::string & llm_path) {
+    OmniModelPaths paths;
+    paths.llm      = llm_path;
+    paths.base_dir = get_parent_dir(llm_path);
+    paths.audio    = paths.base_dir + "/audio/MiniCPM-o-4_5-audio-F16.gguf";
+    paths.tts      = paths.base_dir + "/tts/MiniCPM-o-4_5-tts-F16.gguf";
+    paths.projector = paths.base_dir + "/tts/MiniCPM-o-4_5-projector-F16.gguf";
+    return paths;
+}
+
+static void print_model_paths(const OmniModelPaths & paths) {
+    printf("=== Model Paths ===\n");
+    printf("  Base dir:   %s\n", paths.base_dir.c_str());
+    printf("  LLM:        %s %s\n", paths.llm.c_str(),       file_exists(paths.llm)       ? "[OK]" : "[NOT FOUND]");
+    printf("  Audio:      %s %s\n", paths.audio.c_str(),     file_exists(paths.audio)     ? "[OK]" : "[NOT FOUND]");
+    printf("  TTS:        %s %s\n", paths.tts.c_str(),       file_exists(paths.tts)       ? "[OK]" : "[NOT FOUND]");
+    printf("  Projector:  %s %s\n", paths.projector.c_str(), file_exists(paths.projector) ? "[OK]" : "[NOT FOUND]");
+    printf("===================\n");
+}
+
+// ==================== 批量测试主流程 ====================
+
+// 纯音频单工批量测试：所有 audio chunk 同步 prefill，最后统一 decode 一次
+static void run_audio_test(struct omni_context * ctx_omni,
+                           const std::string & data_path_prefix,
+                           int cnt) {
+    ctx_omni->system_prompt_initialized = false;
+    bool orig_async = ctx_omni->async;
+    ctx_omni->async = false;  // 同步模式 prefill，确保所有数据被处理
+
+    // index=0 仅用于系统 prompt + ref_audio 初始化，不会处理用户音频。
+    // 用户音频必须从 index>=1 开始喂，否则第一个 chunk 会被丢掉（见 omni.cpp stream_prefill）。
+    {
+        auto t0 = std::chrono::high_resolution_clock::now();
+        stream_prefill(ctx_omni, std::string(), std::string(), 0);
+        auto t1 = std::chrono::high_resolution_clock::now();
+        std::cout << "prefill init (system prompt) : "
+                  << std::chrono::duration<double>(t1 - t0).count() << " s" << std::endl;
+    }
+
+    for (int il = 0; il < cnt; ++il) {
+        char idx_str[16];
+        snprintf(idx_str, sizeof(idx_str), "%04d", il);
+        std::string aud_fname = data_path_prefix + idx_str + ".wav";
+
+        if (!file_exists(aud_fname)) {
+            fprintf(stderr, "Warning: audio chunk not found, skip: %s\n", aud_fname.c_str());
+            continue;
+        }
+
+        auto t0 = std::chrono::high_resolution_clock::now();
+        stream_prefill(ctx_omni, aud_fname, std::string(), il + 1);
+        auto t1 = std::chrono::high_resolution_clock::now();
+        std::cout << "prefill " << il << " (audio) : "
+                  << std::chrono::duration<double>(t1 - t0).count() << " s" << std::endl;
+    }
+
+    ctx_omni->async = orig_async;
+    stream_decode(ctx_omni, "./");
+}
+
+static void show_usage(const char * prog_name) {
+    printf(
+        "MiniCPM-o Singleplex Audio-only Test\n\n"
+        "Usage: %s -m <llm_model_path> --test <prefix> <n> [options]\n\n"
+        "Required:\n"
+        "  -m <path>              LLM GGUF 模型路径\n"
+        "  --test <prefix> <n>    测试数据前缀和 chunk 数量 (文件: <prefix>0000.wav 等)\n\n"
+        "Options:\n"
+        "  --audio <path>         覆盖 audio 模型路径\n"
+        "  --tts <path>           覆盖 TTS 模型路径\n"
+        "  --projector <path>     覆盖 projector 模型路径\n"
+        "  --ref-audio <path>     参考音频路径 (voice clone)\n"
+        "  -c, --ctx-size <n>     上下文大小 (默认 4096)\n"
+        "  -ngl <n>               GPU 层数 (默认 99)\n"
+        "  --no-tts               禁用 TTS\n"
+        "  -h, --help             显示帮助\n\n"
+        "Example:\n"
+        "  %s -m /path/to/MiniCPM-o-4_5-gguf/MiniCPM-o-4_5-Q4_K_M.gguf \\\n"
+        "     --test tools/omni/assets/test_case/audio_test_case/audio_test_case_ 2\n",
+        prog_name, prog_name
+    );
+}
+
+int main(int argc, char ** argv) {
+    ggml_time_init();
+
+    std::string llm_path;
+    std::string audio_path_override;
+    std::string tts_path_override;
+    std::string projector_path_override;
+    std::string ref_audio_path = "tools/omni/assets/default_ref_audio/default_ref_audio.wav";
+    int n_ctx = 4096;
+    int n_gpu_layers = 99;
+    bool use_tts = true;
+    std::string test_audio_prefix;
+    int test_count = 0;
+
+    for (int i = 1; i < argc; i++) {
+        std::string arg = argv[i];
+
+        if (arg == "-h" || arg == "--help") {
+            show_usage(argv[0]);
+            return 0;
+        } else if (arg == "-m" && i + 1 < argc) {
+            llm_path = argv[++i];
+        } else if (arg == "--audio" && i + 1 < argc) {
+            audio_path_override = argv[++i];
+        } else if (arg == "--tts" && i + 1 < argc) {
+            tts_path_override = argv[++i];
+        } else if (arg == "--projector" && i + 1 < argc) {
+            projector_path_override = argv[++i];
+        } else if (arg == "--ref-audio" && i + 1 < argc) {
+            ref_audio_path = argv[++i];
+        } else if ((arg == "-c" || arg == "--ctx-size") && i + 1 < argc) {
+            n_ctx = std::atoi(argv[++i]);
+        } else if (arg == "-ngl" && i + 1 < argc) {
+            n_gpu_layers = std::atoi(argv[++i]);
+        } else if (arg == "--no-tts") {
+            use_tts = false;
+        } else if (arg == "--test" && i + 2 < argc) {
+            test_audio_prefix = argv[++i];
+            test_count = std::atoi(argv[++i]);
+        } else {
+            fprintf(stderr, "Unknown argument: %s\n", arg.c_str());
+            show_usage(argv[0]);
+            return 1;
+        }
+    }
+
+    if (llm_path.empty()) {
+        fprintf(stderr, "Error: -m <llm_model_path> is required\n\n");
+        show_usage(argv[0]);
+        return 1;
+    }
+    if (test_audio_prefix.empty() || test_count <= 0) {
+        fprintf(stderr, "Error: --test <prefix> <n> is required\n\n");
+        show_usage(argv[0]);
+        return 1;
+    }
+
+    OmniModelPaths paths = resolve_model_paths(llm_path);
+    if (!audio_path_override.empty())     paths.audio     = audio_path_override;
+    if (!tts_path_override.empty())       paths.tts       = tts_path_override;
+    if (!projector_path_override.empty()) paths.projector = projector_path_override;
+    print_model_paths(paths);
+
+    if (!file_exists(paths.llm)) {
+        fprintf(stderr, "Error: LLM model not found: %s\n", paths.llm.c_str());
+        return 1;
+    }
+    if (!file_exists(paths.audio)) {
+        fprintf(stderr, "Error: Audio model not found: %s\n", paths.audio.c_str());
+        return 1;
+    }
+    if (use_tts && !file_exists(paths.tts)) {
+        fprintf(stderr, "Warning: TTS model not found: %s, disabling TTS\n", paths.tts.c_str());
+        use_tts = false;
+    }
+
+    common_params params;
+    params.model.path = paths.llm;
+    params.apm_model  = paths.audio;
+    params.tts_model  = paths.tts;
+    params.n_ctx        = n_ctx;
+    params.n_gpu_layers = n_gpu_layers;
+
+    std::string tts_bin_dir = get_parent_dir(paths.tts);
+
+    common_init();
+
+    printf("=== Initializing Omni Context (audio only) ===\n");
+    printf("  TTS enabled:  %s\n", use_tts ? "yes" : "no");
+    printf("  Context size: %d\n", n_ctx);
+    printf("  GPU layers:   %d\n", n_gpu_layers);
+    printf("  TTS bin dir:  %s\n", tts_bin_dir.c_str());
+    printf("  Ref audio:    %s\n", ref_audio_path.c_str());
+
+    // media_type=1 表示纯音频输入（与双工共享的多模态通道里只开 audio）
+    auto ctx_omni = omni_init(&params, /*media_type=*/1, use_tts, tts_bin_dir, -1, "gpu:0");
+    if (ctx_omni == nullptr) {
+        fprintf(stderr, "Error: Failed to initialize omni context\n");
+        return 1;
+    }
+    ctx_omni->async = true;
+    ctx_omni->ref_audio_path = ref_audio_path;
+
+    printf("=== Running audio-only singleplex test ===\n");
+    printf("  Audio prefix: %s\n", test_audio_prefix.c_str());
+    printf("  Count:        %d\n", test_count);
+    run_audio_test(ctx_omni, test_audio_prefix, test_count);
+
+    if (ctx_omni->async && ctx_omni->use_tts) {
+        std::string done_flag = std::string(ctx_omni->base_output_dir) + "/round_000/tts_wav/generation_done.flag";
+        fprintf(stderr, "Waiting for audio generation to complete...\n");
+        for (int i = 0; i < 1200; ++i) {  // 最多等 120 秒
+            FILE * f = fopen(done_flag.c_str(), "r");
+            if (f) { fclose(f); fprintf(stderr, "Audio generation completed.\n"); break; }
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+            usleep(100000);  // 100ms
+#elif defined(_WIN32)
+            Sleep(100);
+#endif
+        }
+    }
+
+    if (ctx_omni->async) {
+        omni_stop_threads(ctx_omni);
+        if (ctx_omni->llm_thread.joinable()) { ctx_omni->llm_thread.join(); printf("llm thread end\n"); }
+        if (ctx_omni->use_tts && ctx_omni->tts_thread.joinable()) { ctx_omni->tts_thread.join(); printf("tts thread end\n"); }
+        if (ctx_omni->use_tts && ctx_omni->t2w_thread.joinable()) { ctx_omni->t2w_thread.join(); printf("t2w thread end\n"); }
+    }
+
+    llama_perf_context_print(ctx_omni->ctx_llama);
+    omni_free(ctx_omni);
+    return 0;
+}

--- a/tools/omni/test/single_test_omni.cpp
+++ b/tools/omni/test/single_test_omni.cpp
@@ -1,27 +1,20 @@
 /**
- * 单工 (Singleplex) Omni 模式批量测试
+ * 单工 (Singleplex) Omni (audio + vision) 批量测试
  *
- * 单工模式下，所有音频（+可选图片）一次性 prefill 完成，最后统一 decode 一次生成完整回复。
+ * 测试数据格式: <prefix>0000.wav / <prefix>0000.jpg, <prefix>0001.wav / <prefix>0001.jpg, ...
+ * 每个 chunk 的图片 (.jpg) 与音频 (.wav) 同前缀同编号配对；图片缺失的 chunk 会退化为纯音频 prefill。
+ * 典型数据集:
+ *   tools/omni/assets/test_case/omni_test_case/omni_test_case_XXXX.{wav,jpg}
  *
- * 与双工模式的区别：
- *   - 单工：所有 chunk 一次性 prefill，然后统一 decode 一次
- *   - 双工：每个 chunk prefill 后立即 decode，模型实时决策
+ * 流程：所有 (audio[+image]) chunk 同步 prefill 完成后，统一 decode 一次生成完整回复。
  *
  * 用法:
- *   llama-omni-test-singleplex -m <llm_model_path> [options]
- *     --test <prefix> <n>   指定测试数据前缀和 chunk 数量 (必需)
- *     --ref-audio <path>    参考音频路径
- *     --no-tts              禁用 TTS
- *     --omni                启用 omni 模式 (audio+vision)
- *     --vision-backend <mode>  Vision 后端: 'metal'(默认) 或 'coreml'
- *     --vision-coreml <path>   CoreML 模型路径 (backend=coreml 时需要)
- *     -c <n>                上下文大小 (默认 4096)
- *     -ngl <n>              GPU 层数 (默认 99)
+ *   llama-omni-single-test-omni -m <llm_model_path> --test <prefix> <n> [options]
  *
  * 示例:
- *   llama-omni-test-singleplex \
- *       -m ./models/MiniCPM-o-4_5-gguf/MiniCPM-o-4_5-Q4_K_M.gguf \
- *       --omni --test tools/omni/assets/test_case/omni_test_case/omni_test_case_ 9
+ *   llama-omni-single-test-omni \
+ *       -m /path/to/MiniCPM-o-4_5-gguf/MiniCPM-o-4_5-Q4_K_M.gguf \
+ *       --test tools/omni/assets/test_case/omni_test_case/omni_test_case_ 9
  */
 
 #include "omni-impl.h"
@@ -97,37 +90,34 @@ static bool file_exists(const std::string & path) {
 
 static OmniModelPaths resolve_model_paths(const std::string & llm_path) {
     OmniModelPaths paths;
-    paths.llm = llm_path;
+    paths.llm      = llm_path;
     paths.base_dir = get_parent_dir(llm_path);
 
-    paths.vision = paths.base_dir + "/vision/MiniCPM-o-4_5-vision-F16.gguf";
-    paths.audio = paths.base_dir + "/audio/MiniCPM-o-4_5-audio-F16.gguf";
-    paths.tts = paths.base_dir + "/tts/MiniCPM-o-4_5-tts-F16.gguf";
-    paths.projector = paths.base_dir + "/tts/MiniCPM-o-4_5-projector-F16.gguf";
+    paths.vision        = paths.base_dir + "/vision/MiniCPM-o-4_5-vision-F16.gguf";
+    paths.audio         = paths.base_dir + "/audio/MiniCPM-o-4_5-audio-F16.gguf";
+    paths.tts           = paths.base_dir + "/tts/MiniCPM-o-4_5-tts-F16.gguf";
+    paths.projector     = paths.base_dir + "/tts/MiniCPM-o-4_5-projector-F16.gguf";
     paths.vision_coreml = paths.base_dir + "/vision/coreml_minicpmo45_vit_all_f16.mlmodelc";
-
     return paths;
 }
 
 static void print_model_paths(const OmniModelPaths & paths) {
     printf("=== Model Paths ===\n");
     printf("  Base dir:   %s\n", paths.base_dir.c_str());
-    printf("  LLM:        %s %s\n", paths.llm.c_str(), file_exists(paths.llm) ? "[OK]" : "[NOT FOUND]");
-    printf("  Vision:     %s %s\n", paths.vision.c_str(), file_exists(paths.vision) ? "[OK]" : "[NOT FOUND]");
-    printf("  Audio:      %s %s\n", paths.audio.c_str(), file_exists(paths.audio) ? "[OK]" : "[NOT FOUND]");
-    printf("  TTS:        %s %s\n", paths.tts.c_str(), file_exists(paths.tts) ? "[OK]" : "[NOT FOUND]");
+    printf("  LLM:        %s %s\n", paths.llm.c_str(),       file_exists(paths.llm)       ? "[OK]" : "[NOT FOUND]");
+    printf("  Vision:     %s %s\n", paths.vision.c_str(),    file_exists(paths.vision)    ? "[OK]" : "[NOT FOUND]");
+    printf("  Audio:      %s %s\n", paths.audio.c_str(),     file_exists(paths.audio)     ? "[OK]" : "[NOT FOUND]");
+    printf("  TTS:        %s %s\n", paths.tts.c_str(),       file_exists(paths.tts)       ? "[OK]" : "[NOT FOUND]");
     printf("  Projector:  %s %s\n", paths.projector.c_str(), file_exists(paths.projector) ? "[OK]" : "[NOT FOUND]");
     printf("===================\n");
 }
 
 // ==================== 批量测试主流程 ====================
 
-// 单工批量测试：所有 chunk 同步 prefill，最后统一 decode 一次
-static void run_singleplex_test(struct omni_context * ctx_omni,
-                                const std::string & data_path_prefix,
-                                int cnt) {
-    // 单工模式：先 prefill 所有输入，然后 decode 一次生成完整回复
-    // 使用同步模式 prefill，避免 async 模式下的竞态条件
+// Omni 单工批量测试：audio + 同名 .jpg 图片同步 prefill，最后统一 decode 一次
+static void run_omni_test(struct omni_context * ctx_omni,
+                          const std::string & data_path_prefix,
+                          int cnt) {
     ctx_omni->system_prompt_initialized = false;
     bool orig_async = ctx_omni->async;
     ctx_omni->async = false;  // 同步模式 prefill，确保所有数据被处理
@@ -146,56 +136,55 @@ static void run_singleplex_test(struct omni_context * ctx_omni,
         char idx_str[16];
         snprintf(idx_str, sizeof(idx_str), "%04d", il);
         std::string aud_fname = data_path_prefix + idx_str + ".wav";
-
-        // omni 模式：自动检测同名 .jpg 图片
         std::string img_fname;
         std::string img_candidate = data_path_prefix + idx_str + ".jpg";
         if (file_exists(img_candidate)) {
             img_fname = img_candidate;
         }
 
+        if (!file_exists(aud_fname)) {
+            fprintf(stderr, "Warning: audio chunk not found, skip: %s\n", aud_fname.c_str());
+            continue;
+        }
+
         auto t0 = std::chrono::high_resolution_clock::now();
-        // 用户音频 chunk 从 index=1 开始喂入（index=0 保留给 system prompt 初始化）
         stream_prefill(ctx_omni, aud_fname, img_fname, il + 1);
         auto t1 = std::chrono::high_resolution_clock::now();
-        std::chrono::duration<double> elapsed_seconds = t1 - t0;
-        double dt = elapsed_seconds.count();
+        double dt = std::chrono::duration<double>(t1 - t0).count();
         if (img_fname.empty()) {
-            std::cout << "prefill " << il << " (audio) : " << dt << " s" << std::endl;
+            std::cout << "prefill " << il << " (audio only) : " << dt << " s" << std::endl;
         } else {
             std::cout << "prefill " << il << " (audio+vision) : " << dt << " s" << std::endl;
         }
     }
 
-    // 所有数据同步 prefill 完成后恢复 async 模式并调用 decode
-    // stream_decode 内部会根据 async 标志启动 TTS/T2W 线程
     ctx_omni->async = orig_async;
     stream_decode(ctx_omni, "./");
 }
 
 static void show_usage(const char * prog_name) {
     printf(
-        "MiniCPM-o Singleplex Test - Batch prefill + single decode\n\n"
+        "MiniCPM-o Singleplex Omni (audio+vision) Test\n\n"
         "Usage: %s -m <llm_model_path> --test <prefix> <n> [options]\n\n"
         "Required:\n"
         "  -m <path>                LLM GGUF 模型路径\n"
-        "  --test <prefix> <n>      测试数据前缀和 chunk 数量\n\n"
+        "  --test <prefix> <n>      测试数据前缀和 chunk 数量\n"
+        "                           (文件: <prefix>0000.wav/.jpg 等)\n\n"
         "Options:\n"
         "  --vision <path>          覆盖 vision 模型路径\n"
         "  --audio <path>           覆盖 audio 模型路径\n"
         "  --tts <path>             覆盖 TTS 模型路径\n"
         "  --projector <path>       覆盖 projector 模型路径\n"
-        "  --ref-audio <path>       参考音频路径\n"
+        "  --ref-audio <path>       参考音频路径 (voice clone)\n"
         "  -c, --ctx-size <n>       上下文大小 (默认 4096)\n"
         "  -ngl <n>                 GPU 层数 (默认 99)\n"
         "  --no-tts                 禁用 TTS\n"
-        "  --omni                   启用 omni 模式 (audio+vision, media_type=2)\n"
         "  --vision-backend <mode>  Vision 后端: 'metal'(默认) 或 'coreml'\n"
         "  --vision-coreml <path>   CoreML 模型路径 (backend=coreml 时需要)\n"
         "  -h, --help               显示帮助\n\n"
         "Example:\n"
-        "  %s -m ./models/MiniCPM-o-4_5-gguf/MiniCPM-o-4_5-Q4_K_M.gguf \\\n"
-        "     --omni --test tools/omni/assets/test_case/omni_test_case/omni_test_case_ 9\n",
+        "  %s -m /path/to/MiniCPM-o-4_5-gguf/MiniCPM-o-4_5-Q4_K_M.gguf \\\n"
+        "     --test tools/omni/assets/test_case/omni_test_case/omni_test_case_ 9\n",
         prog_name, prog_name
     );
 }
@@ -213,7 +202,6 @@ int main(int argc, char ** argv) {
     std::string ref_audio_path = "tools/omni/assets/default_ref_audio/default_ref_audio.wav";
     int n_ctx = 4096;
     int n_gpu_layers = 99;
-    int media_type = 1;  // 1=audio only, 2=omni(audio+vision)
     bool use_tts = true;
     std::string test_audio_prefix;
     int test_count = 0;
@@ -242,8 +230,6 @@ int main(int argc, char ** argv) {
             n_gpu_layers = std::atoi(argv[++i]);
         } else if (arg == "--no-tts") {
             use_tts = false;
-        } else if (arg == "--omni") {
-            media_type = 2;
         } else if (arg == "--vision-backend" && i + 1 < argc) {
             vision_backend = argv[++i];
             if (vision_backend != "metal" && vision_backend != "coreml") {
@@ -288,6 +274,10 @@ int main(int argc, char ** argv) {
         fprintf(stderr, "Error: Audio model not found: %s\n", paths.audio.c_str());
         return 1;
     }
+    if (!file_exists(paths.vision)) {
+        fprintf(stderr, "Error: Vision model not found: %s\n", paths.vision.c_str());
+        return 1;
+    }
     if (use_tts && !file_exists(paths.tts)) {
         fprintf(stderr, "Warning: TTS model not found: %s, disabling TTS\n", paths.tts.c_str());
         use_tts = false;
@@ -311,20 +301,19 @@ int main(int argc, char ** argv) {
 
     common_init();
 
-    printf("=== Initializing Omni Context ===\n");
-    printf("  Media type: %d (%s)\n", media_type, media_type == 2 ? "omni: audio+vision" : "audio only");
-    printf("  TTS enabled: %s\n", use_tts ? "yes" : "no");
-    printf("  Context size: %d\n", n_ctx);
-    printf("  GPU layers: %d\n", n_gpu_layers);
-    printf("  Vision backend: %s\n", vision_backend.c_str());
+    printf("=== Initializing Omni Context (audio+vision) ===\n");
+    printf("  TTS enabled:   %s\n", use_tts ? "yes" : "no");
+    printf("  Context size:  %d\n", n_ctx);
+    printf("  GPU layers:    %d\n", n_gpu_layers);
+    printf("  Vision backend:%s\n", vision_backend.c_str());
     if (vision_backend == "coreml") {
         printf("  Vision CoreML: %s\n", vision_coreml_model_path.c_str());
     }
-    printf("  TTS bin dir: %s\n", tts_bin_dir.c_str());
-    printf("  Ref audio: %s\n", ref_audio_path.c_str());
+    printf("  TTS bin dir:   %s\n", tts_bin_dir.c_str());
+    printf("  Ref audio:     %s\n", ref_audio_path.c_str());
 
-    // Token2Wav 使用 GPU（Metal），已用 ggml_add+ggml_repeat 替代不支持的 ggml_add1
-    auto ctx_omni = omni_init(&params, media_type, use_tts, tts_bin_dir, -1, "gpu:0");
+    // media_type=2 表示 omni 模式（audio + vision）
+    auto ctx_omni = omni_init(&params, /*media_type=*/2, use_tts, tts_bin_dir, -1, "gpu:0");
     if (ctx_omni == nullptr) {
         fprintf(stderr, "Error: Failed to initialize omni context\n");
         return 1;
@@ -332,12 +321,11 @@ int main(int argc, char ** argv) {
     ctx_omni->async = true;
     ctx_omni->ref_audio_path = ref_audio_path;
 
-    printf("=== Running singleplex test ===\n");
-    printf("  Audio prefix: %s\n", test_audio_prefix.c_str());
-    printf("  Count: %d\n", test_count);
-    run_singleplex_test(ctx_omni, test_audio_prefix, test_count);
+    printf("=== Running omni (audio+vision) singleplex test ===\n");
+    printf("  Prefix: %s\n", test_audio_prefix.c_str());
+    printf("  Count:  %d\n", test_count);
+    run_omni_test(ctx_omni, test_audio_prefix, test_count);
 
-    // 等待 T2W 完成所有音频生成后再停止线程
     if (ctx_omni->async && ctx_omni->use_tts) {
         std::string done_flag = std::string(ctx_omni->base_output_dir) + "/round_000/tts_wav/generation_done.flag";
         fprintf(stderr, "Waiting for audio generation to complete...\n");
@@ -360,7 +348,6 @@ int main(int argc, char ** argv) {
     }
 
     llama_perf_context_print(ctx_omni->ctx_llama);
-
     omni_free(ctx_omni);
     return 0;
 }

--- a/tools/omni/test/test-singleplex.cpp
+++ b/tools/omni/test/test-singleplex.cpp
@@ -1,0 +1,366 @@
+/**
+ * 单工 (Singleplex) Omni 模式批量测试
+ *
+ * 单工模式下，所有音频（+可选图片）一次性 prefill 完成，最后统一 decode 一次生成完整回复。
+ *
+ * 与双工模式的区别：
+ *   - 单工：所有 chunk 一次性 prefill，然后统一 decode 一次
+ *   - 双工：每个 chunk prefill 后立即 decode，模型实时决策
+ *
+ * 用法:
+ *   llama-omni-test-singleplex -m <llm_model_path> [options]
+ *     --test <prefix> <n>   指定测试数据前缀和 chunk 数量 (必需)
+ *     --ref-audio <path>    参考音频路径
+ *     --no-tts              禁用 TTS
+ *     --omni                启用 omni 模式 (audio+vision)
+ *     --vision-backend <mode>  Vision 后端: 'metal'(默认) 或 'coreml'
+ *     --vision-coreml <path>   CoreML 模型路径 (backend=coreml 时需要)
+ *     -c <n>                上下文大小 (默认 4096)
+ *     -ngl <n>              GPU 层数 (默认 99)
+ *
+ * 示例:
+ *   llama-omni-test-singleplex \
+ *       -m ./models/MiniCPM-o-4_5-gguf/MiniCPM-o-4_5-Q4_K_M.gguf \
+ *       --omni --test tools/omni/assets/test_case/omni_test_case/omni_test_case_ 9
+ */
+
+#include "omni-impl.h"
+#include "omni.h"
+
+#include "arg.h"
+#include "log.h"
+#include "sampling.h"
+#include "llama.h"
+#include "ggml.h"
+
+#include <iostream>
+#include <chrono>
+#include <vector>
+#include <string>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+#include <signal.h>
+#include <unistd.h>
+#elif defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#include <signal.h>
+#endif
+
+static volatile bool g_is_interrupted = false;
+
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__)) || defined(_WIN32)
+static void sigint_handler(int signo) {
+    if (signo == SIGINT) {
+        if (g_is_interrupted) {
+            _exit(1);
+        }
+        g_is_interrupted = true;
+    }
+}
+#endif
+
+// ==================== 模型路径解析 ====================
+
+struct OmniModelPaths {
+    std::string llm;
+    std::string vision;
+    std::string audio;
+    std::string tts;
+    std::string projector;
+    std::string vision_coreml;
+    std::string base_dir;
+};
+
+static std::string get_parent_dir(const std::string & path) {
+    size_t last_slash = path.find_last_of("/\\");
+    if (last_slash != std::string::npos) {
+        return path.substr(0, last_slash);
+    }
+    return ".";
+}
+
+static bool file_exists(const std::string & path) {
+    FILE * f = fopen(path.c_str(), "rb");
+    if (f) {
+        fclose(f);
+        return true;
+    }
+    return false;
+}
+
+static OmniModelPaths resolve_model_paths(const std::string & llm_path) {
+    OmniModelPaths paths;
+    paths.llm = llm_path;
+    paths.base_dir = get_parent_dir(llm_path);
+
+    paths.vision = paths.base_dir + "/vision/MiniCPM-o-4_5-vision-F16.gguf";
+    paths.audio = paths.base_dir + "/audio/MiniCPM-o-4_5-audio-F16.gguf";
+    paths.tts = paths.base_dir + "/tts/MiniCPM-o-4_5-tts-F16.gguf";
+    paths.projector = paths.base_dir + "/tts/MiniCPM-o-4_5-projector-F16.gguf";
+    paths.vision_coreml = paths.base_dir + "/vision/coreml_minicpmo45_vit_all_f16.mlmodelc";
+
+    return paths;
+}
+
+static void print_model_paths(const OmniModelPaths & paths) {
+    printf("=== Model Paths ===\n");
+    printf("  Base dir:   %s\n", paths.base_dir.c_str());
+    printf("  LLM:        %s %s\n", paths.llm.c_str(), file_exists(paths.llm) ? "[OK]" : "[NOT FOUND]");
+    printf("  Vision:     %s %s\n", paths.vision.c_str(), file_exists(paths.vision) ? "[OK]" : "[NOT FOUND]");
+    printf("  Audio:      %s %s\n", paths.audio.c_str(), file_exists(paths.audio) ? "[OK]" : "[NOT FOUND]");
+    printf("  TTS:        %s %s\n", paths.tts.c_str(), file_exists(paths.tts) ? "[OK]" : "[NOT FOUND]");
+    printf("  Projector:  %s %s\n", paths.projector.c_str(), file_exists(paths.projector) ? "[OK]" : "[NOT FOUND]");
+    printf("===================\n");
+}
+
+// ==================== 批量测试主流程 ====================
+
+// 单工批量测试：所有 chunk 同步 prefill，最后统一 decode 一次
+static void run_singleplex_test(struct omni_context * ctx_omni,
+                                const std::string & data_path_prefix,
+                                int cnt) {
+    // 单工模式：先 prefill 所有输入，然后 decode 一次生成完整回复
+    // 使用同步模式 prefill，避免 async 模式下的竞态条件
+    ctx_omni->system_prompt_initialized = false;
+    bool orig_async = ctx_omni->async;
+    ctx_omni->async = false;  // 同步模式 prefill，确保所有数据被处理
+
+    // index=0 仅用于系统 prompt + ref_audio 初始化，不会处理用户音频。
+    // 用户音频必须从 index>=1 开始喂，否则第一个 chunk 会被丢掉（见 omni.cpp stream_prefill）。
+    {
+        auto t0 = std::chrono::high_resolution_clock::now();
+        stream_prefill(ctx_omni, std::string(), std::string(), 0);
+        auto t1 = std::chrono::high_resolution_clock::now();
+        std::cout << "prefill init (system prompt) : "
+                  << std::chrono::duration<double>(t1 - t0).count() << " s" << std::endl;
+    }
+
+    for (int il = 0; il < cnt; ++il) {
+        char idx_str[16];
+        snprintf(idx_str, sizeof(idx_str), "%04d", il);
+        std::string aud_fname = data_path_prefix + idx_str + ".wav";
+
+        // omni 模式：自动检测同名 .jpg 图片
+        std::string img_fname;
+        std::string img_candidate = data_path_prefix + idx_str + ".jpg";
+        if (file_exists(img_candidate)) {
+            img_fname = img_candidate;
+        }
+
+        auto t0 = std::chrono::high_resolution_clock::now();
+        // 用户音频 chunk 从 index=1 开始喂入（index=0 保留给 system prompt 初始化）
+        stream_prefill(ctx_omni, aud_fname, img_fname, il + 1);
+        auto t1 = std::chrono::high_resolution_clock::now();
+        std::chrono::duration<double> elapsed_seconds = t1 - t0;
+        double dt = elapsed_seconds.count();
+        if (img_fname.empty()) {
+            std::cout << "prefill " << il << " (audio) : " << dt << " s" << std::endl;
+        } else {
+            std::cout << "prefill " << il << " (audio+vision) : " << dt << " s" << std::endl;
+        }
+    }
+
+    // 所有数据同步 prefill 完成后恢复 async 模式并调用 decode
+    // stream_decode 内部会根据 async 标志启动 TTS/T2W 线程
+    ctx_omni->async = orig_async;
+    stream_decode(ctx_omni, "./");
+}
+
+static void show_usage(const char * prog_name) {
+    printf(
+        "MiniCPM-o Singleplex Test - Batch prefill + single decode\n\n"
+        "Usage: %s -m <llm_model_path> --test <prefix> <n> [options]\n\n"
+        "Required:\n"
+        "  -m <path>                LLM GGUF 模型路径\n"
+        "  --test <prefix> <n>      测试数据前缀和 chunk 数量\n\n"
+        "Options:\n"
+        "  --vision <path>          覆盖 vision 模型路径\n"
+        "  --audio <path>           覆盖 audio 模型路径\n"
+        "  --tts <path>             覆盖 TTS 模型路径\n"
+        "  --projector <path>       覆盖 projector 模型路径\n"
+        "  --ref-audio <path>       参考音频路径\n"
+        "  -c, --ctx-size <n>       上下文大小 (默认 4096)\n"
+        "  -ngl <n>                 GPU 层数 (默认 99)\n"
+        "  --no-tts                 禁用 TTS\n"
+        "  --omni                   启用 omni 模式 (audio+vision, media_type=2)\n"
+        "  --vision-backend <mode>  Vision 后端: 'metal'(默认) 或 'coreml'\n"
+        "  --vision-coreml <path>   CoreML 模型路径 (backend=coreml 时需要)\n"
+        "  -h, --help               显示帮助\n\n"
+        "Example:\n"
+        "  %s -m ./models/MiniCPM-o-4_5-gguf/MiniCPM-o-4_5-Q4_K_M.gguf \\\n"
+        "     --omni --test tools/omni/assets/test_case/omni_test_case/omni_test_case_ 9\n",
+        prog_name, prog_name
+    );
+}
+
+int main(int argc, char ** argv) {
+    ggml_time_init();
+
+    std::string llm_path;
+    std::string vision_path_override;
+    std::string audio_path_override;
+    std::string tts_path_override;
+    std::string projector_path_override;
+    std::string vision_backend = "metal";
+    std::string vision_coreml_model_path;
+    std::string ref_audio_path = "tools/omni/assets/default_ref_audio/default_ref_audio.wav";
+    int n_ctx = 4096;
+    int n_gpu_layers = 99;
+    int media_type = 1;  // 1=audio only, 2=omni(audio+vision)
+    bool use_tts = true;
+    std::string test_audio_prefix;
+    int test_count = 0;
+
+    for (int i = 1; i < argc; i++) {
+        std::string arg = argv[i];
+
+        if (arg == "-h" || arg == "--help") {
+            show_usage(argv[0]);
+            return 0;
+        } else if (arg == "-m" && i + 1 < argc) {
+            llm_path = argv[++i];
+        } else if (arg == "--vision" && i + 1 < argc) {
+            vision_path_override = argv[++i];
+        } else if (arg == "--audio" && i + 1 < argc) {
+            audio_path_override = argv[++i];
+        } else if (arg == "--tts" && i + 1 < argc) {
+            tts_path_override = argv[++i];
+        } else if (arg == "--projector" && i + 1 < argc) {
+            projector_path_override = argv[++i];
+        } else if (arg == "--ref-audio" && i + 1 < argc) {
+            ref_audio_path = argv[++i];
+        } else if ((arg == "-c" || arg == "--ctx-size") && i + 1 < argc) {
+            n_ctx = std::atoi(argv[++i]);
+        } else if (arg == "-ngl" && i + 1 < argc) {
+            n_gpu_layers = std::atoi(argv[++i]);
+        } else if (arg == "--no-tts") {
+            use_tts = false;
+        } else if (arg == "--omni") {
+            media_type = 2;
+        } else if (arg == "--vision-backend" && i + 1 < argc) {
+            vision_backend = argv[++i];
+            if (vision_backend != "metal" && vision_backend != "coreml") {
+                fprintf(stderr, "Error: --vision-backend must be 'metal' or 'coreml', got '%s'\n", vision_backend.c_str());
+                return 1;
+            }
+        } else if (arg == "--vision-coreml" && i + 1 < argc) {
+            vision_coreml_model_path = argv[++i];
+        } else if (arg == "--test" && i + 2 < argc) {
+            test_audio_prefix = argv[++i];
+            test_count = std::atoi(argv[++i]);
+        } else {
+            fprintf(stderr, "Unknown argument: %s\n", arg.c_str());
+            show_usage(argv[0]);
+            return 1;
+        }
+    }
+
+    if (llm_path.empty()) {
+        fprintf(stderr, "Error: -m <llm_model_path> is required\n\n");
+        show_usage(argv[0]);
+        return 1;
+    }
+    if (test_audio_prefix.empty() || test_count <= 0) {
+        fprintf(stderr, "Error: --test <prefix> <n> is required\n\n");
+        show_usage(argv[0]);
+        return 1;
+    }
+
+    OmniModelPaths paths = resolve_model_paths(llm_path);
+    if (!vision_path_override.empty())    paths.vision    = vision_path_override;
+    if (!audio_path_override.empty())     paths.audio     = audio_path_override;
+    if (!tts_path_override.empty())       paths.tts       = tts_path_override;
+    if (!projector_path_override.empty()) paths.projector = projector_path_override;
+    print_model_paths(paths);
+
+    if (!file_exists(paths.llm)) {
+        fprintf(stderr, "Error: LLM model not found: %s\n", paths.llm.c_str());
+        return 1;
+    }
+    if (!file_exists(paths.audio)) {
+        fprintf(stderr, "Error: Audio model not found: %s\n", paths.audio.c_str());
+        return 1;
+    }
+    if (use_tts && !file_exists(paths.tts)) {
+        fprintf(stderr, "Warning: TTS model not found: %s, disabling TTS\n", paths.tts.c_str());
+        use_tts = false;
+    }
+
+    common_params params;
+    params.model.path = paths.llm;
+    params.vpm_model  = paths.vision;
+    params.apm_model  = paths.audio;
+    params.tts_model  = paths.tts;
+    if (vision_backend == "coreml") {
+        if (vision_coreml_model_path.empty()) {
+            vision_coreml_model_path = paths.vision_coreml;
+        }
+        params.vision_coreml_model_path = vision_coreml_model_path;
+    }
+    params.n_ctx        = n_ctx;
+    params.n_gpu_layers = n_gpu_layers;
+
+    std::string tts_bin_dir = get_parent_dir(paths.tts);
+
+    common_init();
+
+    printf("=== Initializing Omni Context ===\n");
+    printf("  Media type: %d (%s)\n", media_type, media_type == 2 ? "omni: audio+vision" : "audio only");
+    printf("  TTS enabled: %s\n", use_tts ? "yes" : "no");
+    printf("  Context size: %d\n", n_ctx);
+    printf("  GPU layers: %d\n", n_gpu_layers);
+    printf("  Vision backend: %s\n", vision_backend.c_str());
+    if (vision_backend == "coreml") {
+        printf("  Vision CoreML: %s\n", vision_coreml_model_path.c_str());
+    }
+    printf("  TTS bin dir: %s\n", tts_bin_dir.c_str());
+    printf("  Ref audio: %s\n", ref_audio_path.c_str());
+
+    // Token2Wav 使用 GPU（Metal），已用 ggml_add+ggml_repeat 替代不支持的 ggml_add1
+    auto ctx_omni = omni_init(&params, media_type, use_tts, tts_bin_dir, -1, "gpu:0");
+    if (ctx_omni == nullptr) {
+        fprintf(stderr, "Error: Failed to initialize omni context\n");
+        return 1;
+    }
+    ctx_omni->async = true;
+    ctx_omni->ref_audio_path = ref_audio_path;
+
+    printf("=== Running singleplex test ===\n");
+    printf("  Audio prefix: %s\n", test_audio_prefix.c_str());
+    printf("  Count: %d\n", test_count);
+    run_singleplex_test(ctx_omni, test_audio_prefix, test_count);
+
+    // 等待 T2W 完成所有音频生成后再停止线程
+    if (ctx_omni->async && ctx_omni->use_tts) {
+        std::string done_flag = std::string(ctx_omni->base_output_dir) + "/round_000/tts_wav/generation_done.flag";
+        fprintf(stderr, "Waiting for audio generation to complete...\n");
+        for (int i = 0; i < 1200; ++i) {  // 最多等 120 秒
+            FILE * f = fopen(done_flag.c_str(), "r");
+            if (f) { fclose(f); fprintf(stderr, "Audio generation completed.\n"); break; }
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+            usleep(100000);  // 100ms
+#elif defined(_WIN32)
+            Sleep(100);
+#endif
+        }
+    }
+
+    if (ctx_omni->async) {
+        omni_stop_threads(ctx_omni);
+        if (ctx_omni->llm_thread.joinable()) { ctx_omni->llm_thread.join(); printf("llm thread end\n"); }
+        if (ctx_omni->use_tts && ctx_omni->tts_thread.joinable()) { ctx_omni->tts_thread.join(); printf("tts thread end\n"); }
+        if (ctx_omni->use_tts && ctx_omni->t2w_thread.joinable()) { ctx_omni->t2w_thread.join(); printf("t2w thread end\n"); }
+    }
+
+    llama_perf_context_print(ctx_omni->ctx_llama);
+
+    omni_free(ctx_omni);
+    return 0;
+}


### PR DESCRIPTION
1.add audio test and omni test
2.simplify the cli
`omni-cli` 是单轮、同步的多模态推理 CLI，支持 `audio / image / text` 任意组合输入（至少 1 项）。

## 基本用法

```bash
./omni-cli -m <llm_model_path> [-a <audio.wav>] [-i <image.jpg/png>] [-p <text>] [options]
```

- 必填参数：`-m <llm.gguf>`
- 输入参数：
  - `-a, --audio-input <path>`：输入音频（wav）
  - `-i, --image <path>`：输入图片（jpg/png）
  - `-p, --prompt <text>`：输入文本

## 关键行为与约束

- 输入至少提供 `-a / -i / -p` 中的一项，否则报错。
- 使用 `-i` 时必须同时开启 `--omni`，否则报错。
- 默认开启 TTS（会生成 wav）；可用 `--no-tts` 关闭，仅输出文本。
- 若 TTS 模型不存在，会告警并自动降级为无 TTS。

## 模型路径规则

仅 `-m` 必填，其它模型默认按 `-m` 所在目录自动推断：

- `vision/MiniCPM-o-4_5-vision-F16.gguf`（仅 `--omni` 时需要）
- `audio/MiniCPM-o-4_5-audio-F16.gguf`
- `tts/MiniCPM-o-4_5-tts-F16.gguf`
- `tts/MiniCPM-o-4_5-projector-F16.gguf`

可通过以下参数覆盖默认路径：

- `--vision <path>`
- `--audio <path>`
- `--tts <path>`
- `--projector <path>`

## 常用参数

- `--omni`：启用视觉模型（允许 `-i`）
- `--no-tts`：关闭 TTS
- `-o, --output-dir <path>`：TTS 输出目录（默认 `./tools/omni/output`）
- `--ref-audio <path>`：参考音频（默认 `tools/omni/assets/default_ref_audio/default_ref_audio.wav`）
- `-c, --ctx-size <n>`：上下文长度（默认 `4096`）
- `-ngl <n>`：GPU 层数（默认 `99`）
- `--vision-backend <metal|coreml>`：视觉后端（默认 `metal`）
- `--vision-coreml <path>`：CoreML 模型路径（`backend=coreml` 时使用）
- `-h, --help`：显示帮助

## 示例命令

```bash
# 纯文本 QA（不生成语音）
./omni-cli -m ./models/MiniCPM-o-4_5-Q4_K_M.gguf -p "介绍一下你自己" --no-tts

# 音频 + 图片 + 文本，多模态并输出 TTS
./omni-cli -m ./models/MiniCPM-o-4_5-Q4_K_M.gguf --omni \
  -a ./input.wav -i ./input.jpg -p "描述一下图片里的场景" -o ./out
```