### PR TITLE
fix: avoid sliding during duplex speech and preserve TTS state across chunks

### DIFF
--- a/tools/omni/omni.cpp
+++ b/tools/omni/omni.cpp
@@ -3529,6 +3529,27 @@ bool sliding_window_enforce(struct omni_context * ctx_omni) {
     if (cache_len_before <= cfg.high_water_tokens) {
         return false;  // 未超过高水位线，不触发
     }
+
+    if (ctx_omni->duplex_mode) {
+        const int n_ctx = (ctx_omni->params != nullptr) ? ctx_omni->params->n_ctx : 0;
+        const bool generating  = ctx_omni->text_streaming;
+        const bool tts_busy    = !ctx_omni->speek_done;
+        const bool mid_speak   = !ctx_omni->slide_last_was_listen.load();
+        const bool force_slide = (n_ctx > 0 && cache_len_before >= n_ctx - 512);
+
+        if (!force_slide && (generating || tts_busy || mid_speak)) {
+            print_with_timestamp("[SW] defer sliding: cache=%d > high_water=%d "
+                                "(generating=%d tts_busy=%d mid_speak=%d)\n",
+                                cache_len_before, cfg.high_water_tokens,
+                                generating ? 1 : 0, tts_busy ? 1 : 0, mid_speak ? 1 : 0);
+            return false;
+        }
+
+        if (force_slide) {
+            print_with_timestamp("[SW] force sliding: cache=%d approaching n_ctx=%d\n",
+                                cache_len_before, n_ctx);
+        }
+    }
     
     // 🔧 [增量开发] 只有新增的 "turn" 模式才走 turn-first / unit-fallback 的新路径，
     //   其它任何已有模式（"basic"/"context"/未来扩展）继续按 unit 粒度丢，保证老行为一字不动。
@@ -6045,19 +6066,9 @@ void tts_thread_func_duplex(struct omni_context * ctx_omni, common_params *param
             
             if (ctx_omni->speek_done && llm_finish) {
                 if (ctx_omni->duplex_mode && !current_chunk_token_ids.empty()) {
-                    // 新一轮 SPEAK：重置 TTS 状态，防止上轮残留污染
-                    if (chunk_idx > 0) {
-                        chunk_idx = 0;
-                        tts_n_past = 0;
-                        audio_tokens.clear();
-                        llama_memory_t mem = llama_get_memory(ctx_omni->ctx_tts_llama);
-                        if (mem) {
-                            llama_memory_seq_rm(mem, 0, 0, -1);
-                        }
-                        ctx_omni->tts_n_past_accumulated = 0;
-                        ctx_omni->tts_all_generated_tokens.clear();
-                        ctx_omni->tts_condition_saved = false;
-                    }
+                    // duplex 的 llm_finish 只表示本次 LLM chunk 结束，未必是 turn 结束。
+                    // TTS cache 只能在真正 is_end_of_turn 后清理，否则连续 speak chunk
+                    // 会被当成新一轮，导致中途清 KV 后吞字/断字。
                     ctx_omni->speek_done = false;
                 } else if (ctx_omni->duplex_mode && accumulated_is_end_of_turn) {
                     ctx_omni->speek_done = false;
@@ -6427,6 +6438,7 @@ void tts_thread_func_duplex(struct omni_context * ctx_omni, common_params *param
                     ctx_omni->tts_n_past_accumulated = 0;
                     ctx_omni->tts_all_generated_tokens.clear();
                     ctx_omni->tts_condition_saved = false;
+                    chunk_idx = 0;
                     tts_n_past = 0;
                     audio_tokens.clear();
                     all_audio_tokens.clear();
@@ -6481,6 +6493,7 @@ void tts_thread_func_duplex(struct omni_context * ctx_omni, common_params *param
             ctx_omni->tts_n_past_accumulated = 0;
             ctx_omni->tts_all_generated_tokens.clear();
             ctx_omni->tts_condition_saved = false;
+            chunk_idx = 0;
             tts_n_past = 0;
             audio_tokens.clear();
             all_audio_tokens.clear();

--- a/tools/omni/test/test-duplex.cpp
+++ b/tools/omni/test/test-duplex.cpp
@@ -189,6 +189,9 @@ static void show_usage(const char * prog_name) {
         "  --vision-backend <m>  Vision compute backend: 'metal'(默认) 或 'coreml'(ANE)\n"
         "  --vision-coreml <p>   CoreML/ANE 模型路径 (.mlmodelc)；--vision-backend=coreml 时\n"
         "                        若未指定则默认 <llm 同级目录>/vision/coreml_minicpmo45_vit_all_f16.mlmodelc\n"
+        "  --sliding <mode>    滑窗模式: off|turn|basic|context (默认: off)\n"
+        "  --high-water <n>    滑窗触发水位 token 数 (默认: 4000)\n"
+        "  --low-water <n>     滑窗目标水位 token 数 (默认: 3500)\n"
         "  --test <prefix> <n> 指定测试数据前缀和 chunk 数量\n"
         "  --stream-interval <ms>  push frame 的最小间隔 (默认 0=背靠背压测；\n"
         "                          设为 1000 模拟真实 MiniCPM-o 流式输入)\n"
@@ -221,6 +224,9 @@ int main(int argc, char ** argv) {
     bool use_tts = true;
     bool run_test = false;
     int  stream_interval_ms = 0;  // 0 = 背靠背（压测）；真实流式建议 1000
+    std::string sliding_mode = "off";
+    int sliding_high_water = 4000;
+    int sliding_low_water = 3500;
     std::string test_prefix;
     int test_count = 0;
     std::string token2wav_device = "gpu";
@@ -244,6 +250,9 @@ int main(int argc, char ** argv) {
         else if (arg == "-ngl" && i + 1 < argc) { n_gpu_layers = std::atoi(argv[++i]); }
         else if (arg == "--no-tts") { use_tts = false; }
         else if (arg == "--omni") { media_type = 2; }
+        else if (arg == "--sliding" && i + 1 < argc) { sliding_mode = argv[++i]; }
+        else if (arg == "--high-water" && i + 1 < argc) { sliding_high_water = std::atoi(argv[++i]); }
+        else if (arg == "--low-water" && i + 1 < argc) { sliding_low_water = std::atoi(argv[++i]); }
         else if (arg == "--vision-backend" && i + 1 < argc) {
             vision_backend = argv[++i];
             if (vision_backend != "metal" && vision_backend != "coreml") {
@@ -275,6 +284,16 @@ int main(int argc, char ** argv) {
     if (llm_path.empty()) {
         fprintf(stderr, "Error: -m <llm_model_path> is required\n\n");
         show_usage(argv[0]);
+        return 1;
+    }
+    if (sliding_mode != "off" && sliding_mode != "turn" &&
+        sliding_mode != "basic" && sliding_mode != "context") {
+        fprintf(stderr, "Error: unsupported --sliding mode: %s\n", sliding_mode.c_str());
+        return 1;
+    }
+    if (sliding_high_water <= 0 || sliding_low_water <= 0 ||
+        sliding_high_water <= sliding_low_water) {
+        fprintf(stderr, "Error: sliding watermarks must satisfy high-water > low-water > 0\n");
         return 1;
     }
 
@@ -349,6 +368,11 @@ int main(int argc, char ** argv) {
     }
     ctx_omni->async = true;
     ctx_omni->ref_audio_path = ref_audio_path;
+    ctx_omni->sliding_window_config.mode = sliding_mode;
+    ctx_omni->sliding_window_config.high_water_tokens = sliding_high_water;
+    ctx_omni->sliding_window_config.low_water_tokens = sliding_low_water;
+    printf("  Sliding: %s (high=%d, low=%d)\n",
+           sliding_mode.c_str(), sliding_high_water, sliding_low_water);
 
     const std::string default_prefix = "tools/omni/assets/test_case/audio_test_case/audio_test_case_";
     duplex_test_case(ctx_omni,

--- a/tools/omni/token2wav/token2wav-impl.cpp
+++ b/tools/omni/token2wav/token2wav-impl.cpp
@@ -997,6 +997,8 @@ ggml_tensor * fmCausalConditionalCFM::build_forward_chunk_graph(ggml_context *  
 }
 }  // namespace flow_matching
 }  // namespace omni
+namespace omni {
+namespace flow_matching {
 fmCausalConv1d::fmCausalConv1d(int in_channels, int out_channels, int kernel_size) :
     in_channels_(in_channels),
     out_channels_(out_channels),


### PR DESCRIPTION
## 说明

原 PR #46（ https://github.com/tc-mb/llama.cpp-omni/pull/46 ）经过 rebase 后的版本。

### 修改内容

- **sliding_window_enforce**: duplex 模式下生成/TTS/说话中途延迟滑窗触发，仅在缓存接近 n_ctx 时强制滑动
- **tts_thread_func_duplex**: 移除 llm_finish 时过早的 TTS 状态重置，改由 is_end_of_turn 触发，解决连续 speak chunk 吞字/断字问题
- **test-duplex.cpp**: 新增 --sliding / --high-water / --low-water CLI 参数

### 与原始 PR 的差异

- 移除 commit body 中的 `Co-authored-by: Cursor` trailer
- 添加 `Signed-off-by: tc-mb <tianchi_cai@icloud.com>`
- Rebase 到 clean master（原 master 已修复历史中的 AI 署名问题）

Author: dongfengwuyishi <22373177@buaa.edu.cn>