### PR TITLE
add t2w profiling

### DIFF
--- a/tools/omni/CMakeLists.txt
+++ b/tools/omni/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(omni
             token2wav/token2wav-impl.h
             token2wav/token2wav.cpp
             token2wav/token2wav.h
+            token2wav/token2wav-profile.h
             )
 
 # Add CoreML related files when enabled
@@ -115,8 +116,7 @@ set_target_properties  (${TARGET_DUPLEX_TEST} PROPERTIES OUTPUT_NAME llama-omni-
 target_link_libraries  (${TARGET_DUPLEX_TEST} PRIVATE common omni Threads::Threads)
 target_compile_features(${TARGET_DUPLEX_TEST} PRIVATE cxx_std_17)
 
-# # Token2Wav 测试程序 - 完整 C++ 语音合成
-# add_executable(token2wav-example token2wav/token2wav-example.cpp)
-# target_link_libraries(token2wav-example PRIVATE common omni Threads::Threads)
-# target_compile_features(token2wav-example PRIVATE cxx_std_17)
-
+# Token2Wav 测试程序 - 纯 C++ 单线程 baseline（用于 profile 对照，不占 LLM/TTS GPU）
+add_executable(token2wav-example token2wav/token2wav-example.cpp)
+target_link_libraries(token2wav-example PRIVATE common omni Threads::Threads)
+target_compile_features(token2wav-example PRIVATE cxx_std_17)

--- a/tools/omni/token2wav/readme.txt
+++ b/tools/omni/token2wav/readme.txt
@@ -26,3 +26,17 @@ reset()
   实现位于/llamacpp/tools/omni/token2wav-impl.cpp
   
 3. 使用示例（init_from_prompt_cache_gguf+feed_window() 接口组合）
+
+4. Profile（性能度量，见 token2wav-profile.h）
+  通过环境变量开启，默认关闭，对上层接口完全透明：
+    OMNI_T2W_PROFILE=1    仅在进程退出前打印一次 [profile] summary 汇总
+                          （init / token2mel / vocoder / total / callback 的
+                           min/p50/p95/p99/max/mean，以及 audio / RTF）
+    OMNI_T2W_PROFILE=2    在上面基础上，每次 push_tokens_window 都打印一行 [timing]
+    OMNI_T2W_PRINT_GRAPH=1 第一次调用 token2mel 与 vocoder 的图计算时各 ggml_graph_print 一次
+
+  典型建立 baseline 的做法（同目标硬件跑 10+ 次取中位数）：
+    OMNI_T2W_PROFILE=1 ./token2wav-example 2> /tmp/t2w_profile.log
+  首次做 kernel 级 profile 时可配合：
+    nsys profile --trace=cuda,nvtx,osrt -o t2w \
+        env OMNI_T2W_PROFILE=2 OMNI_T2W_PRINT_GRAPH=1 ./token2wav-example

--- a/tools/omni/token2wav/token2wav-example.cpp
+++ b/tools/omni/token2wav/token2wav-example.cpp
@@ -1,4 +1,5 @@
 #include "token2wav-impl.h"
+#include "token2wav-profile.h"
 
 #include <algorithm>
 #include <cmath>
@@ -95,21 +96,30 @@ int main() {
     // token2wav-example：主要关注初始化和两种送入输出方式即可
     // 目前是使用读取prompt_cache.gguf的方式初始化然后以call的方式来流式输出pcm并转换为wav
 
-    // 默认路径，根据5个gguf和两个输出位置改动
-    std::string model_dir = "./tools/omni/convert/gguf/token2wav-gguf";
-    std::string encoder_gguf = model_dir + "/encoder.gguf";
+    // 默认路径，根据5个gguf和两个输出位置改动；可用环境变量覆盖，便于做纯 T2W profile。
+    //   OMNI_T2W_MODEL_DIR  : token2wav-gguf 目录（内含 encoder/flow_*/hifigan2/prompt_cache）
+    //   OMNI_T2W_DEVICE     : "cpu" / "gpu" / "gpu:<idx>"（对 token2mel 和 vocoder 同时生效）
+    //   OMNI_T2W_OUT_WAV    : 合并输出 WAV 路径
+    //   OMNI_T2W_OUT_CHUNK_DIR : 每个 callback chunk 的输出目录（空串 = 不落盘）
+    auto env_or = [](const char * name, const std::string & def) {
+        const char * v = std::getenv(name);
+        return (v && *v) ? std::string(v) : def;
+    };
+
+    std::string model_dir      = env_or("OMNI_T2W_MODEL_DIR", "./tools/omni/convert/gguf/token2wav-gguf");
+    std::string encoder_gguf       = model_dir + "/encoder.gguf";
     std::string flow_matching_gguf = model_dir + "/flow_matching.gguf";
-    std::string flow_extra_gguf = model_dir + "/flow_extra.gguf";
-    std::string vocoder_gguf = model_dir + "/hifigan2.gguf";
-    std::string prompt_cache_gguf = model_dir + "/prompt_cache.gguf";
+    std::string flow_extra_gguf    = model_dir + "/flow_extra.gguf";
+    std::string vocoder_gguf       = model_dir + "/hifigan2.gguf";
+    std::string prompt_cache_gguf  = model_dir + "/prompt_cache.gguf";
 
-    std::string out_wav = "/tmp/token2wav_example_stream.wav";
-    std::string out_chunk_wav_dir = "/tmp/token2wav_example_chunks";
+    std::string out_wav            = env_or("OMNI_T2W_OUT_WAV", "/tmp/token2wav_example_stream.wav");
+    std::string out_chunk_wav_dir  = env_or("OMNI_T2W_OUT_CHUNK_DIR", "/tmp/token2wav_example_chunks");
 
-    std::string device_token2mel = "gpu";
-    std::string device_vocoder   = "gpu";
+    std::string device_token2mel   = env_or("OMNI_T2W_DEVICE", "gpu");
+    std::string device_vocoder     = env_or("OMNI_T2W_DEVICE", "gpu");
 
-    int       n_timesteps = 10;
+    int       n_timesteps = std::atoi(env_or("OMNI_T2W_N_TIMESTEPS", "5").c_str());
     float     temperature = 1.0f;
     const int sr          = omni::flow::Token2Wav::kSampleRate;
 
@@ -130,8 +140,10 @@ int main() {
         return 2;
     }
 
+    const int repeat = std::max(1, std::atoi(env_or("OMNI_T2W_REPEAT", "1").c_str()));
+
     // 例子 token
-    const std::vector<int32_t> tokens = {
+    std::vector<int32_t> tokens_base = {
         1493, 4299, 4218, 2049, 528,  2752, 4850, 4569, 4575, 6372, 2127, 4068, 2312, 4993, 4769, 2300,
         226,  2175, 2160, 2152, 6311, 6065, 4859, 5102, 4615, 6534, 6426, 1763, 2249, 2209, 5938, 1725,
         6048, 3816, 6058, 958,  63,   4460, 5914, 2379, 735,  5319, 4593, 2328, 890,  35,   751,  1483,
@@ -139,6 +151,11 @@ int main() {
         2031, 414,  4366, 4366, 6059, 5300, 4814, 5092, 5100, 1923, 3054, 4320, 4296, 2148, 4371, 5831,
         5084, 5027, 4946, 4946, 2678, 575,  575,  521,  518,  638,  1367, 2804, 3402, 4299,
     };
+    std::vector<int32_t> tokens;
+    tokens.reserve(tokens_base.size() * (size_t) repeat);
+    for (int r = 0; r < repeat; ++r) {
+        tokens.insert(tokens.end(), tokens_base.begin(), tokens_base.end());
+    }
 
     omni::flow::Token2WavSession sess;
     // 初始化：加载 encoder/flow/vocoder 模型，导入 prompt_cache用于初始化
@@ -226,6 +243,9 @@ int main() {
     if (!out_chunk_wav_dir.empty()) {
         std::printf("[done] out_chunk_wav_dir=%s\n", out_chunk_wav_dir.c_str());
     }
+
+    // 汇总 profile 结果（OMNI_T2W_PROFILE=0 时会直接跳过）
+    omni::flow::profile::print_summary(stderr);
     return 0;
 }
 

--- a/tools/omni/token2wav/token2wav-impl.cpp
+++ b/tools/omni/token2wav/token2wav-impl.cpp
@@ -1,7 +1,9 @@
 
 
 #include "token2wav-impl.h"
+#include "token2wav-profile.h"
 
+#include <atomic>
 #include <cstdio>
 #include <string>
 #include <cmath>
@@ -6460,6 +6462,15 @@ bool voc_hg2_runner::voc_hg2_runner_eval_stream(const std::vector<float> & speec
         hg_backend_tensor_set(model->backend, cache_source_t1_b, cache_source_bt1.data(),
                                                  cache_source_bt1.size() * sizeof(float));
     }
+    if (omni::flow::profile::print_graph_enabled()) {
+        static std::atomic<bool> printed{ false };
+        bool                     expected = false;
+        if (printed.compare_exchange_strong(expected, true)) {
+            std::fprintf(stderr, "[profile] ===== vocoder (HiFiGAN2) graph =====\n");
+            std::fprintf(stderr, "[profile] n_nodes=%d\n", ggml_graph_n_nodes(gf));
+            ggml_graph_print(gf);
+        }
+    }
     const ggml_status st = ggml_backend_graph_compute(model->backend, gf);
     if (st != GGML_STATUS_SUCCESS) {
         LOG_ERROR( "voc_hg2_runner_eval_stream: ggml_backend_graph_compute failed\n");
@@ -7563,6 +7574,21 @@ bool flowGGUFModelRunner::inference_chunk(const int32_t *             token_bt,
                                  B);
     // 根据last_chunk选择图并执行推理
     ggml_cgraph *     gf = last_chunk ? sess_->gf_last : sess_->gf_nonlast;
+    if (omni::flow::profile::print_graph_enabled()) {
+        // 非 last 图和 last 图各打印一次（帮助 profile 阶段看清楚 encoder+flow 融合图的规模）
+        static std::atomic<bool> printed_nonlast{ false };
+        static std::atomic<bool> printed_last{ false };
+        std::atomic<bool> &      flag     = last_chunk ? printed_last : printed_nonlast;
+        bool                     expected = false;
+        if (flag.compare_exchange_strong(expected, true)) {
+            std::fprintf(stderr,
+                         "[profile] ===== token2mel graph (%s) =====\n",
+                         last_chunk ? "gf_last" : "gf_nonlast");
+            std::fprintf(stderr, "[profile] n_nodes=%d n_timesteps=%d T_chunk_token=%lld B=%lld\n",
+                         ggml_graph_n_nodes(gf), n_timesteps, (long long) sess_->T_chunk_token, (long long) B);
+            ggml_graph_print(gf);
+        }
+    }
     const ggml_status st = ggml_backend_graph_compute(loader_.backend(), gf);
     if (st != GGML_STATUS_SUCCESS) {
         return false;
@@ -8624,26 +8650,31 @@ bool Token2Wav::push_tokens_window(const int32_t *      tokens,
     }
 
     using clock = std::chrono::steady_clock;
-    const auto t_total0 = clock::now();
+    const auto                  t_total0 = clock::now();
+    static thread_local int64_t call_id  = 0;
+    const int64_t               cid      = call_id++;
+    const bool                  is_first = (cid == 0);
 
     std::vector<float> mel_bct;
-    const auto t_t2m0 = clock::now();
+    const auto         t_t2m0 = clock::now();
     if (!t2m_.push_tokens(tokens, n_tokens, is_final, mel_bct)) {
-        LOG_ERROR( "Token2Wav.push_tokens_window: Token2Mel.push_tokens failed\n");
+        LOG_ERROR("Token2Wav.push_tokens_window: Token2Mel.push_tokens failed\n");
         return false;
     }
-    const auto t_t2m1 = clock::now();
+    const auto   t_t2m1  = clock::now();
+    const double t2m_ms  = std::chrono::duration<double, std::milli>(t_t2m1 - t_t2m0).count();
 
     if (mel_bct.empty()) {
-        const double t2m_ms =
-            std::chrono::duration<double, std::milli>(t_t2m1 - t_t2m0).count();
-        const double total_ms =
-            std::chrono::duration<double, std::milli>(clock::now() - t_total0).count();
-        static thread_local int64_t call_id = 0;
-        const int64_t cid = call_id++;
-        std::fprintf(stderr,
-                     "[timing] call=%lld tokens=%lld final=%d token2mel=%.3fms vocoder=%.3fms total=%.3fms\n",
-                     (long long) cid, (long long) n_tokens, (int) is_final, t2m_ms, 0.0, total_ms);
+        const double total_ms = std::chrono::duration<double, std::milli>(clock::now() - t_total0).count();
+        omni::flow::profile::record_ms("token2mel", t2m_ms, is_first);
+        omni::flow::profile::record_ms("vocoder", 0.0, is_first);
+        omni::flow::profile::record_ms("total", total_ms, is_first);
+        if (omni::flow::profile::verbose()) {
+            std::fprintf(stderr,
+                         "[timing] call=%lld%s tokens=%lld final=%d token2mel=%.3fms vocoder=%.3fms total=%.3fms\n",
+                         (long long) cid, is_first ? "(first)" : "", (long long) n_tokens, (int) is_final, t2m_ms,
+                         0.0, total_ms);
+        }
         return true;
     }
     if (mel_bct.size() % (size_t) Token2Mel::kMelChannels != 0) {
@@ -8696,18 +8727,21 @@ bool Token2Wav::push_tokens_window(const int32_t *      tokens,
         out_T_audio = (int64_t) wave_bt_out.size();
     }
 
-    const double t2m_ms =
-        std::chrono::duration<double, std::milli>(t_t2m1 - t_t2m0).count();
-    const double voc_ms =
-        std::chrono::duration<double, std::milli>(t_voc1 - t_voc0).count();
-    const double total_ms =
-        std::chrono::duration<double, std::milli>(clock::now() - t_total0).count();
-    static thread_local int64_t call_id = 0;
-    const int64_t cid = call_id++;
-    std::fprintf(stderr,
-                 "[timing] call=%lld tokens=%lld final=%d token2mel=%.3fms vocoder=%.3fms total=%.3fms audio=%lld\n",
-                 (long long) cid, (long long) n_tokens, (int) is_final, t2m_ms, voc_ms, total_ms,
-                 (long long) out_T_audio);
+    const double voc_ms   = std::chrono::duration<double, std::milli>(t_voc1 - t_voc0).count();
+    const double total_ms = std::chrono::duration<double, std::milli>(clock::now() - t_total0).count();
+
+    omni::flow::profile::record_ms("token2mel", t2m_ms, is_first);
+    omni::flow::profile::record_ms("vocoder", voc_ms, is_first);
+    omni::flow::profile::record_ms("total", total_ms, is_first);
+    omni::flow::profile::record_audio_samples((int64_t) out_T_audio, (int32_t) Token2Wav::kSampleRate);
+
+    if (omni::flow::profile::verbose()) {
+        std::fprintf(
+            stderr,
+            "[timing] call=%lld%s tokens=%lld final=%d token2mel=%.3fms vocoder=%.3fms total=%.3fms audio=%lld\n",
+            (long long) cid, is_first ? "(first)" : "", (long long) n_tokens, (int) is_final, t2m_ms, voc_ms, total_ms,
+            (long long) out_T_audio);
+    }
 
     return true;
 }

--- a/tools/omni/token2wav/token2wav-profile.h
+++ b/tools/omni/token2wav/token2wav-profile.h
@@ -1,0 +1,312 @@
+#pragma once
+
+// Token2Wav profiling helpers (header-only).
+//
+// 设计目标：
+//   - 尽量零成本：关闭时只有一次原子读 + 一次时间戳，不做任何 I/O。
+//   - 无侵入：通过环境变量控制，不改公共接口。
+//   - 便于 baseline：统一给出 init / token2mel / vocoder / total / callback 的
+//     p50/p95/p99/mean，并区分 "首 chunk" 和 "稳态 chunk"。
+//
+// 环境变量：
+//   OMNI_T2W_PROFILE        : 0=关闭（默认）
+//                             1=收集统计 + 结束时 print_summary()
+//                             2=每次 push_tokens_window 都打印一行 [timing]
+//   OMNI_T2W_PRINT_GRAPH    : 1=第一次调用时 ggml_graph_print() 一次性转储图结构
+//
+// 使用：
+//   profile::ScopeTimer t("token2mel");           // 超出作用域自动记录
+//   profile::Profiler::instance().print_summary(stderr);
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace omni {
+namespace flow {
+namespace profile {
+
+class Profiler;
+inline Profiler & profiler_instance_();
+inline void       print_summary(std::FILE * f);
+
+// 首次调用 enabled() 时通过 atexit 注册一次性 summary dump，这样 llama-omni-cli、
+// token2wav-example、test-duplex 等任何链接 libomni 的 binary 都会在退出前自动打印。
+//
+// 关键点：必须先"触摸"一次 Profiler::instance() 让 Meyers singleton 完成构造，
+// 然后再调 std::atexit(print_summary)。这样 atexit 的 LIFO 顺序会保证
+// print_summary() 先于 Profiler 的隐式析构器执行，避免访问已销毁的 vector。
+inline void ensure_autoprint_() {
+    static bool once = [] {
+        (void) profiler_instance_();
+        std::atexit([] { print_summary(stderr); });
+        return true;
+    }();
+    (void) once;
+}
+
+inline int level() {
+    static int v = [] {
+        const char * s = std::getenv("OMNI_T2W_PROFILE");
+        if (!s || !*s) {
+            return 0;
+        }
+        const int n = std::atoi(s);
+        return n < 0 ? 0 : n;
+    }();
+    if (v >= 1) {
+        ensure_autoprint_();
+    }
+    return v;
+}
+
+inline bool enabled() {
+    return level() >= 1;
+}
+
+inline bool verbose() {
+    return level() >= 2;
+}
+
+inline bool print_graph_enabled() {
+    static int v = [] {
+        const char * s = std::getenv("OMNI_T2W_PRINT_GRAPH");
+        if (!s || !*s) {
+            return 0;
+        }
+        return std::atoi(s) != 0 ? 1 : 0;
+    }();
+    return v != 0;
+}
+
+struct Stage {
+    std::string         name;
+    std::vector<double> samples_ms;
+};
+
+class Profiler {
+  public:
+    static Profiler & instance() { return profiler_instance_(); }
+
+    void record_init(double ms) {
+        std::lock_guard<std::mutex> lk(mu_);
+        init_ms_ = ms;
+    }
+
+    void record(const char * stage, double ms, bool is_first_chunk = false) {
+        std::lock_guard<std::mutex> lk(mu_);
+        Stage & s = get_or_create(stage);
+        s.samples_ms.push_back(ms);
+        if (is_first_chunk && std::strcmp(stage, "total") == 0) {
+            first_chunk_ms_ = ms;
+        }
+    }
+
+    void add_audio_samples(int64_t n_samples, int32_t sample_rate) {
+        std::lock_guard<std::mutex> lk(mu_);
+        total_audio_samples_ += n_samples;
+        if (sample_rate > 0) {
+            sample_rate_ = sample_rate;
+        }
+    }
+
+    void reset() {
+        std::lock_guard<std::mutex> lk(mu_);
+        stages_.clear();
+        init_ms_             = 0.0;
+        first_chunk_ms_      = 0.0;
+        total_audio_samples_ = 0;
+    }
+
+    // 注意：percentile 使用线性插值；样本量小（<10）时 p95/p99 意义不大但仍能给出上界
+    void print_summary(std::FILE * f = stderr) {
+        std::lock_guard<std::mutex> lk(mu_);
+        if (stages_.empty() && init_ms_ == 0.0) {
+            return;
+        }
+
+        std::fprintf(f, "\n[profile] ===================== token2wav profile summary =====================\n");
+        if (init_ms_ > 0.0) {
+            std::fprintf(f, "[profile] init                                          = %9.3f ms\n", init_ms_);
+        }
+        if (first_chunk_ms_ > 0.0) {
+            std::fprintf(f, "[profile] first-chunk total (warmup, includes JIT etc.) = %9.3f ms\n", first_chunk_ms_);
+        }
+
+        std::fprintf(f,
+                     "[profile] %-12s %8s %10s %10s %10s %10s %10s %10s\n",
+                     "stage", "n", "min", "p50", "p95", "p99", "max", "mean");
+        for (Stage & s : stages_) {
+            const auto st = compute_stats_(s.samples_ms);
+            std::fprintf(f,
+                         "[profile] %-12s %8zu %10.3f %10.3f %10.3f %10.3f %10.3f %10.3f\n",
+                         s.name.c_str(), s.samples_ms.size(), st.min_v, st.p50, st.p95, st.p99, st.max_v, st.mean);
+        }
+
+        if (total_audio_samples_ > 0 && sample_rate_ > 0) {
+            const Stage * total_stage = find_stage_("total");
+            if (total_stage && !total_stage->samples_ms.empty()) {
+                double sum_ms = 0.0;
+                for (double v : total_stage->samples_ms) {
+                    sum_ms += v;
+                }
+                const double audio_ms = 1000.0 * (double) total_audio_samples_ / (double) sample_rate_;
+                const double rtf      = (audio_ms > 0.0) ? (sum_ms / audio_ms) : 0.0;
+                std::fprintf(f,
+                             "[profile] audio=%.3fs compute=%.3fs RTF=%.4f (<1 is faster than realtime)\n",
+                             audio_ms / 1000.0, sum_ms / 1000.0, rtf);
+            }
+        }
+        std::fprintf(f, "[profile] ==========================================================================\n\n");
+    }
+
+  private:
+    struct Stats {
+        double min_v = 0.0;
+        double max_v = 0.0;
+        double mean  = 0.0;
+        double p50   = 0.0;
+        double p95   = 0.0;
+        double p99   = 0.0;
+    };
+
+    static double percentile_(std::vector<double> & v, double p) {
+        if (v.empty()) {
+            return 0.0;
+        }
+        if (v.size() == 1) {
+            return v.front();
+        }
+        const double h     = p * (double) (v.size() - 1);
+        const size_t lo    = (size_t) std::floor(h);
+        const size_t hi    = std::min(lo + 1, v.size() - 1);
+        const double frac  = h - (double) lo;
+        return v[lo] + frac * (v[hi] - v[lo]);
+    }
+
+    static Stats compute_stats_(const std::vector<double> & in) {
+        Stats st{};
+        if (in.empty()) {
+            return st;
+        }
+        std::vector<double> sorted = in;
+        std::sort(sorted.begin(), sorted.end());
+        double sum = 0.0;
+        for (double v : sorted) {
+            sum += v;
+        }
+        st.min_v = sorted.front();
+        st.max_v = sorted.back();
+        st.mean  = sum / (double) sorted.size();
+        st.p50   = percentile_(sorted, 0.50);
+        st.p95   = percentile_(sorted, 0.95);
+        st.p99   = percentile_(sorted, 0.99);
+        return st;
+    }
+
+    Stage & get_or_create(const char * name) {
+        for (Stage & s : stages_) {
+            if (s.name == name) {
+                return s;
+            }
+        }
+        stages_.push_back(Stage{ name, {} });
+        return stages_.back();
+    }
+
+    const Stage * find_stage_(const char * name) const {
+        for (const Stage & s : stages_) {
+            if (s.name == name) {
+                return &s;
+            }
+        }
+        return nullptr;
+    }
+
+    std::mutex         mu_;
+    std::vector<Stage> stages_;
+    double             init_ms_             = 0.0;
+    double             first_chunk_ms_      = 0.0;
+    int64_t            total_audio_samples_ = 0;
+    int32_t            sample_rate_         = 0;
+};
+
+// RAII: 超出作用域时记录一次耗时样本。关闭 profiling 时不会进入 Profiler 内部加锁路径。
+class ScopeTimer {
+  public:
+    explicit ScopeTimer(const char * stage_name, bool is_first_chunk = false) :
+        stage_(stage_name),
+        t0_(std::chrono::steady_clock::now()),
+        first_(is_first_chunk) {}
+
+    ~ScopeTimer() {
+        const auto   t1 = std::chrono::steady_clock::now();
+        const double ms = std::chrono::duration<double, std::milli>(t1 - t0_).count();
+        ms_             = ms;
+        if (record_ && enabled()) {
+            Profiler::instance().record(stage_, ms, first_);
+        }
+    }
+
+    // 禁止复制，允许"吞掉"记录（用于业务代码自行决定是否记录）
+    ScopeTimer(const ScopeTimer &)             = delete;
+    ScopeTimer & operator=(const ScopeTimer &) = delete;
+
+    void cancel() { record_ = false; }
+
+    // 读取已过去的毫秒数（不停止计时）
+    double elapsed_ms() const {
+        const auto t1 = std::chrono::steady_clock::now();
+        return std::chrono::duration<double, std::milli>(t1 - t0_).count();
+    }
+
+    // 析构后可取到最终耗时
+    double ms() const { return ms_; }
+
+  private:
+    const char *                               stage_;
+    std::chrono::steady_clock::time_point      t0_;
+    bool                                       first_  = false;
+    bool                                       record_ = true;
+    double                                     ms_     = 0.0;
+};
+
+// 便捷函数
+inline void record_init_ms(double ms) {
+    if (enabled()) {
+        Profiler::instance().record_init(ms);
+    }
+}
+
+inline void record_ms(const char * stage, double ms, bool is_first_chunk = false) {
+    if (enabled()) {
+        Profiler::instance().record(stage, ms, is_first_chunk);
+    }
+}
+
+inline void record_audio_samples(int64_t n_samples, int32_t sample_rate) {
+    if (enabled()) {
+        Profiler::instance().add_audio_samples(n_samples, sample_rate);
+    }
+}
+
+inline Profiler & profiler_instance_() {
+    static Profiler p;
+    return p;
+}
+
+inline void print_summary(std::FILE * f) {
+    profiler_instance_().print_summary(f);
+}
+
+}  // namespace profile
+}  // namespace flow
+}  // namespace omni

--- a/tools/omni/token2wav/token2wav.cpp
+++ b/tools/omni/token2wav/token2wav.cpp
@@ -1,5 +1,7 @@
 #include "token2wav.h"
+#include "token2wav-profile.h"
 
+#include <chrono>
 #include <cstdio>
 
 namespace omni {
@@ -15,6 +17,7 @@ bool Token2WavSession::init_from_prompt_cache_gguf(const std::string & encoder_g
                                                    int                 n_timesteps,
                                                    float               temperature) {
     // 初始化方式第一种，仅需使用此方式即可，加载模型所有的gguf内容
+    const auto t0 = std::chrono::steady_clock::now();
     reset();
     if (!t2w.load_models(encoder_gguf, flow_matching_gguf, flow_extra_gguf, vocoder_gguf, device_token2mel,
                          device_vocoder)) {
@@ -22,6 +25,12 @@ bool Token2WavSession::init_from_prompt_cache_gguf(const std::string & encoder_g
     }
     if (!t2w.start_stream_with_prompt_cache_gguf(prompt_cache_gguf_path, n_timesteps, temperature)) {
         return false;
+    }
+    const auto   t1     = std::chrono::steady_clock::now();
+    const double init_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+    omni::flow::profile::record_init_ms(init_ms);
+    if (omni::flow::profile::verbose()) {
+        std::fprintf(stderr, "[timing] init_from_prompt_cache_gguf=%.3fms\n", init_ms);
     }
 
     return true;
@@ -78,7 +87,15 @@ bool Token2WavSession::feed_window(const int32_t *              tokens,
         return false;
     }
     if (on_audio_chunk && !wave_tmp_.empty()) {
+        const auto t_cb0 = std::chrono::steady_clock::now();
         on_audio_chunk(wave_tmp_.data(), (int64_t) wave_tmp_.size());
+        const auto   t_cb1 = std::chrono::steady_clock::now();
+        const double cb_ms = std::chrono::duration<double, std::milli>(t_cb1 - t_cb0).count();
+        omni::flow::profile::record_ms("callback", cb_ms);
+        if (omni::flow::profile::verbose()) {
+            std::fprintf(stderr, "[timing] callback=%.3fms samples=%lld\n",
+                         cb_ms, (long long) wave_tmp_.size());
+        }
     }
     return true;
 }


### PR DESCRIPTION
## Summary
为 `tools/omni/token2wav` 加一套**零开销、默认关闭、对上层接口完全透明**的性能度量设施，作为后续 Token2Wav 优化的 baseline 基础设施。不改变任何推理逻辑，不改变现有对外 API 行为。
主要包含三部分：
1. 新增 `tools/omni/token2wav/token2wav-profile.h`：header-only 的 Profiler（单例 + `ScopeTimer`），按环境变量开启，收集各阶段耗时样本并在进程退出前打印 `min / p50 / p95 / p99 / max / mean`，同时根据生成音频长度计算 RTF。
2. 在 `token2wav-impl.cpp` / `token2wav.cpp` 的关键路径上加埋点：`init`、`token2mel`、`vocoder`、`total`、`callback`，并区分 first-chunk（含 warmup/JIT）与稳态样本。
3. `token2wav-example.cpp` 增加环境变量覆盖（模型目录 / device / 输出路径 / timesteps / repeat 次数），并在结尾调用 `profile::print_summary`；`tools/omni/CMakeLists.txt` 重新启用 `token2wav-example` 作为纯 T2W profile baseline 可执行文件（不占 LLM/TTS GPU）。
## 使用方式
通过环境变量开启，默认关闭时不会进入 Profiler 的加锁路径：
| 变量 | 取值 | 作用 |
| --- | --- | --- |
| `OMNI_T2W_PROFILE` | `1` | 进程退出前打印一次 `[profile] summary`（各阶段 min/p50/p95/p99/max/mean，audio / RTF） |
| `OMNI_T2W_PROFILE` | `2` | 在 `1` 的基础上，每次 `push_tokens_window` 再打印一行 `[timing]` |
| `OMNI_T2W_PRINT_GRAPH` | `1` | 第一次进入 token2mel（`gf_last` / `gf_nonlast` 各一次）与 vocoder 时，各 `ggml_graph_print` 一次 |
| `OMNI_T2W_MODEL_DIR` | path | 覆盖 `token2wav-gguf` 目录 |
| `OMNI_T2W_DEVICE` | `cpu` / `gpu` / `gpu:<idx>` | 同时作用于 token2mel 与 vocoder |
| `OMNI_T2W_OUT_WAV` / `OMNI_T2W_OUT_CHUNK_DIR` | path | 覆盖合并输出 / 每 chunk 输出目录（空串 = 不落盘） |
| `OMNI_T2W_N_TIMESTEPS` | int | flow matching 步数（默认 `5`） |
| `OMNI_T2W_REPEAT` | int | 把样例 token 重复 N 次，便于跑够样本量 |
典型用法（同硬件跑 10+ 次取中位数作为 baseline）：
```bash
OMNI_T2W_PROFILE=1 ./token2wav-example 2> /tmp/t2w_profile.log
```
首次做 kernel 级 profile 时可配合：
```bash
nsys profile --trace=cuda,nvtx,osrt -o t2w \
    env OMNI_T2W_PROFILE=2 OMNI_T2W_PRINT_GRAPH=1 ./token2wav-example
```