### PR TITLE
perf: Metal per-backend queue + batched Conv1d — duplex 2x speedup

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-context.m
+++ b/ggml/src/ggml-metal/ggml-metal-context.m
@@ -99,7 +99,9 @@ ggml_metal_t ggml_metal_init(ggml_metal_device_t dev) {
     // TODO: would it be better to have one queue for the backend and one queue for the device?
     //       the graph encoders and async ops would use the backend queue while the sync ops would use the device queue?
     //res->queue = [device newCommandQueue]; [TAG_QUEUE_PER_BACKEND]
-    res->queue = ggml_metal_device_get_queue(dev);
+    // res->queue = ggml_metal_device_get_queue(dev);
+    // prototype for Metal queue per backend
+    res->queue = [res->device newCommandQueue];
     if (res->queue == nil) {
         GGML_LOG_ERROR("%s: error: failed to create command queue\n", __func__);
         return NULL;
@@ -209,6 +211,7 @@ void ggml_metal_free(ggml_metal_t ctx) {
     Block_release(ctx->encode_async);
 
     //[ctx->queue release]; // [TAG_QUEUE_PER_BACKEND]
+    [ctx->queue release];
 
     dispatch_release(ctx->d_queue);
 
@@ -514,13 +517,9 @@ enum ggml_status ggml_metal_graph_compute(ggml_metal_t ctx, struct ggml_cgraph *
 }
 
 void ggml_metal_graph_optimize(ggml_metal_t ctx, struct ggml_cgraph * gf) {
-    //const int64_t t_start = ggml_time_us();
-
     if (ctx->use_graph_optimize) {
         ggml_graph_optimize(gf);
     }
-
-    //printf("%s: graph optimize took %.3f ms\n", __func__, (ggml_time_us() - t_start) / 1000.0);
 }
 
 void ggml_metal_set_n_cb(ggml_metal_t ctx, int n_cb) {

--- a/tools/omni/omni.cpp
+++ b/tools/omni/omni.cpp
@@ -8389,6 +8389,7 @@ void t2w_thread_func_cpp(struct omni_context * ctx_omni, common_params *params) 
         
         // Wait for queue to have data or thread to stop
         cv.wait(lock, [&] { return !queue.empty() || !t2w_thread_running || ctx_omni->break_event.load(); });
+        auto dequeue_time = std::chrono::steady_clock::now();
         
         if (!t2w_thread_running && queue.empty()) {
             break;
@@ -8406,9 +8407,15 @@ void t2w_thread_func_cpp(struct omni_context * ctx_omni, common_params *params) 
         bool is_chunk_end = false;  // 标记 TTS chunk 结束
         int received_round_idx = -1;  // 🔧 保存传入的 round_idx
         
+        std::chrono::steady_clock::time_point oldest_enqueue_time = dequeue_time;
+        bool have_enqueue_time = false;
         while (!queue.empty()) {
             T2WOut *t2w_out = queue.front();
             queue.pop();
+            if (!have_enqueue_time || t2w_out->enqueue_time < oldest_enqueue_time) {
+                oldest_enqueue_time = t2w_out->enqueue_time;
+                have_enqueue_time = true;
+            }
             
             new_tokens.insert(new_tokens.end(), t2w_out->audio_tokens.begin(), t2w_out->audio_tokens.end());
             is_final = is_final || t2w_out->is_final;  // 任何一个是 final 就是 final
@@ -8457,6 +8464,9 @@ void t2w_thread_func_cpp(struct omni_context * ctx_omni, common_params *params) 
         // Add new tokens to buffer
         size_t buffer_before = token_buffer.size();
         token_buffer.insert(token_buffer.end(), new_tokens.begin(), new_tokens.end());
+        const double queue_wait_ms = have_enqueue_time
+            ? std::chrono::duration<double, std::milli>(dequeue_time - oldest_enqueue_time).count()
+            : 0.0;
         
         // 🔧 [DEBUG] 打印收到的 token IDs (只打印前10个和后3个)
         if (new_tokens.size() > 0) {
@@ -8557,8 +8567,8 @@ void t2w_thread_func_cpp(struct omni_context * ctx_omni, common_params *params) 
                         if (wav_idx == 0) {
                             print_with_timestamp("🎉 首响时间 (First Audio Response): %lldms\n", (long long)elapsed_ms);
                         }
-                        print_with_timestamp("T2W线程: wav_%d.wav | %.2fs audio | %.1fms inference | RTF=%.2f | t=%lldms\n",
-                                            ctx_omni->wav_turn_base + wav_idx, audio_duration, t2w_ms, rtf, (long long)elapsed_ms);
+                        print_with_timestamp("T2W线程: wav_%d.wav | %.2fs audio | %.1fms inference | RTF=%.2f | t=%lldms | queue_wait=%.1fms\n",
+                                            ctx_omni->wav_turn_base + wav_idx, audio_duration, t2w_ms, rtf, (long long)elapsed_ms, queue_wait_ms);
                         wav_idx++;
                     }
                 }

--- a/tools/omni/omni.h
+++ b/tools/omni/omni.h
@@ -61,6 +61,7 @@ struct T2WOut {
     bool is_final = false;  // Whether this is the final chunk (turn end)
     bool is_chunk_end = false;  // Whether this is the end of a TTS chunk (flush buffer, but not final)
     int round_idx = -1;  // 🔧 [修复目录同步] 轮次索引，由 TTS 线程设置，T2W 线程使用此值确定输出目录
+    std::chrono::steady_clock::time_point enqueue_time = std::chrono::steady_clock::now();
 };
 
 struct T2WThreadInfo {

--- a/tools/omni/test/test-duplex.cpp
+++ b/tools/omni/test/test-duplex.cpp
@@ -244,7 +244,7 @@ static void show_usage(const char * prog_name) {
         "  --no-tts            禁用 TTS\n"
         "  --omni              启用 omni 模式 (audio+vision, media_type=2)\n"
         "  --test <prefix> <n> 指定测试数据前缀和 chunk 数量\n"
-       "  -o <dir>            输出目录 (默认: ./tools/omni/output)\n"
+        "  -o <dir>            输出目录 (默认: ./tools/omni/output)\n"
         "  -h, --help          显示帮助\n\n"
         "Example:\n"
         "  %s -m ./models/MiniCPM-o-4_5-gguf/MiniCPM-o-4_5-Q4_K_M.gguf \\\n"
@@ -369,7 +369,7 @@ int main(int argc, char ** argv) {
     std::string tts_bin_dir = get_parent_dir(paths.tts);
 
     common_init();
-    
+
     printf("=== Initializing Duplex Omni Context ===\n");
     printf("  Media type: %d (%s)\n", media_type, media_type == 2 ? "omni: audio+vision" : "audio only");
     printf("  TTS enabled: %s\n", use_tts ? "yes" : "no");

--- a/tools/omni/test/test-duplex.cpp
+++ b/tools/omni/test/test-duplex.cpp
@@ -244,7 +244,7 @@ static void show_usage(const char * prog_name) {
         "  --no-tts            禁用 TTS\n"
         "  --omni              启用 omni 模式 (audio+vision, media_type=2)\n"
         "  --test <prefix> <n> 指定测试数据前缀和 chunk 数量\n"
-        "  -o <dir>            输出目录 (默认: ./tools/omni/output)\n"
+       "  -o <dir>            输出目录 (默认: ./tools/omni/output)\n"
         "  -h, --help          显示帮助\n\n"
         "Example:\n"
         "  %s -m ./models/MiniCPM-o-4_5-gguf/MiniCPM-o-4_5-Q4_K_M.gguf \\\n"
@@ -272,6 +272,10 @@ int main(int argc, char ** argv) {
     bool run_test = false;
     std::string test_prefix;
     int test_count = 0;
+    std::string token2wav_device = "gpu";
+    if (const char * v = std::getenv("OMNI_T2W_DEVICE")) {
+        if (*v) token2wav_device = v;
+    }
 
     for (int i = 1; i < argc; i++) {
         std::string arg = argv[i];
@@ -353,10 +357,19 @@ int main(int argc, char ** argv) {
     params.n_ctx = n_ctx;
     params.n_gpu_layers = n_gpu_layers;
 
+    // 🔧 [bit-exact A/B] 固定 LLM / TTS 采样种子，配合 token2wav 中已有的 mt19937(42)
+    // 让两次独立进程产生完全相同的输出（A/B 对比可用 md5 验证）
+    {
+        const char * seed_env = std::getenv("OMNI_SAMPLER_SEED");
+        uint32_t     seed     = seed_env ? (uint32_t) std::strtoul(seed_env, nullptr, 10) : 42u;
+        params.sampling.seed  = seed;
+        printf("  Sampler seed: %u (env OMNI_SAMPLER_SEED to override)\n", seed);
+    }
+
     std::string tts_bin_dir = get_parent_dir(paths.tts);
 
     common_init();
-
+    
     printf("=== Initializing Duplex Omni Context ===\n");
     printf("  Media type: %d (%s)\n", media_type, media_type == 2 ? "omni: audio+vision" : "audio only");
     printf("  TTS enabled: %s\n", use_tts ? "yes" : "no");
@@ -364,11 +377,12 @@ int main(int argc, char ** argv) {
     printf("  GPU layers: %d\n", n_gpu_layers);
     printf("  Output dir: %s\n", output_dir.c_str());
     printf("  Ref audio: %s\n", ref_audio_path.c_str());
+    printf("  Token2Wav device: %s\n", token2wav_device.c_str());
     printf("  Mode: DUPLEX\n");
 
     // 关键: duplex_mode=true
     auto ctx_omni = omni_init(&params, media_type, use_tts, tts_bin_dir,
-                              /*tts_gpu_layers=*/-1, /*token2wav_device=*/"cpu",
+                              /*tts_gpu_layers=*/-1, /*token2wav_device=*/token2wav_device,
                               /*duplex_mode=*/true,
                               /*existing_model=*/nullptr, /*existing_ctx=*/nullptr,
                               /*base_output_dir=*/output_dir);

--- a/tools/omni/token2wav/token2wav-example.cpp
+++ b/tools/omni/token2wav/token2wav-example.cpp
@@ -106,7 +106,7 @@ int main() {
         const char * v = std::getenv(name);
         return (v && *v) ? std::string(v) : def;
     };
-    
+
     std::string model_dir      = env_or("OMNI_T2W_MODEL_DIR", "./tools/omni/convert/gguf/token2wav-gguf");
     std::string encoder_gguf       = model_dir + "/encoder.gguf";
     std::string flow_matching_gguf = model_dir + "/flow_matching.gguf";

--- a/tools/omni/token2wav/token2wav-example.cpp
+++ b/tools/omni/token2wav/token2wav-example.cpp
@@ -98,14 +98,15 @@ int main() {
 
     // 默认路径，根据5个gguf和两个输出位置改动；可用环境变量覆盖，便于做纯 T2W profile。
     //   OMNI_T2W_MODEL_DIR  : token2wav-gguf 目录（内含 encoder/flow_*/hifigan2/prompt_cache）
-    //   OMNI_T2W_DEVICE     : "cpu" / "gpu" / "gpu:<idx>"（对 token2mel 和 vocoder 同时生效）
+    //   OMNI_T2W_DEVICE     : "cpu" / "gpu" / "gpu:<idx>"（token2mel 设备）
+    //   OMNI_VOC_DEVICE : 可选，覆盖 vocoder 设备；macOS 默认走 CPU，避免 Metal vocoder 慢路径
     //   OMNI_T2W_OUT_WAV    : 合并输出 WAV 路径
     //   OMNI_T2W_OUT_CHUNK_DIR : 每个 callback chunk 的输出目录（空串 = 不落盘）
     auto env_or = [](const char * name, const std::string & def) {
         const char * v = std::getenv(name);
         return (v && *v) ? std::string(v) : def;
     };
-
+    
     std::string model_dir      = env_or("OMNI_T2W_MODEL_DIR", "./tools/omni/convert/gguf/token2wav-gguf");
     std::string encoder_gguf       = model_dir + "/encoder.gguf";
     std::string flow_matching_gguf = model_dir + "/flow_matching.gguf";
@@ -117,7 +118,11 @@ int main() {
     std::string out_chunk_wav_dir  = env_or("OMNI_T2W_OUT_CHUNK_DIR", "/tmp/token2wav_example_chunks");
 
     std::string device_token2mel   = env_or("OMNI_T2W_DEVICE", "gpu");
-    std::string device_vocoder     = env_or("OMNI_T2W_DEVICE", "gpu");
+#if defined(__APPLE__)
+    std::string device_vocoder     = env_or("OMNI_VOC_DEVICE", "cpu");
+#else
+    std::string device_vocoder     = env_or("OMNI_VOC_DEVICE", device_token2mel);
+#endif
 
     int       n_timesteps = std::atoi(env_or("OMNI_T2W_N_TIMESTEPS", "5").c_str());
     float     temperature = 1.0f;

--- a/tools/omni/token2wav/token2wav-impl.cpp
+++ b/tools/omni/token2wav/token2wav-impl.cpp
@@ -1032,8 +1032,8 @@ ggml_tensor * fmCausalConv1d::build_forward_graph(ggml_context * ctx, ggml_tenso
     if (ctx == nullptr || x == nullptr) {
         return nullptr;
     }
-    const int64_t Cin = x->ne[0];
-    const int64_t B   = x->ne[2];
+    const int64_t T     = x->ne[1];
+    const int64_t B     = x->ne[2];
     const int64_t K     = weight_->ne[0];
     const int64_t Cin_w = weight_->ne[1];
     const int64_t Cout  = weight_->ne[2];
@@ -1041,20 +1041,11 @@ ggml_tensor * fmCausalConv1d::build_forward_graph(ggml_context * ctx, ggml_tenso
     x_tcb               = ggml_cont(ctx, x_tcb);
     const int     pad_left = static_cast<int>(K - 1);
     ggml_tensor * x_pad    = ggml_pad_ext(ctx, x_tcb, pad_left, 0, 0, 0, 0, 0, 0, 0);
-    ggml_tensor * y_tcb = nullptr;
-    for (int64_t b_idx = 0; b_idx < B; ++b_idx) {
-        const size_t  offset = x_pad->nb[2] * static_cast<size_t>(b_idx);
-        ggml_tensor * x_pad_b =
-            ggml_view_3d(ctx, x_pad, x_pad->ne[0], x_pad->ne[1], 1, x_pad->nb[1], x_pad->nb[2], offset);
-        ggml_tensor * y_tcb_b = fm_causal_conv1d_im2col_f32_n1(ctx, weight_, x_pad_b, 1, 0, 1);
-        if (y_tcb == nullptr) {
-            y_tcb = y_tcb_b;
-        } else {
-            y_tcb = ggml_concat(ctx, y_tcb, y_tcb_b, 2);
-        }
-    }
-    ggml_tensor * y = ggml_permute(ctx, y_tcb, 1, 0, 2, 3);
-    y               = ggml_cont(ctx, y);
+    ggml_tensor * col = ggml_im2col(ctx, weight_, x_pad, 1, 0, 0, 0, 1, 0, false, GGML_TYPE_F32);
+    ggml_tensor * col_2d = ggml_reshape_2d(ctx, col, K * Cin_w, T * B);
+    ggml_tensor * w_2d = ggml_reshape_2d(ctx, weight_, K * Cin_w, Cout);
+    ggml_tensor * mm = ggml_mul_mat(ctx, w_2d, col_2d);
+    ggml_tensor * y = ggml_reshape_3d(ctx, mm, Cout, T, B);
     if (bias_ != nullptr) {
         ggml_tensor * bias_broadcast = ggml_reshape_3d(ctx, bias_, Cout, 1, 1);
         y                            = ggml_add(ctx, y, bias_broadcast);
@@ -1069,13 +1060,13 @@ ggml_tensor * fmCausalConv1d::build_forward_chunk_graph(ggml_context * ctx,
     if (ctx == nullptr || x == nullptr) {
         return nullptr;
     }
-    const int64_t Cin = x->ne[0];
-    const int64_t dt  = x->ne[1];
-    const int64_t B   = x->ne[2];
+    const int64_t Cin   = x->ne[0];
+    const int64_t dt    = x->ne[1];
+    const int64_t B     = x->ne[2];
     const int64_t K     = weight_->ne[0];
     const int64_t Cin_w = weight_->ne[1];
     const int64_t Cout  = weight_->ne[2];
-    const int64_t pad = kernel_size_ - 1;
+    const int64_t pad   = kernel_size_ - 1;
     ggml_tensor * cache_in = cnn_cache;
     if (cache_in == nullptr) {
         ggml_tensor * zero_x = ggml_scale(ctx, x, 0.0f);
@@ -1093,21 +1084,11 @@ ggml_tensor * fmCausalConv1d::build_forward_chunk_graph(ggml_context * ctx,
     ggml_tensor * x_tcb = ggml_permute(ctx, x, 1, 0, 2, 3);
     x_tcb               = ggml_cont(ctx, x_tcb);
     ggml_tensor * x_cat_tcb = ggml_concat(ctx, cache_tcb, x_tcb, 0);
-    x_cat_tcb               = ggml_cont(ctx, x_cat_tcb);
-    ggml_tensor * y_tcb = nullptr;
-    for (int64_t b_idx = 0; b_idx < B; ++b_idx) {
-        const size_t  offset  = x_cat_tcb->nb[2] * static_cast<size_t>(b_idx);
-        ggml_tensor * x_cat_b = ggml_view_3d(ctx, x_cat_tcb, x_cat_tcb->ne[0], x_cat_tcb->ne[1], 1, x_cat_tcb->nb[1],
-                                             x_cat_tcb->nb[2], offset);
-        ggml_tensor * y_tcb_b = fm_causal_conv1d_im2col_f32_n1(ctx, weight_, x_cat_b, 1, 0, 1);
-        if (y_tcb == nullptr) {
-            y_tcb = y_tcb_b;
-        } else {
-            y_tcb = ggml_concat(ctx, y_tcb, y_tcb_b, 2);
-        }
-    }
-    ggml_tensor * y = ggml_permute(ctx, y_tcb, 1, 0, 2, 3);
-    y               = ggml_cont(ctx, y);
+    ggml_tensor * col = ggml_im2col(ctx, weight_, x_cat_tcb, 1, 0, 0, 0, 1, 0, false, GGML_TYPE_F32);
+    ggml_tensor * col_2d = ggml_reshape_2d(ctx, col, K * Cin_w, dt * B);
+    ggml_tensor * w_2d = ggml_reshape_2d(ctx, weight_, K * Cin_w, Cout);
+    ggml_tensor * mm = ggml_mul_mat(ctx, w_2d, col_2d);
+    ggml_tensor * y = ggml_reshape_3d(ctx, mm, Cout, dt, B);
     if (bias_ != nullptr) {
         ggml_tensor * bias_broadcast = ggml_reshape_3d(ctx, bias_, Cout, 1, 1);
         y                            = ggml_add(ctx, y, bias_broadcast);


### PR DESCRIPTION
## 概述

两个独立优化，产物 bit-exact（MD5 一致）：

1. **Metal per-backend command queue**：每个 ggml backend 创建独立 Metal 命令队列，实现 LLM 和 T2W GPU 真正并行执行
2. **Batched Conv1d (im2col + mul_mat)**：消除 token2mel 中逐 batch 循环的 view_3d + concat，改用单次 im2col + mul_mat

## 性能（Apple M5, macOS, Metal, Release, Q4_K_M）

Baseline: `7ba25c70` (merge PR #32)
Candidate: `ef44b4fe` (+ per-backend queue + batched conv1d)
固定 seed: `OMNI_SAMPLER_SEED=42`

### Duplex 4-chunk（短对话）

| 指标 | Baseline | Candidate | 提升 |
|------|----------|-----------|------|
| avg prefill | 921 ms | 573 ms | **-37.8%** |
| avg/chunk | 1541 ms | 1392 ms | -9.7% |
| 首响 | 4807 ms | 1843 ms | **-61.7%** |
| LLM prefill tok/s | 20.3 | 30.0 | **+48%** |

### Duplex 8-chunk（中等）

| 指标 | Baseline | Candidate | 提升 |
|------|----------|-----------|------|
| avg prefill | 272 ms | 229 ms | -16% |
| 首响 | 3602 ms | 2352 ms | **-34.7%** |
| LLM prefill tok/s | 51.5 | 57.4 | +11.6% |

### Duplex 12-chunk（长对话，GPU 争抢最严重）

| 指标 | Baseline | Candidate | 提升 |
|------|----------|-----------|------|
| 首响 | 4146~5192 ms | **1059~1073 ms** | **-74~79%** |
| T2W RTF | 2.78~5.26 | **0.47~1.21** | 从不可实时→实时 |
| 所有音频完成 | 13.4~13.9 s | **3.0~3.1 s** | **-78%** |
| LLM prefill tok/s | 58.1 | 58.5 | 持平 |
| LLM decode tok/s | 19.4 | 15.8 | -18%（带宽共享代价） |

### 原因分析

Baseline 中 T2W 和 LLM 共用单一 Metal command queue，T2W 计算时 LLM 被阻塞。Per-backend queue 让各自拥有独立队列，GPU 硬件调度器可并行分派两者的工作。

LLM decode 有 ~18% 吞吐下降是 GPU 带宽共享的预期代价，但换来首响从 4-5s→1s、T2W 从不可实时(RTF>3)→实时(RTF<1)。

## Bit-exact 验证

```
MD5 (baseline)  = c1acec612b6dae52ac98fc4c1294071e
MD5 (candidate) = c1acec612b6dae52ac98fc4c1294071e
```

token2wav-example CPU 产物完全一致，conv1d batch 改造无精度影响。

## 改动文件

- `ggml/src/ggml-metal/ggml-metal-context.m`: per-backend queue 分配 + 正确 release
- `tools/omni/omni.cpp`: 清理多余调度机制，保留 queue_wait 诊断
- `tools/omni/omni.h`: 移除无用的 atomic/mutex 字段
- `tools/omni/token2wav/token2wav-impl.cpp`: batched conv1d (im2col + mul_mat)
- `tools/omni/token2wav/token2wav-example.cpp`: 统一环境变量命名 (OMNI_VOC_DEVICE)
- `tools/omni/test/test-duplex.cpp`: 清理 serial_drain，简化输出