### PR TITLE
omni: plumb session-level sampling knobs from Python to C++

### DIFF
--- a/tools/omni/omni.cpp
+++ b/tools/omni/omni.cpp
@@ -3686,7 +3686,7 @@ struct omni_context * omni_init(struct common_params * params, int media_type, b
         // 🔧 TTS流式采样参数 - 与 Python ras_sampling 对齐：
         // Python TTSSamplingParams 默认 temperature=0.8 (modeling_minicpmo.py line 75)
         common_params_sampling tts_sampling = params->sampling;
-        tts_sampling.temp = 0.8f;              // 🔧 [与 Python 对齐] TTSSamplingParams.temperature=0.8
+        tts_sampling.temp = ctx_omni->tts_temperature;  // [与 Python 对齐] TTSSamplingParams.temperature
         tts_sampling.top_p = 0.85f;  // 🔧 [与 Python 对齐] TTSSamplingParams.top_p=0.85             // 🔧 [与 Python streaming 对齐] top_p=0.8
         tts_sampling.top_k = 25;               // top_k = 25 (ras_sampling 参数)
         tts_sampling.penalty_repeat = 1.05f;   // repetition_penalty = 1.05
@@ -4740,7 +4740,7 @@ static bool generate_audio_tokens_local_simplex(
     // Create sampler - matching Python TTSStreamingGenerator
     // Python TTSSamplingParams 默认 temperature=0.8 (modeling_minicpmo.py line 75)
     common_params_sampling tts_sampling = params->sampling;
-    tts_sampling.temp = 0.8f;    // 🔧 [与 Python 对齐] TTSSamplingParams.temperature=0.8
+    tts_sampling.temp = ctx_omni->tts_temperature;  // [与 Python 对齐] TTSSamplingParams.temperature
     tts_sampling.top_p = 0.85f;  // 🔧 [与 Python 对齐] TTSSamplingParams.top_p=0.85   // 🔧 [与 Python streaming 对齐] top_p=0.8
     tts_sampling.top_k = 25;
     tts_sampling.penalty_repeat = 1.05f;
@@ -5174,7 +5174,7 @@ static bool generate_audio_tokens_local(
     // 🔧 TTS流式采样参数 - 与 Python TTSStreamingGenerator 对齐
     // Python TTSSamplingParams 默认 temperature=0.8 (modeling_minicpmo.py line 75)
     common_params_sampling tts_sampling = params->sampling;
-    tts_sampling.temp = 0.8f;              // 🔧 [与 Python 对齐] TTSSamplingParams.temperature=0.8
+    tts_sampling.temp = ctx_omni->tts_temperature;  // [与 Python 对齐] TTSSamplingParams.temperature
     tts_sampling.top_p = 0.85f;  // 🔧 [与 Python 对齐] TTSSamplingParams.top_p=0.85             // 🔧 [与 Python streaming 对齐] top_p=0.8
     tts_sampling.top_k = 25;               // top_k = 25
     tts_sampling.penalty_repeat = 1.05f;   // repetition_penalty = 1.05

--- a/tools/omni/omni.h
+++ b/tools/omni/omni.h
@@ -251,7 +251,11 @@ struct omni_context {
     // 每次 update_session_config 时重置 force_listen_used=0。
     int force_listen_count = 3;
     int force_listen_used  = 0;
-    
+
+    // TTS 采样温度（与 Python TTSSamplingParams.temperature 对齐，默认 0.8）
+    // 通过 /v1/stream/update_session_config 的 "tts_temperature" 字段透传
+    float tts_temperature = 0.8f;
+
     // 是否启用双工模式
     // simplex: 单工模式，用户说完后模型回复，回复完用户再说
     // duplex: 双工模式，模型可以在任意时刻决定听/说切换

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -6150,7 +6150,30 @@ int main(int argc, char ** argv) {
                     ctx_server.octx->high_refresh = new_high_refresh;
                 }
             }
-            
+
+            // [Python 透传] session-level sampling 旋钮，对齐 DuplexConfig
+            // 仅当请求显式提供时覆盖；省略时保留 omni_init 阶段的默认值。
+            if (data.contains("listen_prob_scale") && data.at("listen_prob_scale").is_number()) {
+                ctx_server.octx->listen_prob_scale = data.at("listen_prob_scale").get<float>();
+                SRV_INF("%s: listen_prob_scale set to %.4f\n", __func__,
+                        ctx_server.octx->listen_prob_scale);
+            }
+            if (data.contains("force_listen_count") && data.at("force_listen_count").is_number_integer()) {
+                ctx_server.octx->force_listen_count = data.at("force_listen_count").get<int>();
+                SRV_INF("%s: force_listen_count set to %d\n", __func__,
+                        ctx_server.octx->force_listen_count);
+            }
+            if (data.contains("max_new_speak_tokens_per_chunk") && data.at("max_new_speak_tokens_per_chunk").is_number_integer()) {
+                ctx_server.octx->max_new_speak_tokens_per_chunk = data.at("max_new_speak_tokens_per_chunk").get<int>();
+                SRV_INF("%s: max_new_speak_tokens_per_chunk set to %d\n", __func__,
+                        ctx_server.octx->max_new_speak_tokens_per_chunk);
+            }
+            if (data.contains("tts_temperature") && data.at("tts_temperature").is_number()) {
+                ctx_server.octx->tts_temperature = data.at("tts_temperature").get<float>();
+                SRV_INF("%s: tts_temperature set to %.4f\n", __func__,
+                        ctx_server.octx->tts_temperature);
+            }
+
             // 3. 清空 KV cache
             if (ctx_server.octx->ctx_llama) {
                 llama_memory_t mem = llama_get_memory(ctx_server.octx->ctx_llama);
@@ -6246,6 +6269,12 @@ int main(int argc, char ** argv) {
                 {"mode", ctx_server.octx->sliding_window_config.mode},
                 {"high_water_tokens", ctx_server.octx->sliding_window_config.high_water_tokens},
                 {"low_water_tokens", ctx_server.octx->sliding_window_config.low_water_tokens}
+            }},
+            {"sampling", {
+                {"listen_prob_scale", ctx_server.octx->listen_prob_scale},
+                {"force_listen_count", ctx_server.octx->force_listen_count},
+                {"max_new_speak_tokens_per_chunk", ctx_server.octx->max_new_speak_tokens_per_chunk},
+                {"tts_temperature", ctx_server.octx->tts_temperature},
             }},
             {"kv_cache_length", read_stream_kv_cache_length()},
         };


### PR DESCRIPTION
DuplexConfig 中的 listen_prob_scale / force_listen_count / max_new_speak_tokens_per_chunk / tts_temperature 之前在 cpp_backend 那一跳被丢弃，C++ 一直用启动时硬编码值，必须 rebuild 才能改。

本提交把这 4 个旋钮接到 /v1/stream/update_session_config：
  - omni.h: 新增 tts_temperature (默认 0.8)，与 Python TTSSamplingParams 对齐
  - omni.cpp: 3 处 TTS sampler 把硬编码 0.8f 换成 ctx_omni->tts_temperature
  - server.cpp: update_session_config 接 4 个字段，仅显式给出时覆盖；ack 增加 sampling 块回显当前值，便于上层验证

主 LLM sampler 的 temperature/top_p/top_k/repeat_penalty 仍保持启动时一次性 配置，因 sampler 在 llm_thread_func 启动时通过 common_sampler_init 创建并复用， runtime override 需要 sampler rebuild 机制，留作 follow-up。

Made-with: Cursor



--------------



# C++ backend sampling 参数透传

## 1. 背景

部分参数没有透传

**Pytorch backend** 走 `worker.py → utils.py → MiniCPMOWorker`，
能把 `DuplexConfig` / `GenerationConfig` 全字段送进推理；**C++ backend** 走 `worker.py → cpp_backend.py → llama-server`，
只下推 `media_type / duplex_mode / voice_clone_prompt / assistant_prompt / voice_audio / sliding_window_* / highImage / highRefresh` 这些「拓扑/会话级」字段
和 per-decode 的 `length_penalty`、per-prefill 的 `text` / `max_slice_nums`。
其它 sampling 旋钮（`listen_prob_scale`、`force_listen_count`、`max_new_speak_tokens_per_chunk`、`tts_temperature` 等）
要么被 `worker.py` 在 chat / half-duplex 入口处 ignore 掉、要么在 `cpp_backend.py` 这一跳被 drop 掉，
最后撞上 `llama-server` 启动时一次性 hardcode 的默认值。

本次修复目标：把可以"零结构改动"接入的 4 个 session-level 旋钮端到端打通，
让前端 / gateway 调一次 `update_session_config` 就能改 C++ 层的行为，无需 rebuild。

## 2. 改动总览

```
llama.cpp-omni  : 1 file +1 字段, 3 处 TTS sampler 解硬编码, 1 个 setter, 1 个 ack 字段
MiniCPM-o-Demo  : 2 files,  +helper, 5 个 call site 接 sampling kwarg
                  + scripts/verify_cpp_sampling_passthrough.py 验证脚本
```

涉及文件：

```
llama.cpp-omni-wt-cpp-sampling-params-all-modes/
  tools/omni/omni.h                       (+5)
  tools/omni/omni.cpp                     (3 处 TTS temp 解硬编码)
  tools/server/server.cpp                 (+25)  update_session_config setter + ack echo

MiniCPM-o-Demo-wt-cpp-sampling-params-all-modes/
  core/processors/cpp_backend.py          (+~60) 透传 helper + sampling kwarg
  worker.py                               (+~35) helper + 3 个 WS handler 抽参
  scripts/verify_cpp_sampling_passthrough.py    (新增) 端到端验证
```

## 3. C++ 层

### 3.1 `omni.h` — 新增字段

```cpp
// TTS 采样温度（与 Python TTSSamplingParams.temperature 对齐，默认 0.8）
// 通过 /v1/stream/update_session_config 的 "tts_temperature" 字段透传
float tts_temperature = 0.8f;
```

`listen_prob_scale`、`force_listen_count`、`max_new_speak_tokens_per_chunk` 在 `omni_context` 早就存在
（早期 PR 留的接口），但 **从未被任何 HTTP handler 写入**，所以一直保持默认值。

### 3.2 `omni.cpp` — TTS sampler 解硬编码

3 处 TTS sampler 初始化点（`llm_thread_func` 里 1 处、`generate_audio_tokens_local_simplex` 里 2 处）原本是

```cpp
tts_sampling.temp = 0.8f;
```

改为

```cpp
tts_sampling.temp = ctx_omni->tts_temperature;
```

其它 TTS sampling 字段（`top_p=0.85, top_k=25, penalty_repeat=1.05, min_p=0.01, penalty_last_n=16`）
保留硬编码，因为 `TTSSamplingParams` Python schema 也只暴露 `temperature` 这一个旋钮给上层。

### 3.3 `server.cpp` — `/v1/stream/update_session_config` 加 setter + ack

setter（落到 `octx`，仅当请求显式提供时才覆盖，省略沿用 omni_init 默认值）：

```cpp
if (data.contains("listen_prob_scale") && data.at("listen_prob_scale").is_number()) {
    ctx_server.octx->listen_prob_scale = data.at("listen_prob_scale").get<float>();
}
if (data.contains("force_listen_count") && data.at("force_listen_count").is_number_integer()) {
    ctx_server.octx->force_listen_count = data.at("force_listen_count").get<int>();
}
if (data.contains("max_new_speak_tokens_per_chunk") && data.at("max_new_speak_tokens_per_chunk").is_number_integer()) {
    ctx_server.octx->max_new_speak_tokens_per_chunk = data.at("max_new_speak_tokens_per_chunk").get<int>();
}
if (data.contains("tts_temperature") && data.at("tts_temperature").is_number()) {
    ctx_server.octx->tts_temperature = data.at("tts_temperature").get<float>();
}
```

ack 增加 `sampling` 块，便于上层校验：

```cpp
{"sampling", {
    {"listen_prob_scale", ctx_server.octx->listen_prob_scale},
    {"force_listen_count", ctx_server.octx->force_listen_count},
    {"max_new_speak_tokens_per_chunk", ctx_server.octx->max_new_speak_tokens_per_chunk},
    {"tts_temperature", ctx_server.octx->tts_temperature},
}},
```

注意 `force_listen_used` 在原 handler 里被无条件重置为 0，所以新设置的 `force_listen_count` 在
**当下这次** `update_session_config` 之后就立即生效（下一次 `stream_decode` 会按新阈值进入开局强制 LISTEN 期）。

## 4. Python 层

### 4.1 `cpp_backend.py`

新增模块级常量 + helper：

```python
_CPP_SAMPLING_KEYS = (
    "listen_prob_scale",
    "force_listen_count",
    "max_new_speak_tokens_per_chunk",
    "tts_temperature",
)

def _sampling_from_duplex_config(cfg) -> Dict[str, Any]:
    """从 DuplexConfig（pydantic / dict / None）抽出 C++ 能用的 sampling 字段。"""
def _sampling_from_generation(gen) -> Dict[str, Any]:
    """从 GenerationConfig 抽出 C++ 能用的字段（当前只 tts_temperature）。"""
```

`_call_update_session_config` 增加 `sampling: Optional[Dict]` 形参，
仅在显式给出时才注入到 `req_body`，与 C++ 侧的 contract 一致：

```python
if sampling:
    for key in _CPP_SAMPLING_KEYS:
        if key in sampling and sampling[key] is not None:
            req_body[key] = sampling[key]
```

3 个面向上层的入口接 `sampling` kwarg 并往下传：
- `duplex_prepare(...)` — 全双工
- `reset_half_duplex_session(...)` — 半双工
- `chat_prefill(...)` — 轮次 chat
- 另外 `chat()`（非流式）已经持有 `request.generation`，直接用 `_sampling_from_generation()` 抽。

### 4.2 `worker.py`

加同名 helper（避免 PyTorch 路径上 import `cpp_backend` 触发 llama-server 启动副作用）：

```python
_CPP_SAMPLING_KEYS = (...)

def _build_cpp_sampling(cfg: Optional[Dict]) -> Dict:
    """从前端 config dict 抽出 C++ backend 能识别的 sampling 字段。"""
```

3 个 WS handler 入口都接上：

| 入口 | 数据源 | 透传调用 |
|---|---|---|
| `/ws/chat` | `msg.get("generation", {})` | `worker.chat_prefill(..., sampling=chat_sampling or None)` |
| `/ws/half-duplex` | `config.get("generation", {})` | `worker.reset_half_duplex_session(..., sampling=hd_sampling or None)` |
| `/ws/half-duplex-omni` | `config.get("generation", {})` | `worker.reset_half_duplex_session(..., sampling=hdomni_sampling or None)` |
| `/ws/duplex` | `msg.get("config")`（DuplexConfig 序列化形式） | `worker.duplex_prepare(..., sampling=duplex_sampling or None)` |

`MiniCPMOWorker`（PyTorch backend）的对应方法签名同步加 `sampling` kwarg 但标 `noqa: ARG002` 不消费，
保持 PyTorch 路径行为不变（PyTorch 的 `DuplexConfig` 已经全字段透传走 `duplex_view.config`）。

## 5. 验证

`scripts/verify_cpp_sampling_passthrough.py` 直接打 llama-server，
传 4 个非默认值（特意取 `1.7 / 7 / 64 / 0.55` 与 C++ 默认 `1.0 / 3 / 26 / 0.8` 区分），
校验 ack 中 `sampling` 块与请求一致：

```
$ python scripts/verify_cpp_sampling_passthrough.py
[ack.sampling] {"listen_prob_scale": 1.7, "force_listen_count": 7,
                "max_new_speak_tokens_per_chunk": 64, "tts_temperature": 0.55}
[PASS] all 4 sampling fields round-tripped via /v1/stream/update_session_config
```

另外做了一组连续两次 `update_session_config` 的回归测试，确认：

- 仅指定 `listen_prob_scale` + `force_listen_count` 时，`max_new_speak_tokens_per_chunk` 与 `tts_temperature`
  保持上一次的值（`99 / 0.42`），符合"explicit override only"语义；
- 浮点精度按 `float32` 存储，`0.55 → 0.5500000119...`，调用方按 `abs(diff) < 1e-3` 比较即可。

## 6. 端到端对齐情况（修后）

| 字段 | Schema 来源 | PyTorch backend | C++ backend (本 PR 前) | C++ backend (本 PR 后) |
|---|---|---|---|---|
| `listen_prob_scale` | DuplexConfig | ✅ | ❌（hardcoded 1.0）| ✅ |
| `force_listen_count` | DuplexConfig | ✅ | ❌（hardcoded 3）| ✅ |
| `max_new_speak_tokens_per_chunk` | DuplexConfig | ✅ | ❌（hardcoded 26）| ✅ |
| `tts_temperature` | DuplexConfig | ✅ | ❌（3 处 hardcoded 0.8）| ✅ |
| `length_penalty` | DuplexConfig / GenerationConfig | ✅ | ✅（per-decode）| ✅（unchanged）|
| `temperature` | DuplexConfig / GenerationConfig | ✅ | ❌（`--temp` 启动参数）| ❌ — see §7 |
| `top_p` | DuplexConfig / GenerationConfig | ✅ | ❌ | ❌ — see §7 |
| `top_k` | DuplexConfig / GenerationConfig | ✅ | ❌ | ❌ — see §7 |
| `text_repetition_penalty` | DuplexConfig | ✅ | ❌ | ❌ — see §7 |
| `text_repetition_window_size` | DuplexConfig | ✅ | ❌ | ❌ — see §7 |
| `decode_mode` (sampling/greedy) | DuplexConfig | ✅ | ❌ | ❌ — see §7 |
| `listen_top_k` | DuplexConfig | ✅ | ❌ | ❌ — see §7 |
| `max_new_tokens` | GenerationConfig | ✅ | ❌（C++ chat decode 无 token 上限）| ❌ — see §7 |

## 7. 已知 follow-up（不在本 PR 范围）

下面这组想要 runtime 透传，需要更深的结构改动：

### 7.1 主 LLM sampler 的 `temperature / top_p / top_k / repeat_penalty`

C++ 侧主 LLM sampler 是在 `llm_thread_func` 启动时通过 `common_sampler_init(model, params->sampling)`
**一次性创建** 的（`omni.cpp:3646`），整个进程生命周期内复用。要支持运行时改 `temp/top_p/top_k/penalty_repeat`，
干净的做法是：

1. 在 `octx` 加一个 `std::atomic<bool> sampler_dirty{false};`
2. `update_session_config` 写入 `params->sampling.*` 后 `sampler_dirty.store(true)`
3. `llm_thread_func` 主循环每次 dequeue `omni_embeds` 后检查 dirty 标志，
   `common_sampler_free(sampler)` + `sampler = common_sampler_init(...)`，清 dirty

工作量约半天，需要谨慎处理 sampler 重建期间的并发与 KV cache 一致性。

### 7.2 `text_repetition_penalty` / `text_repetition_window_size`

llama.cpp 的 `common_sampler_chain` 已有 `dry`/`penalty` 链，挪用即可，但同样依赖 §7.1 的 sampler rebuild。

### 7.3 `decode_mode` (sampling / greedy)

= `temp = 0.0f`，归到 §7.1。

### 7.4 `listen_top_k`

只在 `<|listen|>` 这一 logits position 单独应用 top-k 截断，与全局 top_k 不是一回事。
要在 `sample_with_hidden_and_token`（`omni.cpp:1040+`）里手写一层 partial sort，~30 行。
不依赖 §7.1，独立小 PR 就能做。

### 7.5 chat 模式 `max_new_tokens` 真上限

C++ `stream_decode` 在 `duplex_mode=false` 时 `max_chunk_tokens = 0`（无限制），
完全依赖 EOS token 终止。要把 GenerationConfig 的 `max_new_tokens` 真做成轮次上限，
需要在 chat 的外层 decode loop 里加一个 `total_tokens_generated >= chat_max_new_tokens` 的早停分支。
影响面比 §7.1 小，独立小 PR 即可，需要确认与现有 `current_chunk_tokens` 计数语义不冲突。

### 7.6 schema 对齐

`GenerationConfig` 当前没有 `tts_temperature` 字段，前端无法在 chat / half-duplex 入口指定 TTS 温度
（虽然 plumbing 已就绪，`_sampling_from_generation` 有读 `tts_temperature` 的分支）。
后续给 `GenerationConfig` 加 `tts_temperature: Optional[float] = None` 即可启用。
