### PR TITLE
turnbased text-in: accept user text in /v1/stream/prefill (fix gibberish)

### DIFF
--- a/tools/omni/omni.cpp
+++ b/tools/omni/omni.cpp
@@ -4445,7 +4445,7 @@ void llm_thread_func(omni_context* ctx_omni, common_params* params){
                     }
                 }
                 // ========== 子分支2：处理只有音频嵌入的数据（纯音频模式） ==========
-                else {
+                else if (!embeds->audio_embed.empty()) {
                     int n_audio_tokens = embeds->audio_embed.size() / hidden_size;
                     print_with_timestamp("用户语音: %d audio tokens\n", n_audio_tokens);
                     
@@ -4467,10 +4467,22 @@ void llm_thread_func(omni_context* ctx_omni, common_params* params){
                         eval_string(ctx_omni, params, "<|audio_end|>", params->n_batch, &ctx_omni->n_past, false);
                     }
                 }
+                // ========== 子分支3：纯文本输入（turn-based chat 文本对话） ==========
+                // 单工：assistant_prompt 末尾已带 <|im_start|>user\n，文本本身不需要
+                //       任何 <|audio_start|>/<|audio_end|> 之类的 modality 包裹。
+                // 双工：与音频对齐，先 <unit> 再写入文本。
+                else if (!embeds->user_text.empty()) {
+                    if (ctx_omni->duplex_mode) {
+                        eval_string(ctx_omni, params, "<unit>", params->n_batch, &ctx_omni->n_past, false);
+                    }
+                    eval_string(ctx_omni, params, embeds->user_text.c_str(), params->n_batch, &ctx_omni->n_past, false);
+                }
                 
                 // 🔧 [#39 滑动窗口] 注册 unit 结束
                 if (ctx_omni->sliding_window_config.mode != "off") {
-                    std::string input_type = embeds->vision_embed.size() > 0 ? "omni" : "audio";
+                    std::string input_type = embeds->vision_embed.size() > 0 ? "omni"
+                                           : !embeds->audio_embed.empty()    ? "audio"
+                                           :                                   "text";
                     sliding_window_register_unit_end(ctx_omni, input_type, {}, false);
                 }
                 
@@ -8745,7 +8757,7 @@ void t2w_thread_func(struct omni_context * ctx_omni, common_params *params) {
     }
 }
 
-bool stream_prefill(struct omni_context * ctx_omni, std::string aud_fname, std::string img_fname, int index, int max_slice_nums) {
+bool stream_prefill(struct omni_context * ctx_omni, std::string aud_fname, std::string img_fname, int index, int max_slice_nums, std::string text) {
     
     // 只有在新一轮开始时 (index == 0) 才需要等待上一轮 TTS 完成
     // 同一轮内的后续 prefill (index >= 1) 不需要等待
@@ -9049,6 +9061,10 @@ bool stream_prefill(struct omni_context * ctx_omni, std::string aud_fname, std::
                 } else {
                     LOG_WRN("%s: audio encoding failed, skipping audio for this frame: %s\n", __func__, aud_fname.c_str());
                 }
+            }
+            // text 仅作为字面量带过去，由 LLM 线程在锁保护下做 eval_string。
+            if (!text.empty()) {
+                omni_embeds->user_text = text;
             }
             omni_embeds->index = index;
             // 🔧 [整合] <|im_start|>user\n 已在 sys prompt 末尾添加，后续轮次在 stream_decode 结束时添加

--- a/tools/omni/omni.h
+++ b/tools/omni/omni.h
@@ -41,6 +41,10 @@ struct omni_embeds{
     // vision_embed[1..n] = slice embeds (各 64 tokens * hidden_size)
     std::vector<std::vector<float>> vision_embed;
     std::vector<float> audio_embed;
+    // 用户文本片段（与 audio/image 同为一种 modality 的载体）。
+    // 非空时，LLM 线程会用 eval_string 将其作为 user-turn 的一部分投入 KV cache，
+    // 不会自动包裹任何 role/special token。
+    std::string user_text;
     int index = 0;
     int end_flag = false;
 };
@@ -435,7 +439,10 @@ bool stream_prefill(struct omni_context * ctx_omni,
                             std::string aud_fname,
                             std::string img_fname = "",
                             int index = 0,
-                            int max_slice_nums = -1);  // -1 表示使用全局设置，>=1 表示本次 prefill 的 slice 数量
+                            int max_slice_nums = -1,  // -1 表示使用全局设置，>=1 表示本次 prefill 的 slice 数量
+                            std::string text = "");   // 用户文本片段：与 audio/image 同为一种 modality，
+                                                     // 在 index>=1 的用户输入阶段插入到当前 user turn 中。
+                                                     // 不会自动包裹任何 role/special token —— 调用方完全控制其字面值。
 
 bool stream_decode(struct omni_context * ctx_omni,
                         std::string debug_dir,

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -5566,12 +5566,18 @@ int main(int argc, char ** argv) {
     // impl: prefill
     const auto handle_stream_prefill_impl = [&ctx_server, &read_stream_kv_cache_length, &res_ok, &res_error](const json & data, httplib::Response & res) -> void {
         // Expected body fields (aligned with test_case in minicpmo-cli.cpp):
-        //  audio_path_prefix: string (required)
-        //  img_path_prefix: string (optional, default "")
-        //  img_posfix: string (optional, default "")
-        //  cnt: integer (required)
-        if (!data.contains("audio_path_prefix") || !data.at("audio_path_prefix").is_string()) {
-            res_error(res, format_error_response("\"audio_path_prefix\" must be provided as string", ERROR_TYPE_INVALID_REQUEST));
+        //  audio_path_prefix: string (optional, default "")
+        //  img_path_prefix:   string (optional, default "")
+        //  img_posfix:        string (optional, default "")
+        //  text:              string (optional, default "")  ← 文本输入（turn-based 文字对话）
+        //  cnt:               integer (required)
+        // 至少需要 audio/img/text 之一非空，否则视为非法请求。
+        if (data.contains("audio_path_prefix") && !data.at("audio_path_prefix").is_string()) {
+            res_error(res, format_error_response("\"audio_path_prefix\" must be a string when present", ERROR_TYPE_INVALID_REQUEST));
+            return;
+        }
+        if (data.contains("text") && !data.at("text").is_string()) {
+            res_error(res, format_error_response("\"text\" must be a string when present", ERROR_TYPE_INVALID_REQUEST));
             return;
         }
         if (!data.contains("cnt") || !data.at("cnt").is_number_integer()) {
@@ -5587,13 +5593,21 @@ int main(int argc, char ** argv) {
             }
         }
 
-        const std::string audio_path_prefix = data.at("audio_path_prefix");
+        const std::string audio_path_prefix = data.value("audio_path_prefix", std::string(""));
         const std::string img_path_prefix   = data.value("img_path_prefix", "");
         const std::string img_posfix        = data.value("img_posfix", "");
+        const std::string text              = data.value("text", std::string(""));
         const int cnt                        = data.at("cnt");
         // 🔧 [高清+高刷] 可选参数：控制本次 prefill 的图片切片数量
         // -1 (默认) = 使用全局设置, 1 = 不切片, 2 = 高清模式切片
         const int max_slice_nums             = data.value("max_slice_nums", -1);
+
+        if (audio_path_prefix.empty() && img_path_prefix.empty() && text.empty()) {
+            res_error(res, format_error_response(
+                "at least one of \"audio_path_prefix\", \"img_path_prefix\", \"text\" must be non-empty",
+                ERROR_TYPE_INVALID_REQUEST));
+            return;
+        }
 
         bool ok = true;
 
@@ -5611,7 +5625,7 @@ int main(int argc, char ** argv) {
         // 同一线程会二次加锁，造成自死锁。
         {
             std::lock_guard<std::mutex> lock(ctx_server.octx_mutex);
-            if (!stream_prefill(ctx_server.octx, aud_fname, img_fname, cnt, max_slice_nums)) {
+            if (!stream_prefill(ctx_server.octx, aud_fname, img_fname, cnt, max_slice_nums, text)) {
                 ok = false;
                 // break;
             }
@@ -5625,9 +5639,9 @@ int main(int argc, char ** argv) {
 
         json ack = {
             {"success", true},
-            {"audio_path_prefix", data.at("audio_path_prefix")},
-            {"img_path_prefix", data.contains("img_path_prefix") ? data.at("img_path_prefix") : json("")},
-            {"img_posfix", data.contains("img_posfix") ? data.at("img_posfix") : json("")},
+            {"audio_path_prefix", audio_path_prefix},
+            {"img_path_prefix", img_path_prefix},
+            {"img_posfix", img_posfix},
             {"cnt", data.at("cnt")},
             {"kv_cache_length", read_stream_kv_cache_length()},
         };


### PR DESCRIPTION
## 表现

启用 C++ 后端跑 turn-based 模式，用**文字**（不是语音/图片）跟模型对话时，模型完全不看用户输入，回的内容跟问题无关 —— 像是从 system prompt + ref-audio 后随机续写。

最小复现脚本输入 "今天北京的天气怎么样？请只回答天气。"：

| | 修复前 | 修复后 |
|---|---|---|
| 模型回复 | 大段无关内容（"我会努力做到的，老板……" 之类） | "今天北京天气晴朗，气温适宜。" |
| `llama-server` 日志里有没有用户文本被 prefill | 没有（KV 里只有 system + ref-audio） | 看到用户文本 token 进入 KV |

只影响 **C++ 后端 + 文字输入**的组合：

- PyTorch 后端走 `processor.apply_chat_template`，文本本来就在 prompt 里，没有这个问题。
- C++ 后端的语音/图片输入走 `audio_path_prefix` / `img_path_prefix`，也没问题。

## 原因

C++ 这条链路上"文本"从来没被当成一种 modality 处理过。

历史上 `omni::stream_prefill` 和 `/v1/stream/prefill` API 是为流式音视频片段设计的，参数只有 `audio_path_prefix` / `img_path_prefix` / `cnt`，没有任何承载用户文本的字段。

到了 turn-based 文字对话场景，链路是：

```
前端 chat.send(text)
    ↓
worker.py /ws/chat
    ↓
CppBackendWorker.chat_prefill(msgs)        ← Python 适配层
    ↓
POST /v1/stream/prefill                     ← llama-server HTTP API
    ↓
omni::stream_prefill                        ← 把 prefix 路径里加载到的 audio/image
                                              embedding 塞进 omni_embeds 队列
    ↓
llm_thread_func 消费 omni_embeds            ← 对 vision_embed / audio_embed 调
                                              eval_tokens 写 KV cache
    ↓
stream_decode                               ← 接着生成
```

Python 适配层那一段（`cpp_backend.chat_prefill`）见到 user message 是纯字符串时直接 `continue` 跳过；HTTP API 也根本没有文本字段可传。所以**用户的文字从来没有走到 KV cache 里**。

LLM 线程拿到的就是一个纯空 user turn（只有 prompt 模板里那个 `<|im_start|>user\n` 头），decode 时模型就只能基于 system prompt + ref-audio embedding 自由发挥 —— 这就是"胡言乱语"。

## 修改概要

让"文本"成为和 audio / image 平级的第三种 modality，全链路打通。

### `llama.cpp-omni`（C++）

1. **`tools/omni/omni.h`**
   - `struct omni_embeds` 新增 `std::string user_text` 字段。
   - `stream_prefill(...)` 函数签名追加可选形参 `std::string text = ""`。

2. **`tools/omni/omni.cpp`**
   - `stream_prefill` 的 async producer 分支：`text` 非空时写入 `omni_embeds->user_text`。
   - `llm_thread_func` 增加一个分支：当 `vision_embed` / `audio_embed` 都空、`user_text` 非空时
     - 单工：直接 `eval_string(user_text)`（assistant prompt 末尾已经带 `<|im_start|>user\n`，不需要再包 modality 标记）。
     - 双工：先 `eval_string("<unit>")` 再 `eval_string(user_text)`，与音频路径对齐。
   - 滑动窗口 `unit_end` 的 `input_type` 增加 `"text"` 类型。

3. **`tools/server/server.cpp`** — `/v1/stream/prefill` handler
   - `audio_path_prefix` 由必填改为可选。
   - 新增可选 `text` 字段。
   - 三者全空返回 400。
   - 透传 `text` 到 `stream_prefill`。

### `MiniCPM-o-Demo`（Python）

`core/processors/cpp_backend.py`：

1. `chat_prefill` 不再把字符串内容 `continue` 掉；当 item 是 `str` 时调用 `_call_prefill("", "", cnt, text=item)`。
2. `_call_prefill` 新增可选 `text` 参数，非空时塞进 `/v1/stream/prefill` 请求体。

### 兼容性

- 所有现存调用点（warmup、cli、纯音频/图片场景）都用默认形参 `text=""`，行为完全不变。
- API 向后兼容：旧客户端不传 `text` 字段，行为也不变。
- C++ sync 路径（当前构建里 `ctx_omni->async` 恒为 true，是死代码）未触及。