### PR TITLE
omni: apply length_penalty to <|turn_eos|> in duplex mode

### DIFF
--- a/tools/omni/omni.cpp
+++ b/tools/omni/omni.cpp
@@ -1066,6 +1066,16 @@ static const char * sample_with_hidden_and_token(struct common_sampler * smpl, s
             if (ctx_omni->special_token_tts_pad >= 0) {
                 logits[ctx_omni->special_token_tts_pad] = -INFINITY;
             }
+
+            // 3. Duplex 模式下对 <|turn_eos|> 应用长度惩罚，让 Python 透传的配置真正生效
+            if (ctx_omni->length_penalty != 1.0f && ctx_omni->special_token_turn_eos >= 0) {
+                float eos_logit = logits[ctx_omni->special_token_turn_eos];
+                if (eos_logit > 0) {
+                    logits[ctx_omni->special_token_turn_eos] = eos_logit / ctx_omni->length_penalty;
+                } else {
+                    logits[ctx_omni->special_token_turn_eos] = eos_logit * ctx_omni->length_penalty;
+                }
+            }
         }
     }
     


### PR DESCRIPTION
The non-duplex sampling branch already adjusts the <|tts_eos|> logit according to ctx_omni->length_penalty, but the duplex branch has been missing the equivalent adjustment for <|turn_eos|>. As a result the length_penalty value posted by the Python adapter could be stored on the omni context yet never influence sampling, so duplex turns ended on whatever logit the model produced regardless of the configured penalty.

Mirror the existing non-duplex piecewise formula (divide a positive logit by length_penalty, multiply a non-positive logit by it) for <|turn_eos|> inside the duplex logit-adjustment block. The new code sits next to the existing listen / tts_pad adjustments, sharing the same logits != nullptr guard, so length_penalty > 1 now actually suppresses turn_eos and pushes duplex turns to be longer, matching the PyTorch StreamDecoder implementation.

Made-with: Cursor