### PR TITLE
perf: build TTS condition embeddings with ggml graph

### DIFF
--- a/tools/omni/CMakeLists.txt
+++ b/tools/omni/CMakeLists.txt
@@ -12,6 +12,8 @@ endif()
 add_library(omni
             omni.cpp
             omni.h
+            tts-condition-graph.cpp
+            tts-condition-graph.h
             audition.cpp
             audition.h
             vision.cpp

--- a/tools/omni/omni.cpp
+++ b/tools/omni/omni.cpp
@@ -4448,6 +4448,10 @@ void omni_free(struct omni_context * ctx_omni) {
         llama_free(ctx_omni->ctx_tts_llama);
         llama_free_model(ctx_omni->model_tts);
         common_sampler_free(ctx_omni->ctx_tts_sampler);
+
+        if (ctx_omni->tts_condition_graph.initialized) {
+            tts_condition_graph_free(ctx_omni);
+        }
         
         // Free TTS weights
         if (ctx_omni->emb_code_weight) {
@@ -6967,194 +6971,32 @@ void tts_thread_func(struct omni_context * ctx_omni, common_params *params) {
             // 这样 TTS 会 flush 剩余的 tts_token_buffer，并正确处理 text_eos_embed
             bool is_final_text_chunk = llm_finish;
             
-            // Try to compute merged embeddings if weights are available
-            if (ctx_omni->emb_text_weight && ctx_omni->projector_semantic_linear1_weight) {
-                // Step 1: Convert token IDs to embeddings using emb_text (using filtered tokens)
-                std::vector<float> llm_embeds(n_tokens_filtered * tts_n_embd, 0.0f);
-                bool emb_text_success = true;
-                
-                for (int i = 0; i < n_tokens_filtered; i++) {
-                    llama_token token_id = filtered_token_ids[i];
-                    float * emb = llm_embeds.data() + i * tts_n_embd;
-                    if (!tts_emb_text(ctx_omni, token_id, emb, tts_n_embd)) {
-                        emb_text_success = false;
-                        break;
-                    }
+            if (ctx_omni->emb_text_weight && ctx_omni->projector.initialized) {
+                if (!ctx_omni->tts_condition_graph.initialized) {
+                    tts_condition_graph_init(ctx_omni);
                 }
-                
-                if (emb_text_success) {
-                    // Debug: Save llm_embeds for comparison
-                    {
-                        std::string chunk_dir = llm_debug_output_dir + "/chunk_" + std::to_string(current_chunk_idx);
-                        create_dir(chunk_dir);
-                        std::string llm_embeds_file = chunk_dir + "/llm_embeds_cpp.txt";
-                        FILE *f_llm_embeds = fopen(llm_embeds_file.c_str(), "w");
-                        if (f_llm_embeds) {
-                            fprintf(f_llm_embeds, "LLM Embeddings from emb_text (C++ computed, shape: [%d, %d]):\n", n_tokens_filtered, tts_n_embd);
-                            for (int i = 0; i < n_tokens_filtered; ++i) {
-                                fprintf(f_llm_embeds, "Token %d: ", i);
-                                for (int j = 0; j < tts_n_embd; ++j) {
-                                    fprintf(f_llm_embeds, "%.6f", llm_embeds[i * tts_n_embd + j]);
-                                    if (j < tts_n_embd - 1) fprintf(f_llm_embeds, " ");
-                                }
-                                fprintf(f_llm_embeds, "\n");
-                            }
-                            fclose(f_llm_embeds);
-                        }
-                    }
-                    
-                    // Step 2: Project hidden states using projector_semantic (using filtered hidden states)
-                    std::vector<float> projected_hidden(n_tokens_filtered * tts_n_embd, 0.0f);
-                    bool projector_success = tts_projector_semantic(ctx_omni,
-                                                                     filtered_hidden_states.data(),
-                                                                     n_tokens_filtered,
-                                                                     current_chunk_n_embd,
-                                                                     projected_hidden.data(),
-                                                                     tts_n_embd);
-                    
-                    if (projector_success) {
-                        // Debug: Save projected_hidden before normalization for comparison
-                        {
-                            std::string chunk_dir = llm_debug_output_dir + "/chunk_" + std::to_string(current_chunk_idx);
-                            create_dir(chunk_dir);
-                            std::string projected_file = chunk_dir + "/projected_hidden_before_norm_cpp.txt";
-                            FILE *f_projected = fopen(projected_file.c_str(), "w");
-                            if (f_projected) {
-                                fprintf(f_projected, "Projected Hidden States BEFORE normalization (C++ computed, shape: [%d, %d]):\n", n_tokens_filtered, tts_n_embd);
-                                for (int i = 0; i < n_tokens_filtered; ++i) {
-                                    fprintf(f_projected, "Token %d: ", i);
-                                    for (int j = 0; j < tts_n_embd; ++j) {
-                                        fprintf(f_projected, "%.6f", projected_hidden[i * tts_n_embd + j]);
-                                        if (j < tts_n_embd - 1) fprintf(f_projected, " ");
-                                    }
-                                    fprintf(f_projected, "\n");
-                                }
-                                fclose(f_projected);
-                            }
-                        }
-                        
-                        // Step 3: Normalize projected hidden states (CRITICAL: must normalize before merging)
-                        // Check L2 norm before normalization for debugging
-                        if (n_tokens_filtered > 0) {
-                            // Check all tokens, not just first one
-                            float avg_norm_before = 0.0f;
-                            float min_norm_before = 1e10f;
-                            float max_norm_before = 0.0f;
-                            for (int t = 0; t < n_tokens_filtered; t++) {
-                                float * vec = projected_hidden.data() + t * tts_n_embd;
-                                float norm_sq = 0.0f;
-                                for (int i = 0; i < tts_n_embd; i++) {
-                                    norm_sq += vec[i] * vec[i];
-                                }
-                                float norm = std::sqrt(norm_sq);
-                                avg_norm_before += norm;
-                                if (norm < min_norm_before) min_norm_before = norm;
-                                if (norm > max_norm_before) max_norm_before = norm;
-                            }
-                            avg_norm_before /= n_tokens_filtered;
-                        }
-                        
-                        // CRITICAL: Normalize projected_hidden before merging
-                        normalize_l2_per_token(projected_hidden.data(), n_tokens_filtered, tts_n_embd);
-                        
-                        // Debug: Save projected_hidden after normalization for comparison
-                        {
-                            std::string chunk_dir = llm_debug_output_dir + "/chunk_" + std::to_string(current_chunk_idx);
-                            create_dir(chunk_dir);
-                            std::string projected_file = chunk_dir + "/projected_hidden_after_norm_cpp.txt";
-                            FILE *f_projected = fopen(projected_file.c_str(), "w");
-                            if (f_projected) {
-                                fprintf(f_projected, "Projected Hidden States AFTER normalization (C++ computed, shape: [%d, %d]):\n", n_tokens_filtered, tts_n_embd);
-                                for (int i = 0; i < n_tokens_filtered; ++i) {
-                                    fprintf(f_projected, "Token %d: ", i);
-                                    for (int j = 0; j < tts_n_embd; ++j) {
-                                        fprintf(f_projected, "%.6f", projected_hidden[i * tts_n_embd + j]);
-                                        if (j < tts_n_embd - 1) fprintf(f_projected, " ");
-                                    }
-                                    fprintf(f_projected, "\n");
-                                }
-                                fclose(f_projected);
-                            }
-                        }
-                        
-                        // Verify normalization after normalization (check all tokens)
-                        if (n_tokens_filtered > 0) {
-                            float avg_norm_after = 0.0f;
-                            float min_norm_after = 1e10f;
-                            float max_norm_after = 0.0f;
-                            int norm_error_count = 0;
-                            for (int t = 0; t < n_tokens_filtered; t++) {
-                                float * vec = projected_hidden.data() + t * tts_n_embd;
-                                float norm_sq = 0.0f;
-                                for (int i = 0; i < tts_n_embd; i++) {
-                                    norm_sq += vec[i] * vec[i];
-                                }
-                                float norm = std::sqrt(norm_sq);
-                                avg_norm_after += norm;
-                                if (norm < min_norm_after) min_norm_after = norm;
-                                if (norm > max_norm_after) max_norm_after = norm;
-                                if (std::abs(norm - 1.0f) > 0.01f) {
-                                    norm_error_count++;
-                                    LOG_ERR("TTS: ERROR - token %d normalization failed: norm=%.6f (expected ~1.0)\n", t, norm);
-                                }
-                            }
-                            avg_norm_after /= n_tokens_filtered;
-                            if (norm_error_count > 0) {
-                                LOG_ERR("TTS: ERROR - normalization failed for %d/%d tokens! Expected all norms to be ~1.0\n", 
-                                        norm_error_count, n_tokens_filtered);
-                            } else {
-                            }
-                        }
-                        
-                        // Step 4: Merge: merged_embeds = llm_embeds + projected_hidden
-                        // CRITICAL: Use normalized projected_hidden for merging
-                        // Verify projected_hidden is normalized before merging
-                        if (n_tokens_filtered > 0) {
-                            float verify_norm_check = 0.0f;
-                            float * vec_check = projected_hidden.data() + 0 * tts_n_embd;
-                            for (int i = 0; i < tts_n_embd; i++) {
-                                verify_norm_check += vec_check[i] * vec_check[i];
-                            }
-                            float verify_norm_val = std::sqrt(verify_norm_check);
-                            if (std::abs(verify_norm_val - 1.0f) > 0.01f) {
-                                LOG_ERR("TTS: CRITICAL ERROR - projected_hidden is NOT normalized before merge! norm=%.6f\n", verify_norm_val);
-                            }
-                        }
-                        
-                        // 🔧 [安全检查] 防止创建过大的 vector 导致崩溃
-                        size_t merge_size = (size_t)n_tokens_filtered * tts_n_embd;
-                        if (n_tokens_filtered <= 0 || n_tokens_filtered > 10000 || 
-                            tts_n_embd <= 0 || tts_n_embd > 10000 ||
-                            merge_size > 100000000) {  // 100M elements max
-                            LOG_ERR("TTS: invalid merge size: n_tokens_filtered=%d, tts_n_embd=%d, merge_size=%zu\n",
-                                    n_tokens_filtered, tts_n_embd, merge_size);
-                            break;  // 跳过这个 chunk，避免崩溃
-                        }
-                        
-                        merged_embeddings.resize(merge_size);
-                        for (size_t i = 0; i < merge_size; i++) {
-                            merged_embeddings[i] = llm_embeds[i] + projected_hidden[i];
-                        }
-                        
-                        // 🔧 [修复] 不在 merge embed 阶段添加 audio_bos
-                        // Python 中 audio_bos 是在 TTS 类内部（prefill 前）添加的
-                        // 由 tts_thread_func 在 prefill 之前动态添加 audio_bos
-                        // 这样可以确保 audio_bos 使用正确的 embedding 权重和位置
-                        
+
+                int graph_tts_n_embd = 0;
+                if (ctx_omni->tts_condition_graph.initialized &&
+                    tts_condition_graph_forward(ctx_omni,
+                                                filtered_token_ids.data(),
+                                                filtered_hidden_states.data(),
+                                                n_tokens_filtered,
+                                                current_chunk_n_embd,
+                                                merged_embeddings,
+                                                graph_tts_n_embd)) {
+                    if (graph_tts_n_embd == tts_n_embd) {
                         merged_success = true;
-                        
-                        // Debug: Verify merged_embeddings calculation
-                        if (n_tokens_filtered > 0) {
-                            float * llm_emb_check = llm_embeds.data() + 0 * tts_n_embd;
-                            float * proj_hidden_check = projected_hidden.data() + 0 * tts_n_embd;
-                            float * merged_check = merged_embeddings.data() + 0 * tts_n_embd;
-                        }
                     } else {
-                        print_with_timestamp("TTS: WARNING - projector_semantic failed, skipping merged embedding save\n");
+                        LOG_ERR("TTS: condition graph tts_n_embd mismatch: got %d, expected %d\n",
+                                graph_tts_n_embd, tts_n_embd);
+                        merged_embeddings.clear();
                     }
+                } else {
+                    print_with_timestamp("TTS: WARNING - condition graph failed, skipping merged embedding computation\n");
                 }
             } else {
-                print_with_timestamp("TTS: WARNING - TTS weights not loaded, skipping merged embedding computation\n");
+                print_with_timestamp("TTS: WARNING - TTS condition graph weights not loaded, skipping merged embedding computation\n");
             }
             
             // Save LLM debug data: text, token_ids, hidden_states, and merged embeddings

--- a/tools/omni/omni.h
+++ b/tools/omni/omni.h
@@ -1,5 +1,6 @@
 #include "ggml.h"
 #include "llama.h"
+#include "tts-condition-graph.h"
 
 #include <thread>
 #include <memory>
@@ -366,6 +367,7 @@ struct omni_context {
     
     // New ggml-based projector model (精度验证版本)
     struct projector_model projector;
+    struct tts_condition_graph_model tts_condition_graph;
     
     // head_code: Linear layer (hidden_size=768 -> num_audio_tokens=6562)
     // Note: num_vq=1, so we only need one head_code layer

--- a/tools/omni/tts-condition-graph.cpp
+++ b/tools/omni/tts-condition-graph.cpp
@@ -1,0 +1,251 @@
+#include "tts-condition-graph.h"
+
+#include "omni.h"
+
+#include "common/log.h"
+#include "ggml-backend.h"
+
+static struct ggml_tensor * tts_condition_graph_build_l2_normalize(
+        struct ggml_context * ctx,
+        struct ggml_tensor  * x,
+        struct ggml_tensor  * eps) {
+    struct ggml_tensor * sq       = ggml_sqr(ctx, x);
+    struct ggml_tensor * sum      = ggml_sum_rows(ctx, sq);
+    struct ggml_tensor * eps_2d   = ggml_reshape_2d(ctx, eps, 1, 1);
+    struct ggml_tensor * eps_rep  = ggml_repeat(ctx, eps_2d, sum);
+    struct ggml_tensor * denom    = ggml_sqrt(ctx, ggml_add(ctx, sum, eps_rep));
+    struct ggml_tensor * denom_r  = ggml_repeat(ctx, denom, x);
+    struct ggml_tensor * normed   = ggml_div(ctx, x, denom_r);
+    return ggml_cont(ctx, normed);
+}
+
+static struct ggml_cgraph * tts_condition_graph_build(
+        struct omni_context * ctx_omni,
+        struct ggml_context * ctx,
+        struct ggml_tensor  * token_ids,
+        struct ggml_tensor  * llm_hidden,
+        struct ggml_tensor  * eps) {
+    struct ggml_cgraph * gf = ggml_new_graph(ctx);
+
+    struct ggml_tensor * llm_embeds = ggml_get_rows(
+        ctx,
+        ctx_omni->tts_condition_graph.emb_text_weight,
+        token_ids);
+
+    struct ggml_tensor * projected = ggml_mul_mat(
+        ctx,
+        ctx_omni->projector.layer.linear1_weight,
+        llm_hidden);
+    projected = ggml_add(ctx, projected, ctx_omni->projector.layer.linear1_bias);
+    projected = ggml_relu(ctx, projected);
+    projected = ggml_mul_mat(ctx, ctx_omni->projector.layer.linear2_weight, projected);
+    projected = ggml_add(ctx, projected, ctx_omni->projector.layer.linear2_bias);
+
+    struct ggml_tensor * normalized = tts_condition_graph_build_l2_normalize(ctx, projected, eps);
+    struct ggml_tensor * merged = ggml_add(ctx, llm_embeds, normalized);
+    merged = ggml_cont(ctx, merged);
+    ggml_set_name(merged, "tts_condition_merged");
+
+    ggml_build_forward_expand(gf, merged);
+    return gf;
+}
+
+bool tts_condition_graph_init(struct omni_context * ctx_omni) {
+    if (!ctx_omni) {
+        return false;
+    }
+    if (ctx_omni->tts_condition_graph.initialized) {
+        return true;
+    }
+    if (!ctx_omni->projector.initialized || !ctx_omni->projector.backend) {
+        LOG_ERR("TTS condition graph: projector graph is not initialized\n");
+        return false;
+    }
+    if (!ctx_omni->emb_text_weight || ctx_omni->emb_text_vocab_size <= 0 || ctx_omni->emb_text_hidden_size <= 0) {
+        LOG_ERR("TTS condition graph: emb_text weights are not loaded\n");
+        return false;
+    }
+    if (!ctx_omni->projector.layer.linear1_weight || !ctx_omni->projector.layer.linear1_bias ||
+        !ctx_omni->projector.layer.linear2_weight || !ctx_omni->projector.layer.linear2_bias) {
+        LOG_ERR("TTS condition graph: projector tensors are incomplete\n");
+        return false;
+    }
+
+    tts_condition_graph_model & model = ctx_omni->tts_condition_graph;
+    model.llm_hidden_dim = ctx_omni->projector.hparams.in_dim;
+    model.tts_hidden_dim = ctx_omni->emb_text_hidden_size;
+    model.text_vocab_size = ctx_omni->emb_text_vocab_size;
+    model.backend = ctx_omni->projector.backend;
+    model.buf_type = ggml_backend_get_default_buffer_type(model.backend);
+
+    const size_t ctx_size = ggml_tensor_overhead() * 1;
+    struct ggml_init_params ctx_params = {
+        /*.mem_size   = */ ctx_size,
+        /*.mem_buffer = */ nullptr,
+        /*.no_alloc   = */ true,
+    };
+
+    model.ctx_w = ggml_init(ctx_params);
+    if (!model.ctx_w) {
+        LOG_ERR("TTS condition graph: failed to create weight context\n");
+        return false;
+    }
+
+    model.emb_text_weight = ggml_new_tensor_2d(
+        model.ctx_w,
+        GGML_TYPE_F32,
+        model.tts_hidden_dim,
+        model.text_vocab_size);
+    ggml_set_name(model.emb_text_weight, "tts_condition_emb_text_weight");
+
+    model.buf_w = ggml_backend_alloc_ctx_tensors(model.ctx_w, model.backend);
+    if (!model.buf_w) {
+        LOG_ERR("TTS condition graph: failed to allocate emb_text backend buffer\n");
+        ggml_free(model.ctx_w);
+        model.ctx_w = nullptr;
+        model.emb_text_weight = nullptr;
+        return false;
+    }
+
+    const size_t emb_text_bytes =
+        (size_t) model.text_vocab_size * (size_t) model.tts_hidden_dim * sizeof(float);
+    ggml_backend_tensor_set(model.emb_text_weight, ctx_omni->emb_text_weight, 0, emb_text_bytes);
+
+    model.initialized = true;
+    LOG_INF("TTS condition graph: initialized (vocab=%d, hidden=%d)\n",
+            model.text_vocab_size, model.tts_hidden_dim);
+    return true;
+}
+
+void tts_condition_graph_free(struct omni_context * ctx_omni) {
+    if (!ctx_omni) {
+        return;
+    }
+
+    tts_condition_graph_model & model = ctx_omni->tts_condition_graph;
+    if (model.buf_w) {
+        ggml_backend_buffer_free(model.buf_w);
+    }
+    if (model.ctx_w) {
+        ggml_free(model.ctx_w);
+    }
+
+    model.ctx_w = nullptr;
+    model.buf_w = nullptr;
+    model.emb_text_weight = nullptr;
+    model.backend = nullptr;
+    model.buf_type = nullptr;
+    model.initialized = false;
+}
+
+bool tts_condition_graph_forward(
+        struct omni_context * ctx_omni,
+        const llama_token * token_ids,
+        const float * llm_hidden_states,
+        int n_tokens,
+        int llm_n_embd,
+        std::vector<float> & merged_embeddings,
+        int & tts_n_embd) {
+    merged_embeddings.clear();
+    tts_n_embd = 0;
+
+    if (!ctx_omni || !token_ids || !llm_hidden_states) {
+        return false;
+    }
+    if (!ctx_omni->tts_condition_graph.initialized) {
+        LOG_ERR("TTS condition graph: forward called before init\n");
+        return false;
+    }
+    if (n_tokens <= 0 || n_tokens > 10000) {
+        LOG_ERR("TTS condition graph: invalid n_tokens=%d\n", n_tokens);
+        return false;
+    }
+
+    tts_condition_graph_model & model = ctx_omni->tts_condition_graph;
+    if (llm_n_embd != model.llm_hidden_dim) {
+        LOG_ERR("TTS condition graph: llm_n_embd (%d) != expected (%d)\n",
+                llm_n_embd, model.llm_hidden_dim);
+        return false;
+    }
+
+    for (int i = 0; i < n_tokens; ++i) {
+        if (token_ids[i] < 0 || token_ids[i] >= model.text_vocab_size) {
+            LOG_ERR("TTS condition graph: token_id %d out of range [0, %d)\n",
+                    token_ids[i], model.text_vocab_size);
+            return false;
+        }
+    }
+
+    const int out_dim = model.tts_hidden_dim;
+    const size_t output_size = (size_t) n_tokens * (size_t) out_dim;
+    if (output_size > 100000000) {
+        LOG_ERR("TTS condition graph: output too large (%zu floats)\n", output_size);
+        return false;
+    }
+
+    const size_t ctx_size = ggml_tensor_overhead() * 32 + ggml_graph_overhead();
+    struct ggml_init_params params = {
+        /*.mem_size   = */ ctx_size,
+        /*.mem_buffer = */ nullptr,
+        /*.no_alloc   = */ true,
+    };
+
+    struct ggml_context * ctx = ggml_init(params);
+    if (!ctx) {
+        LOG_ERR("TTS condition graph: failed to create compute context\n");
+        return false;
+    }
+
+    struct ggml_tensor * token_ids_tensor = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, n_tokens);
+    ggml_set_name(token_ids_tensor, "tts_condition_token_ids");
+    ggml_set_input(token_ids_tensor);
+
+    struct ggml_tensor * hidden_tensor = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, llm_n_embd, n_tokens);
+    ggml_set_name(hidden_tensor, "tts_condition_llm_hidden");
+    ggml_set_input(hidden_tensor);
+
+    struct ggml_tensor * eps_tensor = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, 1);
+    ggml_set_name(eps_tensor, "tts_condition_norm_eps");
+    ggml_set_input(eps_tensor);
+
+    struct ggml_cgraph * gf = tts_condition_graph_build(
+        ctx_omni,
+        ctx,
+        token_ids_tensor,
+        hidden_tensor,
+        eps_tensor);
+
+    ggml_backend_buffer_t buf_compute = ggml_backend_alloc_ctx_tensors(ctx, model.backend);
+    if (!buf_compute) {
+        LOG_ERR("TTS condition graph: failed to allocate compute buffer\n");
+        ggml_free(ctx);
+        return false;
+    }
+
+    std::vector<int32_t> token_ids_i32(n_tokens);
+    for (int i = 0; i < n_tokens; ++i) {
+        token_ids_i32[i] = (int32_t) token_ids[i];
+    }
+
+    const float eps = 1e-8f;
+    ggml_backend_tensor_set(token_ids_tensor, token_ids_i32.data(), 0, token_ids_i32.size() * sizeof(int32_t));
+    ggml_backend_tensor_set(hidden_tensor, llm_hidden_states, 0, (size_t) n_tokens * (size_t) llm_n_embd * sizeof(float));
+    ggml_backend_tensor_set(eps_tensor, &eps, 0, sizeof(float));
+
+    enum ggml_status status = ggml_backend_graph_compute(model.backend, gf);
+    if (status != GGML_STATUS_SUCCESS) {
+        LOG_ERR("TTS condition graph: graph compute failed with status %d\n", (int) status);
+        ggml_backend_buffer_free(buf_compute);
+        ggml_free(ctx);
+        return false;
+    }
+
+    struct ggml_tensor * output = ggml_graph_node(gf, ggml_graph_n_nodes(gf) - 1);
+    merged_embeddings.resize(output_size);
+    ggml_backend_tensor_get(output, merged_embeddings.data(), 0, output_size * sizeof(float));
+    tts_n_embd = out_dim;
+
+    ggml_backend_buffer_free(buf_compute);
+    ggml_free(ctx);
+    return true;
+}

--- a/tools/omni/tts-condition-graph.h
+++ b/tools/omni/tts-condition-graph.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "ggml.h"
+#include "ggml-backend.h"
+#include "llama.h"
+
+#include <cstdint>
+#include <vector>
+
+struct omni_context;
+
+// Fused graph for building TTS text condition embeddings:
+// emb_text(token_ids) + normalize(projector_semantic(llm_hidden_states)).
+struct tts_condition_graph_model {
+    int32_t llm_hidden_dim = 0;
+    int32_t tts_hidden_dim = 0;
+    int32_t text_vocab_size = 0;
+
+    // Non-owning backend borrowed from ctx_omni->projector.
+    ggml_backend_t backend = nullptr;
+    ggml_backend_buffer_type_t buf_type = nullptr;
+
+    struct ggml_context * ctx_w = nullptr;
+    ggml_backend_buffer_t buf_w = nullptr;
+
+    struct ggml_tensor * emb_text_weight = nullptr; // [tts_hidden_dim, text_vocab_size]
+
+    bool initialized = false;
+};
+
+bool tts_condition_graph_init(struct omni_context * ctx_omni);
+void tts_condition_graph_free(struct omni_context * ctx_omni);
+
+bool tts_condition_graph_forward(
+    struct omni_context * ctx_omni,
+    const llama_token * token_ids,
+    const float * llm_hidden_states,
+    int n_tokens,
+    int llm_n_embd,
+    std::vector<float> & merged_embeddings,
+    int & tts_n_embd);


### PR DESCRIPTION
  ## Summary
  - Replace the LLM-to-TTS condition embedding build with a fused ggml graph.
  - The graph covers `emb_text` lookup, `projector_semantic`, L2 normalization, and merge.
  - Keep this PR scoped to the operator replacement only, without debug helpers, validation docs, test edits, or runtime path switches from the experiment branch.