### PR TITLE
[draft: to verify] ix(duplex-tts): preserve TTS KV cache continuity across SPEAK chunks

### DIFF
--- a/tools/omni/omni.cpp
+++ b/tools/omni/omni.cpp
@@ -5941,19 +5941,6 @@ void tts_thread_func_duplex(struct omni_context * ctx_omni, common_params *param
             
             if (ctx_omni->speek_done && llm_finish) {
                 if (ctx_omni->duplex_mode && !current_chunk_token_ids.empty()) {
-                    // 新一轮 SPEAK：重置 TTS 状态，防止上轮残留污染
-                    if (chunk_idx > 0) {
-                        chunk_idx = 0;
-                        tts_n_past = 0;
-                        audio_tokens.clear();
-                        llama_memory_t mem = llama_get_memory(ctx_omni->ctx_tts_llama);
-                        if (mem) {
-                            llama_memory_seq_rm(mem, 0, 0, -1);
-                        }
-                        ctx_omni->tts_n_past_accumulated = 0;
-                        ctx_omni->tts_all_generated_tokens.clear();
-                        ctx_omni->tts_condition_saved = false;
-                    }
                     ctx_omni->speek_done = false;
                 } else if (ctx_omni->duplex_mode && accumulated_is_end_of_turn) {
                     ctx_omni->speek_done = false;


### PR DESCRIPTION
Remove `chunk_idx=0` reset in `tts_thread_func_duplex` that cleared TTS KV cache on every SPEAK segment.

**Root cause**: a speed-dependent race on `speek_done` between LLM decode thread and TTS thread. On Metal/ANE (slow TTS), the reset fires every chunk → each chunk cold-starts TTS → choppy audio. On CUDA (fast TTS), the race rarely triggers → sounds fine.

The existing `accumulated_is_end_of_turn` path already handles cleanup at real turn boundaries.

1 file, 13 lines deleted.

Made with [Cursor](https://cursor.com)