### PR TITLE
server: 修复 ctx_shift 关闭时上下文溢出未置 truncated 标志

### DIFF
--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -2870,10 +2870,12 @@ struct server_context {
 
         // if context shifting is disabled, make sure that we don't run out of context
         if (!params_base.ctx_shift && slot.n_past + 1 >= slot.n_ctx) {
+            slot.truncated      = true;
             slot.stop           = STOP_TYPE_LIMIT;
             slot.has_next_token = false;
 
-            SLT_DBG(slot, "stopped due to running out of context, n_past = %d, n_ctx = %d\n", slot.n_past, slot.n_ctx);
+            SLT_DBG(slot, "stopped due to running out of context capacity, n_past = %d, n_prompt_tokens = %d, n_decoded = %d, n_ctx = %d\n",
+                    slot.n_decoded, slot.n_prompt_tokens(), slot.n_past, slot.n_ctx);
         }
 
         // check the limits

--- a/tools/server/tests/unit/test_ctx_shift.py
+++ b/tools/server/tests/unit/test_ctx_shift.py
@@ -45,7 +45,7 @@ def test_ctx_shift_enabled():
 
 @pytest.mark.parametrize("n_predict,n_token_output,truncated", [
     (64, 64, False),
-    (-1, 120, True),
+    (-1, 248, True), # 8 tokens prompt + 248 tokens generated = 256 tokens total
 ])
 def test_ctx_shift_disabled_short_prompt(n_predict: int, n_token_output: int, truncated: bool):
     global server


### PR DESCRIPTION
## 背景

`tools/server/tests/unit/test_ctx_shift.py::test_ctx_shift_disabled_short_prompt[-1-120-True]` 在 master 上已经红了约 3 个月（自 2026-02-03 起每次 Server 工作流都 fail），典型报错：

```
FAILED unit/test_ctx_shift.py::test_ctx_shift_disabled_short_prompt[-1-120-True] - assert 248 == 120
```

参考 master 最近一次 Server run [`24709580847`](https://github.com/tc-mb/llama.cpp-omni/actions/runs/24709580847)。

## 根因

上游 llama.cpp PR [#16812](https://github.com/ggerganov/llama.cpp/pull/16812) (`ggerganov/llama.cpp@85a7d867`, "memory : remove KV cache size padding") 做了两处联动改动：test 期望 `predicted_n` 从 `120` 改为 `248`；`server.cpp` 在 `!ctx_shift && n_past+1 >= n_ctx` 早停分支里补上 `slot.truncated = true`。

本 fork 之前 sync 时只部分跟进：
- `server.cpp`：早停会在 248 token 触发（和上游一致），但**没有**置 `truncated=true`
- `test_ctx_shift.py`：期望值被留在了 `120`（既不匹配上游也不匹配本 fork 的实际行为）

所以 CI 观察到 `predicted_n=248` vs 期望 `120` 的 assert 失败。

## 改动

两处改动均与上游 `85a7d867` 逐字对齐，合计 +4 / -2：

1. `tools/server/server.cpp`：在 `!ctx_shift && n_past+1 >= n_ctx` 早停分支补 `slot.truncated = true`，并同步调试日志措辞。
2. `tools/server/tests/unit/test_ctx_shift.py`：`(-1, 120, True)` → `(-1, 248, True)`，附上游注释。

## 验证

在本分支 (`cmake -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DCMAKE_BUILD_TYPE=Release -DGGML_CUDA=OFF`) 本地重建 `llama-server` 后：

- [x] `unit/test_ctx_shift.py` → **5 passed**（原来红的 `[-1-120-True]` 现在以 `[-1-248-True]` 形式绿）
- [x] `unit/test_completion.py::test_completion{,_stream}` → **4 passed**（邻近会检查 `truncated` 的用例，确认 `truncated=False` 路径未回归）

## 说明

- 影响面极小：只在 `!ctx_shift && n_past+1 >= n_ctx` 这一条早停分支多置一个 bool，不会把任何原来 `truncated=False` 的路径翻 `True`。
- 不影响 #25（token2wav 优化），那个 PR 只动 `ggml/` 和 `tools/omni/`。
- `server-windows` job 的 `tar.exe: Unrecognized archive format` 错误是 master 上长期存在的 Actions 环境问题（libcurl.zip 下载损坏），不在本 PR 范围。

---

🤖 Made with [Cursor](https://cursor.com)
