### PR TITLE
app/mac: reap residual llama-server on stop

### DIFF
--- a/apps/desktop/menubar_app.py
+++ b/apps/desktop/menubar_app.py
@@ -297,6 +297,108 @@ def _pid_is_alive(pid: int) -> bool:
         return True
 
 
+def _loopback_urlopen(url: str, timeout: float = 3.0):
+    import urllib.request
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+    return opener.open(url, timeout=timeout)
+
+
+def fetch_worker_cpp_runtime_info(worker_port: int) -> Optional[dict]:
+    try:
+        with _loopback_urlopen(f"http://127.0.0.1:{worker_port}/cpp_runtime", timeout=2.0) as resp:
+            if resp.status != 200:
+                return None
+            data = json.loads(resp.read())
+        if isinstance(data, dict) and data.get("active") and isinstance(data.get("pid"), int):
+            return data
+    except Exception as e:
+        logger.debug(f"fetch_worker_cpp_runtime_info failed: {e}")
+    return None
+
+
+def _read_process_snapshot(pid: int) -> Optional[dict]:
+    try:
+        out = subprocess.check_output(
+            ["ps", "-p", str(pid), "-o", "pid=,pgid=,command="],
+            text=True,
+            stderr=subprocess.DEVNULL,
+            timeout=2,
+        ).strip()
+    except Exception:
+        return None
+    if not out:
+        return None
+    parts = out.split(None, 2)
+    if len(parts) < 3:
+        return None
+    try:
+        return {
+            "pid": int(parts[0]),
+            "pgid": int(parts[1]),
+            "command": parts[2],
+        }
+    except ValueError:
+        return None
+
+
+def _command_matches_runtime(command: str, runtime: dict) -> bool:
+    binary_path = runtime.get("binary_path")
+    if binary_path and binary_path not in command:
+        return False
+    port = runtime.get("port")
+    if isinstance(port, int):
+        m = re.search(r"(?:^|\s)--port(?:=|\s+)(\d+)\b", command)
+        if not m or int(m.group(1)) != port:
+            return False
+    return True
+
+
+def cleanup_owned_llama_server_process(runtime: Optional[dict]) -> bool:
+    """Terminate only the llama-server instance explicitly owned by worker.py."""
+    if not runtime or not isinstance(runtime.get("pid"), int):
+        return False
+
+    pid = int(runtime["pid"])
+    snapshot = _read_process_snapshot(pid)
+    if snapshot is None or not _command_matches_runtime(snapshot["command"], runtime):
+        return False
+
+    pgid = runtime.get("pgid")
+    if not isinstance(pgid, int) or pgid <= 0:
+        pgid = snapshot.get("pgid")
+
+    logger.warning(
+        "Cleaning up owned llama-server pid=%s pgid=%s port=%s",
+        pid, pgid, runtime.get("port"),
+    )
+    try:
+        if isinstance(pgid, int) and pgid > 0:
+            os.killpg(pgid, signal.SIGTERM)
+        else:
+            os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return True
+    except Exception as e:
+        logger.debug(f"owned llama-server SIGTERM failed: {e}")
+
+    deadline = time.time() + 3.0
+    while _pid_is_alive(pid) and time.time() < deadline:
+        time.sleep(0.1)
+
+    if _pid_is_alive(pid):
+        try:
+            if isinstance(pgid, int) and pgid > 0:
+                os.killpg(pgid, signal.SIGKILL)
+            else:
+                os.kill(pid, signal.SIGKILL)
+        except ProcessLookupError:
+            return True
+        except Exception as e:
+            logger.debug(f"owned llama-server SIGKILL failed: {e}")
+
+    return True
+
+
 def cleanup_residual_llama_server_processes() -> int:
     """Best-effort cleanup for bundled llama-server processes left behind.
 
@@ -1750,17 +1852,13 @@ class AppDelegate(NSObject):
         # ExceptionsList 含 localhost / 127.0.0.1，Python 的 urllib 仍然会
         # 读 $HTTP_PROXY 把请求走代理。这里用 ProxyHandler({}) 强制不走
         # 任何代理，和 curl 行为对齐。
-        import urllib.request
-        # Build an opener that ignores system HTTP proxy, so loopback probes
-        # aren't intercepted by local HTTP proxies (Clash/V2Ray etc.).
-        opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
         for _ in range(timeout // 2):
             try:
-                resp = opener.open(f"{url}/health", timeout=3)
-                if resp.status == 200:
-                    data = json.loads(resp.read())
-                    if data.get("model_loaded", True):
-                        return True
+                with _loopback_urlopen(f"{url}/health", timeout=3) as resp:
+                    if resp.status == 200:
+                        data = json.loads(resp.read())
+                        if data.get("model_loaded", True):
+                            return True
             except Exception:
                 pass
             if self._worker_proc and self._worker_proc.poll() is not None:
@@ -1881,6 +1979,9 @@ class AppDelegate(NSObject):
     def _do_stop(self):
         logger.info("_do_stop")
         self._stop_log_tail()
+        owned_runtime = None
+        if self._worker_proc and self._worker_proc.poll() is None:
+            owned_runtime = fetch_worker_cpp_runtime_info(self._worker_port)
         for name, proc in [("Gateway", self._gateway_proc), ("Worker", self._worker_proc)]:
             if proc and proc.poll() is None:
                 self._append_log(f"  Stopping {name} (pid={proc.pid})…\n")
@@ -1889,6 +1990,11 @@ class AppDelegate(NSObject):
                     proc.wait(timeout=10)
                 except subprocess.TimeoutExpired:
                     proc.kill()
+        if owned_runtime and _pid_is_alive(int(owned_runtime["pid"])):
+            if cleanup_owned_llama_server_process(owned_runtime):
+                self._append_log(
+                    f"  Cleaned up owned llama-server pid={owned_runtime['pid']}.\n"
+                )
         n_cleaned = cleanup_residual_llama_server_processes()
         if n_cleaned:
             self._append_log(f"  Cleaned up {n_cleaned} residual llama-server process(es).\n")

--- a/apps/desktop/menubar_app.py
+++ b/apps/desktop/menubar_app.py
@@ -15,8 +15,10 @@
 import os
 import sys
 import json
+import re
 import time
 import socket
+import signal
 import subprocess
 import webbrowser
 import threading
@@ -270,6 +272,105 @@ def find_llama_server() -> Optional[str]:
         if c.exists():
             return str(c)
     return None
+
+
+def get_cpp_server_port_from_config() -> int:
+    default_port = 19060
+    if _CONFIG_PATH.exists():
+        try:
+            with open(_CONFIG_PATH, encoding="utf-8") as f:
+                port = json.load(f).get("cpp_backend", {}).get("cpp_server_port")
+            if isinstance(port, int) and port > 0:
+                return port
+        except Exception:
+            pass
+    return default_port
+
+
+def _pid_is_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+def cleanup_residual_llama_server_processes() -> int:
+    """Best-effort cleanup for bundled llama-server processes left behind.
+
+    On macOS, the menu-bar app only owns gateway.py / worker.py directly. If
+    worker.py gets force-killed before FastAPI lifespan shutdown runs, the
+    standalone llama-server subprocess can survive as an orphan and keep the
+    model mmap resident. Sweep by exact bundled binary path plus the configured
+    C++ server port so we only touch this app's own inference backend.
+    """
+    server_bin = find_llama_server()
+    if not server_bin:
+        return 0
+
+    target_port = get_cpp_server_port_from_config()
+    try:
+        out = subprocess.check_output(
+            ["ps", "-axo", "pid=,command="],
+            text=True,
+            stderr=subprocess.DEVNULL,
+            timeout=3,
+        )
+    except Exception as e:
+        logger.debug(f"ps scan for residual llama-server failed: {e}")
+        return 0
+
+    port_re = re.compile(r"(?:^|\s)--port(?:=|\s+)(\d+)\b")
+    pids: List[int] = []
+    for line in out.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        pid_str, _, cmd = line.partition(" ")
+        try:
+            pid = int(pid_str)
+        except ValueError:
+            continue
+        if server_bin not in cmd:
+            continue
+        m = port_re.search(cmd)
+        if m and int(m.group(1)) != target_port:
+            continue
+        pids.append(pid)
+
+    pids = sorted(set(pids))
+    if not pids:
+        return 0
+
+    logger.warning(
+        "Cleaning up residual llama-server process(es) on port %s: %s",
+        target_port, pids,
+    )
+    for pid in pids:
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        except Exception as e:
+            logger.debug(f"SIGTERM pid={pid} failed: {e}")
+
+    deadline = time.time() + 3.0
+    remaining = pids
+    while remaining and time.time() < deadline:
+        time.sleep(0.1)
+        remaining = [pid for pid in remaining if _pid_is_alive(pid)]
+
+    for pid in remaining:
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        except Exception as e:
+            logger.debug(f"SIGKILL pid={pid} failed: {e}")
+
+    return len(pids)
 
 
 def get_model_dir_from_config() -> Optional[str]:
@@ -1552,6 +1653,11 @@ class AppDelegate(NSObject):
     def _do_start(self):
         try:
             logger.info("_do_start worker=%s gateway=%s", self._worker_port, self._port)
+            n_cleaned = cleanup_residual_llama_server_processes()
+            if n_cleaned:
+                self._append_log(
+                    f"Cleaned up {n_cleaned} residual llama-server process(es) from a previous run.\n"
+                )
             if _LOG_PATH.exists():
                 _LOG_PATH.write_text("")
             self._log_file = open(_LOG_PATH, "a", encoding="utf-8")
@@ -1783,6 +1889,9 @@ class AppDelegate(NSObject):
                     proc.wait(timeout=10)
                 except subprocess.TimeoutExpired:
                     proc.kill()
+        n_cleaned = cleanup_residual_llama_server_processes()
+        if n_cleaned:
+            self._append_log(f"  Cleaned up {n_cleaned} residual llama-server process(es).\n")
         self._worker_proc = None
         self._gateway_proc = None
         if self._log_file:

--- a/apps/server/core/processors/cpp_backend.py
+++ b/apps/server/core/processors/cpp_backend.py
@@ -424,6 +424,8 @@ class CppBackendWorker:
         self._cpp_server_port = cpp_server_port or (19060 + gpu_id)
         self._cpp_server_url = f"http://127.0.0.1:{self._cpp_server_port}"
         self._cpp_process: Optional[subprocess.Popen] = None
+        self._cpp_server_bin: Optional[str] = None
+        self._cpp_process_started_at: Optional[float] = None
         # Windows Job Object (kill-on-close) — 所有 llama-server 子进程都
         # assign 到它. worker 进程一旦退出, HANDLE 随之 close, OS 会杀光
         # Job 内一切还活着的进程, 不会留下孤儿 llama-server.exe.
@@ -731,6 +733,43 @@ class CppBackendWorker:
         except Exception:
             return False
 
+    def get_cpp_runtime_info(self) -> Dict[str, Any]:
+        """Return ownership metadata for the current llama-server instance."""
+        proc = self._cpp_process
+        if proc is None or proc.poll() is not None:
+            return {
+                "active": False,
+                "pid": None,
+                "pgid": None,
+                "sid": None,
+                "port": self._cpp_server_port,
+                "binary_path": self._cpp_server_bin,
+                "started_at": self._cpp_process_started_at,
+            }
+
+        pid = proc.pid
+        pgid = None
+        sid = None
+        if not _IS_WIN:
+            try:
+                pgid = os.getpgid(pid)
+            except Exception:
+                pass
+            try:
+                sid = os.getsid(pid)
+            except Exception:
+                pass
+
+        return {
+            "active": True,
+            "pid": pid,
+            "pgid": pgid,
+            "sid": sid,
+            "port": self._cpp_server_port,
+            "binary_path": self._cpp_server_bin,
+            "started_at": self._cpp_process_started_at,
+        }
+
     def _stop_cpp_server(self) -> None:
         if self._cpp_process is None:
             return
@@ -781,6 +820,7 @@ class CppBackendWorker:
             logger.warning(f"_stop_cpp_server: {e}")
         finally:
             self._cpp_process = None
+            self._cpp_process_started_at = None
             # Defensive: 万一进程树里还有漏网的 (比如 Job 不生效的环境),
             # 按端口再扫一遍.
             try:
@@ -1301,6 +1341,7 @@ class CppBackendWorker:
                 logger.debug("VRAM probe raised; ignoring", exc_info=True)
 
         logger.info(f"Starting C++ server: {' '.join(cmd)}")
+        self._cpp_server_bin = server_bin
 
         popen_kwargs: Dict[str, Any] = dict(
             env=env, cwd=self.llamacpp_root,
@@ -1316,6 +1357,7 @@ class CppBackendWorker:
             popen_kwargs["start_new_session"] = True
 
         self._cpp_process = subprocess.Popen(cmd, **popen_kwargs)
+        self._cpp_process_started_at = time.time()
 
         # Windows: 把 llama-server 加入 kill-on-close Job Object.
         # worker 进程死了 (正常退出 / TerminateProcess / 崩溃) 都会关闭 HANDLE,

--- a/apps/server/worker.py
+++ b/apps/server/worker.py
@@ -128,6 +128,17 @@ class WorkerHealthResponse(BaseModel):
     kv_cache_length: int = 0  # 当前 LLM KV cache token 总数
 
 
+class CppRuntimeInfoResponse(BaseModel):
+    """Current owned llama-server runtime, if this worker uses the C++ backend."""
+    active: bool
+    pid: Optional[int] = None
+    pgid: Optional[int] = None
+    sid: Optional[int] = None
+    port: Optional[int] = None
+    binary_path: Optional[str] = None
+    started_at: Optional[float] = None
+
+
 class StreamingWsMessage(BaseModel):
     """Streaming WebSocket 消息（Client → Server）"""
     type: str  # "prefill" | "generate" | "complete_turn" | "close"
@@ -783,6 +794,14 @@ async def health():
         avg_inference_time_ms=avg_time,
         kv_cache_length=kv_len,
     )
+
+
+@app.get("/cpp_runtime", response_model=CppRuntimeInfoResponse)
+async def cpp_runtime():
+    """Return ownership metadata for the current llama-server instance."""
+    if worker is None or not hasattr(worker, "get_cpp_runtime_info"):
+        return CppRuntimeInfoResponse(active=False)
+    return CppRuntimeInfoResponse(**worker.get_cpp_runtime_info())
 
 
 # ========== Chat API ==========


### PR DESCRIPTION
Fixes #42

The macOS menu-bar app only tracks `gateway.py` and `worker.py` directly. If `worker.py` gets terminated before its shutdown path reaches the C++ backend cleanup, the standalone `llama-server` process can survive and keep the model resident in memory.

This switches the stop path to ownership-based cleanup:
- `worker.py` now exposes the currently owned `llama-server` runtime metadata (`pid`, `pgid`, `sid`, `port`, `binary_path`, `started_at`)
- the macOS app queries that metadata before stopping the worker
- if the owned `llama-server` is still alive after worker shutdown, the app reaps only that specific instance

The previous bundled-path + port sweep is kept as a crash-recovery fallback for leftovers from earlier abnormal exits.

Verification: `python3 -m py_compile apps/desktop/menubar_app.py apps/server/worker.py apps/server/core/processors/cpp_backend.py`