### PR TITLE
Merge opt/perf-round4 into duplex perf benchmarking.

### DIFF
--- a/docs/development/demand.md
+++ b/docs/development/demand.md
@@ -1,0 +1,77 @@
+可以参考/cache/hanqingzhe/llama.cpp-omni/docs/development/omni-duplex-performance-analysis.md这个文档是对双工的分析，必要的也结合具体代码分析
+现在要从tools/omni/test/test-duplex.cpp的双工测试开始进行性能分析
+我现在也要对双工的各段进行分析
+1.分好阶段，现在最大的问题是大块的几个函数写的太屎山了，但我也没权限重构，各个阶段完全没分清，现在得细分一下我感觉应该有初始音频载入；whisper音频处理，clip音频处理，但这俩应该可以和在encode阶段去看他的profiling；还有llm的prefill，这个我感觉主体是llmfuncthread但还有streamdecode还有streamprefilling的各部分。TTS分为llm token+hiddenstate-tts token还有tts token-mel mel-pcm byte，这些边界都有划分出来
+2.每个阶段我需要内存，gpu显存占用，开始结束时间
+3.因为各阶段存在并行，所以必须明确打好时间表，后面可以写个python的分析脚本，用来画出个阶段的时序图，这个python的活先不做，先能让cpp代码各阶段输出明白
+
+## 实现总结
+
+本次改动从 `tools/omni/test/test-duplex.cpp` 的双工测试入口开始，新增了统一的 `[DUPLEX_PERF]` 性能日志输出。每条日志会带上阶段名、事件类型、chunk index、相对开始时间、阶段耗时、进程 RSS、CUDA 显存占用、`n_past` 和补充 detail，方便后续脚本按时间线重建各阶段并行关系。
+
+主要代码改动：
+
+1. 在 `tools/omni/omni.cpp` 中新增 `omni_perf_mark()` 和 `OmniPerfScope`，统一负责性能打点、耗时统计、RSS 读取和 CUDA 显存读取。
+2. 在 `tools/omni/omni.h` 中新增 `perf_current_chunk_index`，用于跨 LLM/TTS/T2W 异步线程关联当前双工 chunk；同时导出 `omni_perf_mark()` 方便测试入口打点。
+3. 在 `tools/omni/test/test-duplex.cpp` 中为每个 chunk 设置当前 index，并在外层 `stream_prefill()`、`stream_decode()` 调用前后输出 API 级别的开始/结束日志。
+4. 在 `stream_prefill()` 内部细分 system/ref audio 初始化、vision encode、vision KV prefill、audio encode、audio KV prefill、异步 LLM queue enqueue 等阶段。
+5. 在 `llm_thread_func()` 中为异步 LLM KV prefill 打点，记录实际写入 KV cache 的耗时和 `n_past` 增量，避免只看到测试外层 prefill 的入队时间。
+6. 在 `stream_decode()` 中细分等待异步 prefill、force listen、LLM sampling、first token、TTS enqueue 等阶段。
+7. 在 TTS 链路中区分 `llm token/hidden state -> audio token` 和 `audio token -> wav` 两段；Python Token2Wav 和 C++ Token2Wav 都会输出 `t2w.tokens_to_wav` 阶段日志。
+
+阶段边界目前覆盖：
+
+- `test.chunk_prefill_api`：测试入口外层 prefill API 耗时。
+- `stream_prefill`：单个 chunk 的 prefill 总入口。
+- `session.ref_audio_encode` / `session.ref_audio_kv_prefill`：会话初始化参考音频相关阶段。
+- `prefill.vision_encode` / `prefill.vision_kv_prefill`：图像编码和视觉 embedding 写入 KV。
+- `prefill.audio_encode` / `prefill.audio_kv_prefill`：音频编码和音频 embedding 写入 KV。
+- `prefill.enqueue_llm`：异步模式下将 embedding 放入 LLM 线程队列。
+- `llm.kv_prefill`：LLM 线程里真实执行 KV prefill 的阶段。
+- `test.chunk_decode_api` / `stream_decode`：测试入口和 decode 内部总耗时。
+- `decode.wait_llm_prefill`：decode 等待异步 LLM prefill 完成的时间。
+- `decode.llm_sample` / `decode.first_token`：LLM 采样总耗时和首 token 延迟。
+- `tts.enqueue_from_llm`：LLM 输出 token 入 TTS 队列。
+- `tts.llm_to_audio_tokens`：文本 token/hidden state 转 TTS audio token。
+- `t2w.tokens_to_wav`：TTS audio token 转 wav/pcm。
+
+## 编译和运行
+
+编译双工测试目标：
+
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DGGML_CUDA=ON
+cmake --build build --target llama-omni-test-duplex -j"$(nproc)"
+```
+
+快速验证可以先关闭 TTS，只看 prefill/decode 主链路：
+
+```bash
+./build/bin/llama-omni-test-duplex \
+  -m /path/to/MiniCPM-o-4_5-gguf/MiniCPM-o-4_5-Q4_K_M.gguf \
+  --test /path/to/chunks/audio_test_case_ 3 \
+  --ref-audio /path/to/ref_audio.wav \
+  --no-tts \
+  -ngl 99 \
+  -c 4096 \
+  2>&1 | tee duplex_perf.log
+```
+
+需要验证 TTS/T2W 阶段时去掉 `--no-tts`：
+
+```bash
+./build/bin/llama-omni-test-duplex \
+  -m /path/to/MiniCPM-o-4_5-gguf/MiniCPM-o-4_5-Q4_K_M.gguf \
+  --test /path/to/chunks/audio_test_case_ 3 \
+  --ref-audio /path/to/ref_audio.wav \
+  -ngl 99 \
+  -c 4096 \
+  -o ./tools/omni/output \
+  2>&1 | tee duplex_perf.log
+```
+
+查看性能日志：
+
+```bash
+rg '\[DUPLEX_PERF\]' duplex_perf.log
+```

--- a/docs/development/demand1.md
+++ b/docs/development/demand1.md
@@ -1,0 +1,76 @@
+# 双工性能阶段划分需求
+
+## 核心目标
+
+当前要解决的问题不是把代码重构得很细，而是把双工链路的性能日志划分成几个稳定、可解释、可对比的大阶段。阶段划分需要能回答：
+
+- 每个输入 chunk 从进入系统到产生输出，主要耗时花在哪几段。
+- 哪些时间是真正在做模型/算子计算，哪些时间只是线程同步、队列等待或 API 包络。
+- 各阶段在异步双工流水线中是否并行，以及并行时各自归属到哪个 chunk。
+
+## 划分原则
+
+1. 计算阶段保持中等粒度，不拆到每个小函数或每个算子。
+2. 队列等待、线程等待、锁等待必须从计算阶段中剥离出来，单独作为 queue/wait 类 stage。
+3. 连续发生、语义上属于同一模型阶段的 CPU 和 GPU 计算可以放在同一个 compute stage 里。
+4. 不必把 prefill 里的 prefix token eval 和后续 embedding prefill 过度拆开；只要它们共同服务于同一个 LLM prefill 阶段，可以归到同一段。
+5. TTS 进入核心 LLM 架构 prefill 前的线性变换、归一化、embedding merge 等算子，可以算入 TTS 计算阶段，不需要单独拆成很细的 profiling 项。
+6. API 外层阶段可以保留，但只能用于端到端包络分析，不能和内部 compute stage 相加。
+
+## 建议的大阶段
+
+| 类别 | 阶段 | 说明 |
+| --- | --- | --- |
+| Compute | `vision.encode` | 图像输入经过 vision encoder 得到 vision embedding。 |
+| Compute | `audio.encode` | 音频输入经过 audio encoder 得到 audio embedding。 |
+| Queue/Wait | `queue.llm.*` | `stream_prefill()` 将 embedding 交给 LLM 线程时的等待和入队。 |
+| Compute | `llm.prefill` | LLM 线程把当前 chunk 的 prefix/marker token 和 audio/vision embedding 写入 KV cache。 |
+| Wait | `wait.llm_prefill_done` | `stream_decode()` 等待异步 LLM prefill 完成。 |
+| Compute | `llm.decode` | LLM 自回归生成阶段，即循环采样并把新 token 写回 KV cache。chunk eos、unit end 这类紧随 decode 的特殊 token 注入也可以放在这一大段里。 |
+| Queue/Wait | `queue.tts.*` | LLM 输出交给 TTS 线程时的等待和入队。 |
+| Compute | `tts.infer` | LLM token + hidden state 到 TTS audio token 的整体计算，包括 projector、normalize、condition merge、TTS prefill 和 audio token decode。 |
+| Queue/Wait | `queue.t2w.*` | TTS audio token 交给 T2W 线程时的等待和入队。 |
+| Compute | `t2w.infer` | TTS audio token 到 mel/PCM/WAV 数据的模型推理部分。 |
+| IO | `t2w.write` | 如果需要单独看文件写出，可以把 WAV/PCM 落盘从 T2W 推理中剥离出来。 |
+
+## 不建议过度拆分的地方
+
+- `llm.prefill` 不必拆成 `prefix_eval`、`marker_eval`、`embedding_prefill` 多个很细阶段；除非后续确实要比较 audio KV 和 vision KV 的耗时差异。
+- `tts.infer` 不必把 projector、L2 normalize、embedding merge、TTS condition prefill、audio token decode 全部拆成独立主阶段；这些可以作为同一个 TTS 计算阶段的内部细节。
+- `llm.decode` 不必把每个 token step 单独作为主阶段；可以统计整个 token loop 的总耗时，同时在 detail 里记录生成 token 数、有效 TTS token 数和 `n_past` 增量。
+
+## 必须剥离的时间
+
+以下内容不能算进 compute stage：
+
+- 等 LLM 队列有空间。
+- 等 TTS 队列有空间。
+- TTS/T2W 后台线程等待队列数据。
+- `stream_decode()` 等待异步 prefill 完成。
+- 纯 API 包络时间，例如 `stream_prefill`、`stream_decode`、测试入口的 chunk API 时间。
+
+这些时间应该单独标成 queue/wait/api，这样后续画时间线时能看出流水线并行和阻塞点。
+
+## 日志字段要求
+
+每个 stage 至少需要输出：
+
+- `stage`：阶段名。
+- `event`：`start` / `end` / `mark`。
+- `chunk`：稳定的输入 chunk id，异步线程里不能再读全局 current chunk，必须随队列数据传递。
+- `t_rel_ms`：相对测试开始时间。
+- `duration_ms`：阶段结束时的耗时。
+- `rss_mb`：进程内存。
+- `gpu_used_mb`：GPU 显存。
+- `n_past`：LLM/TTS KV cache 相关阶段需要记录。
+- `detail`：记录 token 数、window size、backend、是否 final 等补充信息。
+
+## 统计口径
+
+后续分析时建议分三种口径：
+
+- 端到端口径：只看测试入口或 API 包络阶段，例如 `api.chunk_prefill`、`api.chunk_decode`。
+- 计算口径：只汇总 `vision.encode`、`audio.encode`、`llm.prefill`、`llm.decode`、`tts.infer`、`t2w.infer`。
+- 阻塞口径：单独看 queue/wait 阶段，用来判断是否被后台线程、队列容量或同步点卡住。
+
+这三类口径不要混加，否则会把父子阶段或并行阶段重复统计。

--- a/docs/development/duplex-perf-stage-audit.md
+++ b/docs/development/duplex-perf-stage-audit.md
@@ -1,0 +1,196 @@
+# Duplex 性能阶段划分复核报告
+
+## 结论
+
+当前分支的 `[DUPLEX_PERF]` 打点已经能把双工链路的主要时间线串起来，但它还不是严格的“计算阶段”划分。现在的 stage 里混有三类东西：
+
+- API 包络：例如 `stream_prefill`、`stream_decode`、`test.chunk_*_api`，适合看端到端调用耗时，不适合当成单一计算阶段。
+- 等待/队列：例如 `decode.wait_llm_prefill`、`prefill.enqueue_llm`、`tts.enqueue_from_llm`，这些时间主要是同步、排队、等待队列空间。
+- 真实计算：例如 `llama_decode`、`prefill_with_emb`、`prefill_with_emb_tts`、`vision_image_encode`、`audition_audio_encode`、`Token2WavSession::feed_window`，这些才是 GPU/CPU 推理或编码计算。
+
+最需要修的是：TTS/T2W 后台线程目前用全局 `perf_current_chunk_index` 取 chunk id。主线程进入下一轮 prefill 后，这个全局值会被更新，而 TTS/T2W 可能还在处理上一轮已经入队的数据，所以 TTS/T2W 日志的 `chunk=` 可能会错归属。建议把 `perf_chunk_index` 放进 `LLMOut`、`T2WOut`，随队列数据一起传递。
+
+## 代码路径口径
+
+本次复核以当前分支 `perf/duplex-benchmarking` 的改动为准，重点看：
+
+- `tools/omni/test/test-duplex.cpp`：测试入口，设置 `ctx_omni->async = true`，每个 chunk 调 `stream_prefill()` 后调 `stream_decode()`。
+- `tools/omni/omni.cpp`：性能打点、LLM/TTS/T2W 线程、prefill/decode 主体。
+- `scripts/analyze_duplex_perf.py`：后处理脚本对 stage 的解释方式。
+
+注意：当前双工测试默认是 async 路径，因此 `prefill.audio_kv_prefill` 和 `prefill.vision_kv_prefill` 主要覆盖同步路径；测试主路径里的真实 LLM KV 写入发生在 LLM 线程的 `llm.kv_prefill`。
+
+## 阶段逐项审计
+
+| stage | 当前覆盖内容 | 性质 | 问题 | 建议 |
+| --- | --- | --- | --- | --- |
+| `test.chunk_prefill_api` | 测试入口外层 `stream_prefill()` 调用 | API 包络 | 包含 encoder、入队、index=0 session 初始化等，不是单一阶段 | 保留为外层 API 指标，统计时不要和内部 stage 相加 |
+| `stream_prefill` | `stream_prefill()` 整体 | API 包络 + 少量等待 | 非双工/首轮路径里会等上一轮 TTS；async 路径里只到 LLM 入队，不包含真实 LLM KV prefill | 命名为 `api.stream_prefill` 或在报告里明确“包络” |
+| `session.ref_audio_encode` | 参考音频 APM encode | 计算 | index=0 初始化，不是普通用户 chunk | 归到 `session.init.*`，和普通 chunk 分开统计 |
+| `session.ref_audio_kv_prefill` | 参考音频写入 LLM KV cache | 计算 | 只表示会话初始化 ref audio，不代表用户音频 prefill | 归到 `session.init.*` |
+| `prefill.vision_encode` | vision encoder 生成 embedding | 计算 | 语义基本正确 | 可保留 |
+| `prefill.audio_encode` | audio encoder 生成 embedding | 计算 | 语义基本正确 | 可保留 |
+| `prefill.vision_kv_prefill` | 同步路径里 vision embedding 写入 LLM KV | 计算 | async 双工测试主路径不会走这里 | async 路径需要在 `llm_thread_func()` 内补更细 stage |
+| `prefill.audio_kv_prefill` | 同步路径里 audio embedding 写入 LLM KV | 计算 | async 双工测试主路径不会走这里 | async 路径需要在 `llm_thread_func()` 内补更细 stage |
+| `prefill.enqueue_llm` | 等 LLM 队列有空间，然后 push | 等待/队列 | 不是计算；可能包含 `cv.wait` 等待队列空间 | 拆成 `queue.llm.wait_space` 和 `queue.llm.enqueue`，或至少标注 queue stage |
+| `llm.kv_prefill` | LLM 线程取队列后写 KV cache | 计算为主 | 把 audio、vision、marker token 的 `eval_string()` 和 `prefill_with_emb()` 混在一起；一次可 drain 多个队列项，`chunk` 只取第一个 item | 拆成 `llm.prefill.marker_eval`、`llm.prefill.vision_kv`、`llm.prefill.audio_kv`，并按每个 `omni_embeds->index` 单独打点 |
+| `test.chunk_decode_api` | 测试入口外层 `stream_decode()` 调用 | API 包络 | 包含等待 prefill、force listen、LLM sampling、TTS 入队和清理 | 保留为外层 API 指标，不能和内部 stage 相加 |
+| `stream_decode` | `stream_decode()` 整体 | API 包络 | 包含等待、采样、prompt eval、队列操作、滑窗记账；不是纯 decode | 命名为 `api.stream_decode` 或报告里明确“包络” |
+| `decode.wait_llm_prefill` | 等 LLM 线程发 `g_decode_cv` | 等待 | 这个阶段常常和后台 `llm.kv_prefill` 同时发生，不能算作计算 | 保留，但归类为 wait；不要放到“LLM 计算耗时”里 |
+| `decode.force_listen` | 开局强制 listen，跳过采样 | 控制流 | 不是模型计算 | 单独归类为 policy/control |
+| `decode.llm_sample` | 从开始 LLM token loop 到整个 loop 结束 | 混合 | 里面包含真实 `llama_loop_with_hidden_and_token()`/`llama_decode`，也包含文本后处理、`tts.enqueue_from_llm` 队列等待、chunk_eos/unit_end 注入 | 拆成 `llm.decode.token_loop`、`llm.decode.inject_special_tokens`、`decode.postprocess`；TTS 入队移出该 scope |
+| `decode.first_token` | 从 `decode.llm_sample` 开始到首 token 完成 | 计算 + 首 token 延迟 | 当前 marker 发生在 `llama_loop_with_hidden_and_token()` 后，包含首 token sample 和首 token eval 写 KV | 语义可接受，但报告里说明它是“首 token 完成”，不是纯 sampler 时间 |
+| `tts.enqueue_from_llm` | 等 TTS 队列空间，然后 push `LLMOut` | 等待/队列 | 被嵌在 `decode.llm_sample` scope 内，统计相加会双算 | 保留为 queue stage，但从 `decode.llm_sample` scope 中剥离 |
+| `tts.llm_to_audio_tokens` | `generate_audio_tokens_local()` 整体 | 混合 | stage 名叫“LLM token/hidden -> audio token”，但真正的 emb_text/projector/normalize/merge 在调用前已完成；scope 内反而包含 TTS condition prefill、audio token decode、T2W 入队和文件写 token | 拆成 `tts.condition_merge`、`tts.condition_prefill`、`tts.audio_token_decode`、`tts.enqueue_t2w`、`tts.write_debug_tokens` |
+| `t2w.tokens_to_wav` | T2W window 转 wav | 计算为主/后端相关 | C++ 路径基本包 `feed_window()`，不含后续 PCM/WAV 写文件；Python 路径包 IPC 发送、等待 Python 服务、服务端推理和可能的文件输出 | 拆 `t2w.queue_wait`、`t2w.feed_window`、`t2w.write_wav`；Python 路径 detail 里继续保留 `infer_ms` |
+
+## 主要混杂点
+
+### 1. Async prefill 的真实计算没有按音频/视觉拆开
+
+在 async 双工测试中，`stream_prefill()` 只负责把 audio/vision embedding 放进 `LLMThreadInfo::queue`。真正调用 `eval_string()`、`prefill_with_emb()`、最终触发 `llama_decode()` 的地方在 `llm_thread_func()`。
+
+当前 `llm.kv_prefill` 从队列 drain 后开始，到所有 item 处理完结束。这个阶段是计算为主，但粒度太粗：
+
+- vision marker、overview、slice、audio embedding 都在同一个 stage。
+- 一次可能处理多个 `omni_embeds`，日志 `chunk` 只使用 `llm_embeds.front()->index`，后续 item 的时间会被归到第一个 chunk。
+- 无法从日志直接回答“audio KV prefill 花了多少、vision KV prefill 花了多少”。
+
+建议在 LLM 线程内部围绕实际调用拆分：
+
+- `llm.prefill.unit_marker_eval`
+- `llm.prefill.vision_overview_kv`
+- `llm.prefill.vision_slice_kv`
+- `llm.prefill.audio_kv`
+- `llm.prefill.end_marker_eval`
+
+这些 stage 应该用当前 `embeds->index`，不要用批量队列的第一个 index。
+
+### 2. `decode.llm_sample` 不是纯 LLM 采样
+
+`decode.llm_sample` 的 start 在 LLM token loop 前，end 在整个 loop 结束后。loop 中确实有真实计算：`llama_loop_with_hidden_and_token()` 会采样 token，并通过 `eval_id_with_hidden()` 写回 KV，最终进入 `llama_decode()`。
+
+但同一个 scope 里还包括：
+
+- special token 判断、字符串清洗、text_queue 推送；
+- 达到 chunk 限制时注入 `<|chunk_eos|>`，会再调用 `eval_tokens()`；
+- 每个 chunk 后注入 `</unit>`，也会调用 `eval_tokens()`；
+- `tts.enqueue_from_llm`，包括等待 TTS 队列空间和 push。
+
+所以 `decode.llm_sample` 现在是“LLM token 生成主循环 + 后处理 + TTS 入队”的混合段。它可以作为 decode 主循环耗时，但不能直接解释为纯 `llama_decode` 时间。
+
+建议改成：
+
+- `llm.decode.token_step` 或 `llm.decode.token_loop`：只包 `llama_loop_with_hidden_and_token()` 的循环。
+- `llm.decode.inject_chunk_eos`：包 chunk limit 后的 `eval_tokens()`。
+- `llm.decode.inject_unit_end`：包 `</unit>` 的 `eval_tokens()`。
+- `queue.tts.enqueue_from_llm`：放在 LLM compute scope 外。
+
+### 3. TTS stage 名字和实际范围不一致
+
+`tts.llm_to_audio_tokens` 目前包的是 `generate_audio_tokens_local()`。这个函数里确实会生成 audio token，但它不包含完整的“LLM token/hidden state -> TTS condition”过程。
+
+在双工 TTS 线程里，真正的 condition merge 在调用 `generate_audio_tokens_local()` 之前已经完成：
+
+- `tts_emb_text()`：LLM token id -> TTS text embedding。
+- `tts_projector_semantic()`：LLM hidden state -> TTS hidden dim。
+- `normalize_l2_per_token()`。
+- `merged_embeddings = llm_embeds + projected_hidden`。
+
+而 `tts.llm_to_audio_tokens` scope 内包含的是：
+
+- 添加 `text_eos_embed`、`audio_bos`；
+- `prefill_with_emb_tts()`，内部调用 TTS 模型 `llama_decode()`；
+- 多次 `sample_tts_token()`，其中又包括 head_code logits 计算、采样、audio token embedding 写回 TTS KV；
+- 推送 `T2WOut` 到 T2W 队列；
+- 写 token debug 文件。
+
+因此这个 stage 应改名或拆分。推荐拆成：
+
+- `tts.condition_merge`：LLM token/hidden -> merged embedding。
+- `tts.condition_prefill`：merged embedding -> TTS KV。
+- `tts.audio_token_decode`：TTS audio token autoregressive decode。
+- `queue.t2w.enqueue`：TTS -> T2W 入队。
+
+### 4. TTS/T2W chunk id 可能错归属
+
+后台线程里的 TTS/T2W 打点大多读取 `ctx_omni->perf_current_chunk_index.load()`。这个字段由主线程在每个 `stream_prefill(index)` 开始时更新。
+
+双工里 TTS/T2W 和下一轮 prefill/decode 会并行。当主线程已经进入 chunk N+1 时，TTS/T2W 可能仍在处理 chunk N 的 LLM 输出。此时日志会把 TTS/T2W 事件标成 N+1。
+
+建议：
+
+- `LLMOut` 增加 `int perf_chunk_index`，在 `stream_decode()` 入队 TTS 时写入当前 `perf_chunk_index`。
+- `T2WOut` 增加 `int perf_chunk_index`，由 TTS 线程转发给 T2W。
+- TTS/T2W 打点都用队列数据携带的 id，不读全局 `perf_current_chunk_index`。
+- 如果后续要分析连续说话的一轮，还应再加 `turn_id` / `utterance_id` / `tts_chunk_id`，避免“用户音频 chunk”和“TTS audio chunk”混在一个 `chunk` 字段里。
+
+### 5. `stream_*` 和内部 stage 不应该相加
+
+`stream_prefill` 包含 `prefill.audio_encode`、`prefill.vision_encode`、`prefill.enqueue_llm` 等内部阶段。`stream_decode` 包含 `decode.wait_llm_prefill`、`decode.llm_sample`、`tts.enqueue_from_llm` 等内部阶段。
+
+后处理脚本如果同时画 `stream_decode` 和 `decode.llm_sample`，它们是父子关系，不是并列关系。看时间线可以保留父子嵌套，但算总耗时时必须只选一种口径：
+
+- API 口径：只用 `test.chunk_prefill_api` / `test.chunk_decode_api` 或 `stream_prefill` / `stream_decode`。
+- 内部分解口径：只用内部 stage，并明确哪些是 wait，哪些是 compute。
+
+### 6. 后处理脚本对 stage 的分类需要调整
+
+`scripts/analyze_duplex_perf.py` 目前把 `decode.wait_llm_prefill` 放在 LLM lane，并在 `STAGE_ROWS` 里和 `decode.llm_sample`、`stream_decode` 一起统计。这样图上容易被理解成同类计算耗时。
+
+建议调整：
+
+- 增加 stage 类型字段：`api`、`wait`、`queue`、`compute`、`control`。
+- `decode.wait_llm_prefill` 放入 wait lane。
+- `prefill.enqueue_llm`、`tts.enqueue_from_llm`、后续 `queue.t2w.enqueue` 放入 queue lane。
+- `stream_prefill`、`stream_decode` 只在 API 图出现，不进入“阶段耗时均值”的 compute 表。
+- `PERF_RE` 目前只接受数字 GPU 字段；如果无 CUDA 时日志是 `gpu_used_mb=NA`，解析会丢事件。建议允许 `NA`。
+
+## 建议的新阶段表
+
+| 类别 | 建议 stage | 说明 |
+| --- | --- | --- |
+| API | `api.chunk_prefill` | 测试入口外层 prefill |
+| API | `api.chunk_decode` | 测试入口外层 decode |
+| Session init | `session.ref_audio_encode` | ref audio APM encode |
+| Session init | `session.ref_audio_kv_prefill` | ref audio 写 LLM KV |
+| Compute | `encode.vision` | vision encoder |
+| Compute | `encode.audio` | audio encoder |
+| Queue | `queue.llm.wait_space` | 等 LLM 队列空间 |
+| Queue | `queue.llm.enqueue` | 入 LLM 队列 |
+| Compute | `llm.prefill.audio_kv` | 用户音频 embedding 写 LLM KV |
+| Compute | `llm.prefill.vision_kv` | 图像 embedding 写 LLM KV |
+| Compute | `llm.prefill.marker_eval` | `<unit>`、`<image>`、`</image>` 等 marker token eval |
+| Wait | `wait.llm_prefill_done` | decode 等异步 prefill 完成 |
+| Control | `decode.force_listen` | 强制 listen 策略 |
+| Compute | `llm.decode.token_loop` | LLM 自回归 token 生成，含每步 `llama_decode` |
+| Compute | `llm.decode.inject_special_token` | chunk eos、unit end 等手动注入 |
+| Queue | `queue.tts.wait_space` | 等 TTS 队列空间 |
+| Queue | `queue.tts.enqueue` | LLMOut 入 TTS 队列 |
+| Compute | `tts.condition_merge` | LLM token/hidden -> TTS merged embedding |
+| Compute | `tts.condition_prefill` | TTS condition 写 TTS KV |
+| Compute | `tts.audio_token_decode` | TTS audio token 自回归生成 |
+| Queue | `queue.t2w.enqueue` | audio token 入 T2W 队列 |
+| Wait | `queue.t2w.wait_data` | T2W 线程等数据 |
+| Compute | `t2w.feed_window` | Token2Wav window 推理 |
+| IO | `t2w.write_wav` | PCM/WAV 文件写出 |
+
+## 优先级
+
+1. P0：给 `LLMOut` 和 `T2WOut` 增加稳定 `perf_chunk_index`，修正 TTS/T2W 的 chunk 归属。
+2. P0：把 queue/wait stage 从 compute scope 中剥离，尤其是 `tts.enqueue_from_llm` 不要嵌在 `decode.llm_sample` 里。
+3. P1：在 `llm_thread_func()` 内按 `embeds->index` 拆 `llm.prefill.audio_kv` / `llm.prefill.vision_kv` / marker eval。
+4. P1：把 `tts.llm_to_audio_tokens` 拆成 condition merge、condition prefill、audio token decode、T2W enqueue。
+5. P2：调整分析脚本的 stage 分类，避免父子 stage 相加，并兼容 `gpu_used_mb=NA`。
+
+## 当前可用口径
+
+在修正前，建议这样读现有日志：
+
+- 看端到端 chunk 延迟：用 `test.chunk_prefill_api` 和 `test.chunk_decode_api`。
+- 看 encoder：用 `prefill.audio_encode`、`prefill.vision_encode`。
+- 看 async LLM prefill：用 `llm.kv_prefill`，但只作为合并口径，不能拆 audio/vision。
+- 看等待：单独看 `decode.wait_llm_prefill`，不要算进 compute。
+- 看 LLM decode 主循环：可暂用 `decode.llm_sample`，但要知道里面混了 TTS enqueue 和 special token eval。
+- 看 TTS：`tts.llm_to_audio_tokens` 只能暂作“TTS 线程处理一次 LLMOut 的总耗时”，不能解释成完整“LLM hidden -> audio token”。
+- 看 T2W：`t2w.tokens_to_wav` 可暂作 window 处理耗时，但 Python 后端包含 IPC/服务等待，C++ 后端不含 WAV 写文件。

--- a/docs/development/duplex-thread-pipeline.md
+++ b/docs/development/duplex-thread-pipeline.md
@@ -1,0 +1,259 @@
+# 双工测试线程流水线说明
+
+## 结论
+
+`tools/omni/test/test-duplex.cpp` 的双工测试表面上是每个输入 chunk 串行执行：
+
+```text
+stream_prefill(chunk N) -> stream_decode(chunk N) -> stream_prefill(chunk N+1) -> stream_decode(chunk N+1)
+```
+
+但 `ctx_omni->async = true` 后，真正运行时不是单线程顺序链路，而是由测试主线程、LLM prefill 线程、TTS 线程和 T2W 线程组成的流水线。
+
+需要特别注意一点：当前代码里 **LLM 采样/解码不在 `llm_thread_func()` 线程里**。`llm_thread_func()` 主要负责异步 LLM prefill，也就是把 audio/vision embedding 写入 LLM KV cache。真正的 LLM decode token loop 在调用 `stream_decode()` 的测试主线程里执行。
+
+## 线程和队列
+
+### 测试主线程
+
+入口是 `duplex_test_case()`。它对每个测试音频 chunk 做：
+
+1. 设置 `perf_current_chunk_index = il`。
+2. 调 `stream_prefill(ctx_omni, aud_fname, img_fname, il)`。
+3. 调 `stream_decode(ctx_omni, "./")`。
+4. 从 `text_queue` 里读本次 decode 的文本结果。
+
+这个主线程负责同步执行：
+
+- 读取当前 chunk 的音频/图片路径。
+- 调用 audio encoder / vision encoder 生成 embedding。
+- 把 embedding 放入 LLM 队列。
+- 等待 LLM prefill 完成。
+- 执行 LLM decode token loop。
+- 每积累一段 LLM 输出，就把 `LLMOut` 放入 TTS 队列。
+
+### LLM prefill 线程
+
+线程函数是 `llm_thread_func()`，输入队列是：
+
+```text
+LLMThreadInfo::queue: omni_embeds*
+```
+
+它的作用是处理 `stream_prefill()` 送来的 audio/vision embedding：
+
+1. 等待 `llm_thread_info->queue` 非空，或等待 `need_speek=true`。
+2. 如果队列非空，取出所有 `omni_embeds`。
+3. 对每个 item 执行 `<unit>`、`<image>` 等 marker token eval，以及 audio/vision embedding prefill。
+4. 写入 LLM KV cache 后，等待 `stream_decode()` 设置 `need_speek=true`。
+5. 当队列空且 `need_speek=true` 时，设置 `prefill_done=true`，通知 `stream_decode()` 可以开始采样。
+
+所以这个线程的核心用途是：让 `stream_prefill()` 不直接阻塞在 LLM KV prefill 上，而是先把 embedding 入队，再由后台线程写 KV。
+
+### TTS 线程
+
+双工测试使用 `tts_thread_func_duplex()`。输入队列是：
+
+```text
+TTSThreadInfo::queue: LLMOut*
+```
+
+`stream_decode()` 每生成一段 LLM token，就构造 `LLMOut`：
+
+- `text`：本段文本。
+- `token_ids`：用于 TTS 的 LLM token。
+- `hidden_states`：对应 token 的 hidden state。
+- `llm_finish`：本次 decode 是否结束。
+- `is_end_of_turn`：是否需要 flush TTS/T2W 状态。
+- `perf_chunk_index`：性能日志归属的输入 chunk。
+
+TTS 线程收到后做：
+
+1. 等待 `tts_thread_info->queue` 有数据。
+2. 从队列中取出 `LLMOut`，当前实现会尽量累计队列中已有的数据，遇到 end-of-turn 边界停止。
+3. 过滤特殊 token。
+4. 做 TTS condition 构造：`tts_emb_text()`、`tts_projector_semantic()`、L2 normalize、embedding merge。
+5. 调 `generate_audio_tokens_local()` 生成 audio tokens。
+6. 把 audio tokens 通过 `T2WOut` 推给 T2W 队列。
+
+### T2W 线程
+
+入口是 `t2w_thread_func()`，根据配置选择：
+
+- `t2w_thread_func_cpp()`：C++ Token2Wav。
+- `t2w_thread_func_python()`：Python Token2Wav 服务。
+
+输入队列是：
+
+```text
+T2WThreadInfo::queue: T2WOut*
+```
+
+它负责把 TTS audio tokens 变成音频：
+
+1. 等待 T2W 队列有数据。
+2. 把收到的 audio tokens 累积到 `token_buffer`。
+3. 按 Token2Wav 滑窗处理，C++ 路径窗口大小是 `25 + 3`，也就是 25 个主 token 加 3 个 lookahead。
+4. 调 Token2Wav 推理。
+5. 写出 WAV/PCM 文件。
+
+## 双工流水线顺序
+
+对一个普通输入 chunk，逻辑顺序可以理解为：
+
+```text
+测试主线程:
+  audio/vision encode
+  -> enqueue LLM prefill
+  -> stream_decode 等待 prefill_done
+  -> LLM decode token loop
+  -> 每 10 个有效 TTS token enqueue TTS
+
+LLM prefill 线程:
+  wait LLM queue
+  -> LLM KV prefill
+  -> 通知 prefill_done
+
+TTS 线程:
+  wait TTS queue
+  -> LLM token/hidden -> TTS condition
+  -> TTS audio token decode
+  -> enqueue T2W
+
+T2W 线程:
+  wait T2W queue
+  -> Token2Wav infer
+  -> write wav
+```
+
+## 谁和谁能并行
+
+### 不能并行的部分
+
+同一个输入 chunk 内，下面这些关系是串行的：
+
+- `audio.encode` / `vision.encode` 必须先完成，之后才能把 embedding 入 LLM 队列。
+- `llm.prefill` 必须先完成，`stream_decode()` 才会开始 LLM 采样。
+- 同一个 `llama_context` 上的 prefill 和 decode 不能真正同时跑；代码用等待和 `llama_mtx` 保证顺序。
+
+所以同一个 chunk 的主链路不是：
+
+```text
+encode || llm.prefill || llm.decode
+```
+
+而是：
+
+```text
+encode -> llm.prefill -> llm.decode
+```
+
+### 能并行的部分
+
+真正的流水线并行发生在生成侧和下一轮输入侧：
+
+- `stream_decode()` 的 LLM token loop 可以一边继续采样后续 token，一边让 TTS 线程处理已经入队的前一段 token。
+- TTS 线程生成 audio tokens 后，T2W 线程可以一边把前一批 audio tokens 转音频，一边等待/接收 TTS 的后续 audio tokens。
+- `stream_decode()` 返回后，测试主线程会进入下一个输入 chunk 的 `stream_prefill()`；此时上一个 chunk 的 TTS/T2W 可能还没完全处理完，所以“下一秒音频的 encode/prefill/decode”和“上一段回复的 TTS/T2W”可以并行。
+- 如果 TTS/T2W 队列还有积压，测试结束后还会等待 `omni_tts_queues_empty()` 连续空闲一段时间，再停线程。
+
+### 会限制并行的地方
+
+TTS 队列容量当前是 `TTSThreadInfo(1)`。这意味着 `stream_decode()` 往 TTS 队列推 `LLMOut` 时，如果 TTS 线程还没取走上一段，`tts.enqueue_from_llm` 会阻塞。
+
+因此 LLM decode 和 TTS 的并行不是无限制的。它更像一个带背压的小流水线：
+
+```text
+LLM decode chunklet -> TTS queue(size=1) -> TTS infer -> T2W queue -> T2W infer
+```
+
+如果 TTS 比 LLM decode 慢，LLM decode 会在入队 TTS 时被卡住。
+
+## LLM 固定数量 token 交给 TTS 的逻辑
+
+`stream_decode()` 里有：
+
+```text
+step_size = 10
+```
+
+内层 token loop 的条件是收集够 `step_size` 个“有效 TTS token”，或者遇到结束条件：
+
+- 每次调用 `llama_loop_with_hidden_and_token()` 采样一个 LLM token，并拿到 hidden state。
+- 只有 `is_valid_tts_token(sampled_token)` 为 true 的 token 才进入 `chunk_token_ids` 和 `chunk_hidden_states`。
+- `jl` 只统计有效 TTS token，不统计 `<think>`、`<|speak|>`、`<|listen|>`、`<|chunk_eos|>` 等特殊 token。
+- 收集到 10 个有效 TTS token 后，构造一个 `LLMOut` 推给 TTS 线程。
+- 如果遇到 `chunk_eos`、`listen`、`turn_eos`、`max_new_speak_tokens_per_chunk` 等结束/切分条件，也会提前结束当前段并推给 TTS。
+
+这个 10-token 小段不是输入音频 chunk，而是 LLM 输出内部的一个 TTS chunklet。它的作用是降低首响延迟：不必等整段回答全部生成完，TTS 可以先处理前 10 个有效 token。
+
+## 阶段归属建议
+
+按照“不要拆太碎，但排除等待”的口径，可以这样归类：
+
+| 代码行为 | 建议阶段 | 类型 |
+| --- | --- | --- |
+| 测试入口调用 `stream_prefill()` | `api.chunk_prefill` | API 包络 |
+| audio/vision encoder 生成 embedding | `audio.encode` / `vision.encode` | Compute |
+| 等 LLM queue 空间并 push `omni_embeds` | `queue.llm.enqueue` | Queue/Wait |
+| LLM 线程执行 marker eval + embedding prefill | `llm.prefill` | Compute |
+| `stream_decode()` 等 `prefill_done` | `wait.llm_prefill_done` | Wait |
+| LLM token loop，含每步采样和写 KV | `llm.decode` | Compute |
+| 达到 chunk limit 后注入 `chunk_eos`、每段后注入 `</unit>` | 可并入 `llm.decode` | Compute |
+| 构造 `LLMOut` 前的文本清洗、特殊 token 处理 | `llm.decode.postprocess` 或并入 `llm.decode` detail | CPU/Postprocess |
+| 等 TTS queue 空间并 push `LLMOut` | `queue.tts.enqueue` | Queue/Wait |
+| TTS 线程等 `LLMOut` | `queue.tts.wait_data` | Wait |
+| token/hidden 到 merged TTS condition，再到 audio tokens | `tts.infer` | Compute |
+| 等 T2W queue 空间并 push `T2WOut` | `queue.t2w.enqueue` | Queue/Wait |
+| T2W 线程等 audio tokens | `queue.t2w.wait_data` | Wait |
+| Token2Wav 模型推理 | `t2w.infer` | Compute |
+| WAV/PCM 落盘 | `t2w.write` | IO |
+
+当前 profiling 已按这个口径改成：
+
+- API 包络使用 `api.chunk_prefill`、`api.chunk_decode`、`api.stream_prefill`、`api.stream_decode`。
+- LLM compute 使用 `llm.prefill` 和 `llm.decode`；完整 decode loop 包络保留为 `api.llm_decode_loop`。
+- LLM 到 TTS 的背压拆成 `queue.tts.wait_space` 和 `queue.tts.enqueue`。
+- TTS compute 使用 `tts.infer`，T2W compute 使用 `t2w.infer`，C++ WAV 落盘使用 `t2w.write`。
+
+## 性能分析时的读法
+
+建议把一轮双工测试拆成三条时间线看：
+
+1. 输入侧主链路：`audio/vision encode -> queue.llm -> llm.prefill -> wait.llm_prefill_done -> llm.decode`。
+2. 输出侧语音链路：`queue.tts -> tts.infer -> queue.t2w -> t2w.infer -> t2w.write`。
+3. 跨 chunk 并行：chunk N 的 TTS/T2W 可能和 chunk N+1 的 encode/prefill/decode 同时发生。
+
+如果只问“一个完整周期”，可以把它定义成：
+
+```text
+输入 1 秒音频
+-> audio/vision encode
+-> LLM prefill
+-> LLM decode 生成 token
+-> 每 10 个有效 token 交给 TTS
+-> TTS 生成 audio tokens
+-> T2W 生成 wav/pcm
+```
+
+但做性能统计时不要把这些阶段简单相加，因为其中一部分会并行，另一部分是父子包络关系。正确做法是用时间线看重叠，用 compute/wait/queue 分类看瓶颈。
+
+运行命令
+ 用这个完整命令即可测 Q4_K_M + 全部 36 个 duplex omni chunk：
+
+  cd /cache/hanqingzhe/llama.cpp-omni
+  ./build/bin/llama-omni-test-duplex \
+    -m /cache/hanqingzhe/o45-gguf/MiniCPM-o-4_5-Q4_K_M.gguf \
+    --omni \
+    --test /cache/hanqingzhe/llama.cpp-omni/tools/omni/assets/test_case/duplex_omni_test_case/duplex_omni_test_case_ 36 \
+    --ref-audio /cache/hanqingzhe/llama.cpp-omni/tools/omni/assets/default_ref_audio/default_ref_audio.wav \
+    -ngl 99 \
+    -c 4096 \
+    -o /cache/hanqingzhe/llama.cpp-omni/tools/omni/output/duplex_q4km_full \
+    2>&1 | tee duplex_q4km_full.log
+
+  跑完分析：
+
+  python scripts/analyze_duplex_perf.py \
+    --log duplex_q4km_full.log \
+    --out-dir docs/development/perf-duplex-q4km-full

--- a/scripts/analyze_duplex_perf.py
+++ b/scripts/analyze_duplex_perf.py
@@ -1,0 +1,893 @@
+#!/usr/bin/env python3
+"""Parse duplex omni perf logs and generate SVG/CSV/Markdown assets.
+
+This script uses only the Python standard library so it can run on the benchmark
+host without creating a conda environment.
+"""
+
+from __future__ import annotations
+
+import argparse
+import bisect
+import csv
+import html
+import re
+import statistics
+from collections import Counter, defaultdict
+from pathlib import Path
+
+PERF_RE = re.compile(
+    r"(?P<wall>\d{2}:\d{2}:\d{2}\.\d{3}) "
+    r"\[DUPLEX_PERF\] (?:seq=(?P<seq>\d+) )?stage=(?P<stage>\S+) event=(?P<event>\S+) "
+    r"chunk=(?P<chunk>-?\d+) t_ms=(?P<t_ms>[-\d.]+) dur_ms=(?P<dur_ms>[-\d.]+) "
+    r"rss_mb=(?P<rss_mb>[-\d.]+|NA) gpu_used_mb=(?P<gpu_used_mb>[-\d.]+|NA) "
+    r"gpu_total_mb=(?P<gpu_total_mb>[-\d.]+|NA) n_past=(?P<n_past>-?\d+) "
+    r'detail="(?P<detail>[^"]*)"'
+)
+GPU_SAMPLE_RE = re.compile(
+    r"(?P<wall>\d{2}:\d{2}:\d{2}\.\d{3}) "
+    r"\[DUPLEX_GPU\] sample_id=(?P<sample_id>\d+) t_ms=(?P<t_ms>[-\d.]+) "
+    r"device=(?P<device>\d+) sm_util_pct=(?P<sm_util_pct>[-\d.]+|NA) "
+    r"mem_util_pct=(?P<mem_util_pct>[-\d.]+|NA) gpu_used_mb=(?P<gpu_used_mb>[-\d.]+|NA) "
+    r"gpu_total_mb=(?P<gpu_total_mb>[-\d.]+|NA) power_w=(?P<power_w>[-\d.]+|NA) "
+    r"temp_c=(?P<temp_c>[-\d.]+|NA) graphics_clock_mhz=(?P<graphics_clock_mhz>[-\d.]+|NA) "
+    r"mem_clock_mhz=(?P<mem_clock_mhz>[-\d.]+|NA)"
+)
+GPU_STATUS_RE = re.compile(
+    r"(?P<wall>\d{2}:\d{2}:\d{2}\.\d{3}) "
+    r'\[DUPLEX_GPU\] event=(?P<event>\S+) reason="(?P<reason>[^"]*)"'
+)
+CHUNK_RE = re.compile(r"prefill:\s*([0-9.]+) s \| decode:\s*([0-9.]+) s \| total:\s*([0-9.]+) s \| n_past:\s*(\d+)")
+OPT4_CHUNK_RE = re.compile(
+    r"--- Chunk (?P<seq>\d+)/(?P<count>\d+) --- "
+    r"prefill (?P<prefill_ms>[0-9.]+)ms \| decode (?P<decode_ms>[0-9.]+)ms \| "
+    r"e2e (?P<e2e_ms>[0-9.]+)ms \| n_past (?P<n_past>\d+) \| "
+    r"<\|(?P<decision>speak|listen)\|>(?: \"(?P<text>[^\"]*)\")?"
+)
+DECISION_RE = re.compile(r"决策:\s*<\|(speak|listen)\|>(?:\s*→\s*\"([^\"]*)\")?")
+
+STAGE_ROWS = [
+    ("vision.encode", "#4c78a8"),
+    ("audio.encode", "#72b7b2"),
+    ("queue.llm.wait_space", "#c7e9c0"),
+    ("queue.llm.enqueue", "#74c476"),
+    ("llm.prefill", "#b279a2"),
+    ("wait.llm_prefill_done", "#f58518"),
+    ("llm.decode", "#e45756"),
+    ("queue.tts.wait_space", "#bae4b3"),
+    ("queue.tts.enqueue", "#8cd17d"),
+    ("tts.infer", "#54a24b"),
+    ("queue.t2w.enqueue", "#9ecae9"),
+    ("t2w.infer", "#3182bd"),
+    ("t2w.write", "#9e9ac8"),
+]
+
+TOKEN_SPEED_STAGES = ["llm.prefill", "llm.decode", "tts.infer"]
+
+
+def esc(value: object) -> str:
+    return html.escape(str(value), quote=True)
+
+
+def avg(values):
+    values = list(values)
+    return statistics.mean(values) if values else 0.0
+
+
+def pctl(values, pct):
+    values = sorted(values)
+    if not values:
+        return 0.0
+    if len(values) == 1:
+        return values[0]
+    pos = (len(values) - 1) * pct
+    lo = int(pos)
+    hi = min(lo + 1, len(values) - 1)
+    frac = pos - lo
+    return values[lo] * (1 - frac) + values[hi] * frac
+
+
+def parse_metric(value: str) -> float:
+    return -1.0 if value == "NA" else float(value)
+
+
+def parse_detail(detail: str):
+    result = {}
+    for part in detail.split(","):
+        if "=" not in part:
+            continue
+        key, value = part.split("=", 1)
+        result[key.strip()] = value.strip()
+    return result
+
+
+def detail_int(detail, key, default=0):
+    try:
+        return int(detail.get(key, default))
+    except (TypeError, ValueError):
+        return default
+
+
+def token_count_for_event(event):
+    detail = parse_detail(event["detail"])
+    if "tokens" in detail:
+        return detail_int(detail, "tokens", -1)
+    if event["stage"] == "tts.infer":
+        return detail_int(detail, "audio_tokens_generated", -1)
+    if event["stage"] == "llm.prefill":
+        # Old logs did not have a dedicated token field; n_past_delta is the
+        # closest available KV-token proxy when no sliding happened.
+        return detail_int(detail, "n_past_delta", -1)
+    if event["stage"] == "llm.decode":
+        return detail_int(detail, "tokens", -1)
+    return -1
+
+
+def parse_log(path: Path, gpu_log_path=None):
+    text = path.read_text(errors="replace")
+    gpu_text = ""
+    if gpu_log_path and gpu_log_path != path:
+        gpu_text = gpu_log_path.read_text(errors="replace")
+    combined_gpu_text = text + "\n" + gpu_text
+
+    events = []
+    for match in PERF_RE.finditer(text):
+        group = match.groupdict()
+        events.append({
+            "wall": group["wall"],
+            "seq": int(group["seq"]) if group.get("seq") is not None else -1,
+            "stage": group["stage"],
+            "event": group["event"],
+            "chunk": int(group["chunk"]),
+            "t_ms": float(group["t_ms"]),
+            "dur_ms": float(group["dur_ms"]),
+            "rss_mb": parse_metric(group["rss_mb"]),
+            "gpu_used_mb": parse_metric(group["gpu_used_mb"]),
+            "gpu_total_mb": parse_metric(group["gpu_total_mb"]),
+            "n_past": int(group["n_past"]),
+            "detail": group["detail"],
+        })
+
+    gpu_samples = []
+    for match in GPU_SAMPLE_RE.finditer(combined_gpu_text):
+        group = match.groupdict()
+        gpu_samples.append({
+            "wall": group["wall"],
+            "sample_id": int(group["sample_id"]),
+            "t_ms": float(group["t_ms"]),
+            "device": int(group["device"]),
+            "sm_util_pct": parse_metric(group["sm_util_pct"]),
+            "mem_util_pct": parse_metric(group["mem_util_pct"]),
+            "gpu_used_mb": parse_metric(group["gpu_used_mb"]),
+            "gpu_total_mb": parse_metric(group["gpu_total_mb"]),
+            "power_w": parse_metric(group["power_w"]),
+            "temp_c": parse_metric(group["temp_c"]),
+            "graphics_clock_mhz": parse_metric(group["graphics_clock_mhz"]),
+            "mem_clock_mhz": parse_metric(group["mem_clock_mhz"]),
+        })
+    gpu_samples.sort(key=lambda row: (row["device"], row["t_ms"], row["sample_id"]))
+
+    gpu_statuses = []
+    for match in GPU_STATUS_RE.finditer(combined_gpu_text):
+        group = match.groupdict()
+        gpu_statuses.append({
+            "wall": group["wall"],
+            "event": group["event"],
+            "reason": group["reason"],
+        })
+
+    chunks = []
+    for match in OPT4_CHUNK_RE.finditer(text):
+        group = match.groupdict()
+        chunks.append({
+            "chunk": int(group["seq"]),
+            "prefill_ms": float(group["prefill_ms"]),
+            "decode_ms": float(group["decode_ms"]),
+            "total_ms": float(group["e2e_ms"]),
+            "n_past": int(group["n_past"]),
+            "decision": group["decision"],
+            "text": group["text"] or "",
+        })
+    if not chunks:
+        decisions = list(DECISION_RE.finditer(text))
+        for idx, match in enumerate(CHUNK_RE.finditer(text)):
+            decision = decisions[idx].group(1) if idx < len(decisions) else ""
+            decision_text = decisions[idx].group(2) if idx < len(decisions) and decisions[idx].group(2) else ""
+            chunks.append({
+                "chunk": idx,
+                "prefill_ms": float(match.group(1)) * 1000.0,
+                "decode_ms": float(match.group(2)) * 1000.0,
+                "total_ms": float(match.group(3)) * 1000.0,
+                "n_past": int(match.group(4)),
+                "decision": decision,
+                "text": decision_text,
+            })
+    return text, events, chunks, gpu_samples, gpu_statuses
+
+
+def stage_stats(events):
+    grouped = defaultdict(list)
+    for event in events:
+        if event["event"] == "end" and event["dur_ms"] >= 0:
+            grouped[event["stage"]].append(event["dur_ms"])
+    stats = {}
+    for stage, values in grouped.items():
+        stats[stage] = {
+            "n": len(values),
+            "total": sum(values),
+            "avg": avg(values),
+            "p50": statistics.median(values),
+            "p90": pctl(values, 0.90),
+            "min": min(values),
+            "max": max(values),
+        }
+    return stats
+
+
+def stage_token_stats(events):
+    grouped = defaultdict(lambda: {
+        "n": 0,
+        "tokens": 0,
+        "total_ms": 0.0,
+        "event_tokens_per_s": [],
+        "event_ms_per_token": [],
+    })
+    for event in events:
+        if event["stage"] not in TOKEN_SPEED_STAGES or event["event"] != "end" or event["dur_ms"] < 0:
+            continue
+        tokens = token_count_for_event(event)
+        if tokens < 0:
+            continue
+        row = grouped[event["stage"]]
+        row["n"] += 1
+        row["tokens"] += tokens
+        row["total_ms"] += event["dur_ms"]
+        if tokens > 0 and event["dur_ms"] > 0:
+            row["event_tokens_per_s"].append(tokens * 1000.0 / event["dur_ms"])
+            row["event_ms_per_token"].append(event["dur_ms"] / tokens)
+
+    stats = {}
+    for stage, row in grouped.items():
+        tokens = row["tokens"]
+        total_ms = row["total_ms"]
+        stats[stage] = {
+            "n": row["n"],
+            "tokens": tokens,
+            "total_ms": total_ms,
+            "tokens_per_s": tokens * 1000.0 / total_ms if tokens > 0 and total_ms > 0 else 0.0,
+            "ms_per_token": total_ms / tokens if tokens > 0 else 0.0,
+            "avg_event_tokens_per_s": avg(row["event_tokens_per_s"]),
+            "p50_event_tokens_per_s": statistics.median(row["event_tokens_per_s"]) if row["event_tokens_per_s"] else 0.0,
+            "avg_event_ms_per_token": avg(row["event_ms_per_token"]),
+        }
+    return stats
+
+
+def tts_token_rows(events):
+    rows = []
+    for event in sorted(events, key=lambda item: (item["t_ms"], item.get("seq", -1))):
+        if event["stage"] != "tts.infer" or event["event"] != "end":
+            continue
+        detail = parse_detail(event["detail"])
+        def to_int(key, default=0):
+            try:
+                return int(detail.get(key, default))
+            except ValueError:
+                return default
+        llm_tokens = to_int("llm_tokens")
+        filtered_llm_tokens = to_int("filtered_llm_tokens", llm_tokens)
+        condition_tokens = to_int("condition_tokens")
+        compute_tokens = to_int("compute_tokens", to_int("tokens", -1))
+        audio_tokens = to_int("audio_tokens_generated", -1)
+        if compute_tokens < 0:
+            compute_tokens = audio_tokens
+        rows.append({
+            "chunk": event["chunk"],
+            "tts_chunk": to_int("tts_chunk", event["chunk"]),
+            "dur_ms": event["dur_ms"],
+            "llm_tokens": llm_tokens,
+            "filtered_llm_tokens": filtered_llm_tokens,
+            "condition_tokens": condition_tokens,
+            "compute_tokens": compute_tokens,
+            "audio_tokens_generated": audio_tokens,
+            "is_end_of_turn": to_int("is_end_of_turn"),
+            "flush_only": to_int("flush_only"),
+            "compute_tokens_per_s": compute_tokens * 1000.0 / event["dur_ms"] if compute_tokens >= 0 and event["dur_ms"] > 0 else 0.0,
+            "audio_tokens_per_ms": audio_tokens / event["dur_ms"] if audio_tokens >= 0 and event["dur_ms"] > 0 else 0.0,
+            "audio_tokens_per_s": audio_tokens * 1000.0 / event["dur_ms"] if audio_tokens >= 0 and event["dur_ms"] > 0 else 0.0,
+            "ms_per_audio_token": event["dur_ms"] / audio_tokens if audio_tokens > 0 else 0.0,
+            "has_audio_token_detail": int(audio_tokens >= 0),
+        })
+    return rows
+
+
+def build_stage_intervals(events):
+    starts = defaultdict(list)
+    intervals = []
+    for event in sorted(events, key=lambda item: (item["t_ms"], item.get("seq", -1))):
+        key = (event["stage"], event["chunk"])
+        if event["event"] == "start":
+            starts[key].append(event)
+        elif event["event"] == "end" and event["dur_ms"] >= 0:
+            start = starts[key].pop(0) if starts[key] else None
+            begin = start["t_ms"] if start else event["t_ms"] - event["dur_ms"]
+            finish = event["t_ms"]
+            if finish >= begin:
+                intervals.append({
+                    "stage": event["stage"],
+                    "chunk": event["chunk"],
+                    "begin_ms": begin,
+                    "end_ms": finish,
+                    "duration_ms": finish - begin,
+                })
+    return intervals
+
+
+def nearest_sample(samples, times, target):
+    if not samples:
+        return None
+    idx = bisect.bisect_left(times, target)
+    candidates = []
+    if idx < len(samples):
+        candidates.append(samples[idx])
+    if idx > 0:
+        candidates.append(samples[idx - 1])
+    return min(candidates, key=lambda sample: abs(sample["t_ms"] - target)) if candidates else None
+
+
+def stage_gpu_stats(intervals, gpu_samples):
+    by_device = defaultdict(list)
+    for sample in gpu_samples:
+        by_device[sample["device"]].append(sample)
+    for samples in by_device.values():
+        samples.sort(key=lambda sample: sample["t_ms"])
+
+    grouped = defaultdict(lambda: {
+        "n_intervals": 0,
+        "n_samples": 0,
+        "total_ms": 0.0,
+        "estimated_samples": 0,
+        "sm": [],
+        "mem": [],
+        "power": [],
+    })
+
+    for interval in intervals:
+        for device, samples in by_device.items():
+            times = [sample["t_ms"] for sample in samples]
+            lo = bisect.bisect_left(times, interval["begin_ms"])
+            hi = bisect.bisect_right(times, interval["end_ms"])
+            selected = samples[lo:hi]
+            estimated = False
+            if not selected:
+                sample = nearest_sample(samples, times, (interval["begin_ms"] + interval["end_ms"]) / 2.0)
+                selected = [sample] if sample else []
+                estimated = bool(sample)
+
+            row = grouped[(interval["stage"], device)]
+            row["n_intervals"] += 1
+            row["total_ms"] += interval["duration_ms"]
+            if estimated:
+                row["estimated_samples"] += 1
+            row["n_samples"] += len(selected)
+            row["sm"].extend(sample["sm_util_pct"] for sample in selected if sample["sm_util_pct"] >= 0)
+            row["mem"].extend(sample["mem_util_pct"] for sample in selected if sample["mem_util_pct"] >= 0)
+            row["power"].extend(sample["power_w"] for sample in selected if sample["power_w"] >= 0)
+
+    stats = {}
+    for (stage, device), row in grouped.items():
+        avg_sm = avg(row["sm"])
+        stats[(stage, device)] = {
+            "stage": stage,
+            "device": device,
+            "n_intervals": row["n_intervals"],
+            "n_samples": row["n_samples"],
+            "total_ms": row["total_ms"],
+            "avg_sm_util_pct": avg_sm,
+            "p50_sm_util_pct": pctl(row["sm"], 0.50),
+            "p90_sm_util_pct": pctl(row["sm"], 0.90),
+            "max_sm_util_pct": max(row["sm"]) if row["sm"] else 0.0,
+            "avg_mem_util_pct": avg(row["mem"]),
+            "max_mem_util_pct": max(row["mem"]) if row["mem"] else 0.0,
+            "avg_power_w": avg(row["power"]),
+            "max_power_w": max(row["power"]) if row["power"] else 0.0,
+            "estimated_samples": row["estimated_samples"],
+            "stage_gpu_busy_ms": row["total_ms"] * avg_sm / 100.0,
+        }
+    return stats
+
+
+def svg_base(width, height, body):
+    return "\n".join([
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}">',
+        "<style>",
+        "text{font-family:Arial,'Noto Sans CJK SC','Microsoft YaHei',sans-serif;fill:#172033}",
+        ".title{font-size:22px;font-weight:700}.subtitle{font-size:13px;fill:#5b6475}",
+        ".label{font-size:13px}.small{font-size:11px;fill:#5b6475}.tiny{font-size:10px;fill:#5b6475}",
+        ".lane{fill:#f6f8fb;stroke:#d6dde8}.box{rx:12;ry:12;stroke:#29415f;stroke-width:1.2}",
+        "</style>",
+        *body,
+        "</svg>",
+        "",
+    ])
+
+
+def write(path: Path, content: str):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def pipeline_svg(path: Path):
+    body = [
+        '<rect width="1180" height="640" fill="#ffffff"/>',
+        '<text x="40" y="42" class="title">Omni Duplex 实测流水线</text>',
+        '<text x="40" y="66" class="subtitle">主线程按 chunk 串行推进；LLM KV prefill、TTS 和 T2W 在后台线程中异步执行</text>',
+    ]
+    lanes = [("主线程 / API", 110), ("LLM 线程", 235), ("TTS 线程", 360), ("T2W 线程", 485)]
+    for lane, y in lanes:
+        body += [f'<rect x="30" y="{y - 42}" width="1120" height="92" class="lane" rx="14"/>', f'<text x="48" y="{y - 14}" class="label" font-weight="700">{esc(lane)}</text>']
+    boxes = [
+        (170, 96, 160, 48, "api.stream_prefill", "vision + audio encode", "#dcecff"),
+        (365, 96, 150, 48, "queue.llm", "enqueue embedding", "#d8f3dc"),
+        (560, 96, 150, 48, "api.stream_decode", "wait + sample", "#fff2cc"),
+        (760, 96, 150, 48, "decision", "LISTEN / SPEAK", "#ffe4e6"),
+        (365, 222, 165, 48, "llm.prefill", "write KV cache", "#e6dcff"),
+        (560, 222, 165, 48, "llm.decode", "token loop", "#ffd6a5"),
+        (760, 347, 180, 48, "tts.infer", "token/hidden -> audio token", "#d0f4de"),
+        (760, 472, 180, 48, "t2w.infer", "audio tokens -> wav", "#cde7ff"),
+    ]
+    for x, y, w, h, title, sub, color in boxes:
+        body += [f'<rect x="{x}" y="{y}" width="{w}" height="{h}" fill="{color}" class="box"/>', f'<text x="{x + 12}" y="{y + 20}" class="label" font-weight="700">{esc(title)}</text>', f'<text x="{x + 12}" y="{y + 38}" class="small">{esc(sub)}</text>']
+    body.append('<defs><marker id="arrow" markerWidth="10" markerHeight="8" refX="9" refY="4" orient="auto"><path d="M0,0 L10,4 L0,8 Z" fill="#29415f"/></marker></defs>')
+    for x1, y1, x2, y2 in [(330,120,365,120),(515,120,560,120),(710,120,760,120),(440,144,440,222),(530,246,560,246),(635,222,635,144),(835,144,835,347),(850,395,850,472),(940,496,1040,496)]:
+        body.append(f'<line x1="{x1}" y1="{y1}" x2="{x2}" y2="{y2}" stroke="#29415f" stroke-width="1.8" marker-end="url(#arrow)"/>')
+    for x, text in [(60, "index=0 是 session/ref audio 初始化"), (420, "decode 包含等待异步 KV prefill"), (795, "TTS/T2W 与下一轮 chunk 重叠")]:
+        body.append(f'<text x="{x}" y="585" class="small">• {esc(text)}</text>')
+    write(path, svg_base(1180, 640, body))
+
+
+def stage_latency_svg(path: Path, stats):
+    width = 1080
+    left, top, bar_w, row_h = 270, 88, 650, 42
+    chart_bottom = top + len(STAGE_ROWS) * row_h + 10
+    height = max(470, chart_bottom + 50)
+    max_value = max([stats.get(stage, {}).get("avg", 0) for stage, _ in STAGE_ROWS] + [260])
+    body = [f'<rect width="1080" height="{height}" fill="#ffffff"/>', '<text x="40" y="42" class="title">阶段耗时均值</text>', '<text x="40" y="66" class="subtitle">单位 ms；横条为平均值，灰线为 p50 到 max</text>']
+    for tick in range(0, 301, 50):
+        x = left + tick / max_value * bar_w
+        body += [f'<line x1="{x:.1f}" y1="78" x2="{x:.1f}" y2="{chart_bottom}" stroke="#edf1f7"/>', f'<text x="{x - 8:.1f}" y="{chart_bottom + 19}" class="tiny">{tick}</text>']
+    for idx, (stage, color) in enumerate(STAGE_ROWS):
+        y = top + idx * row_h
+        row = stats.get(stage, {})
+        avgv, p50, maxv, n = row.get("avg", 0), row.get("p50", 0), row.get("max", 0), int(row.get("n", 0))
+        w = avgv / max_value * bar_w
+        p50x, maxx = left + p50 / max_value * bar_w, left + maxv / max_value * bar_w
+        body += [f'<text x="40" y="{y + 18}" class="label">{esc(stage)}</text>', f'<rect x="{left}" y="{y}" width="{w:.1f}" height="22" fill="{color}" rx="5"/>', f'<line x1="{p50x:.1f}" y1="{y + 31}" x2="{maxx:.1f}" y2="{y + 31}" stroke="#7f8897" stroke-width="2"/>', f'<circle cx="{p50x:.1f}" cy="{y + 31}" r="3" fill="#7f8897"/>', f'<circle cx="{maxx:.1f}" cy="{y + 31}" r="3" fill="#7f8897"/>', f'<text x="{left + w + 8:.1f}" y="{y + 16}" class="small">{avgv:.1f} ms</text>', f'<text x="940" y="{y + 18}" class="tiny">n={n} p50={p50:.1f} max={maxv:.1f}</text>']
+    write(path, svg_base(width, height, body))
+
+
+def chunk_latency_svg(path: Path, chunks):
+    width, height = 1180, 560
+    left, top, chart_w, chart_h = 70, 90, 1030, 350
+    max_total = max([c["total_ms"] for c in chunks] + [1])
+    max_n_past = max([c["n_past"] for c in chunks] + [1])
+    bar_gap = 3
+    bar_w = max(6, (chart_w - bar_gap * max(0, len(chunks) - 1)) / max(1, len(chunks)))
+    body = ['<rect width="1180" height="560" fill="#ffffff"/>', '<text x="40" y="42" class="title">逐 chunk API 延迟</text>', '<text x="40" y="66" class="subtitle">蓝色=prefill，橙色=decode；圆点表示决策，绿=SPEAK，灰=LISTEN；紫线=n_past</text>']
+    for tick in range(0, int(max_total) + 51, 50):
+        y = top + chart_h - tick / max_total * chart_h
+        body += [f'<line x1="{left}" y1="{y:.1f}" x2="{left + chart_w}" y2="{y:.1f}" stroke="#edf1f7"/>', f'<text x="30" y="{y + 4:.1f}" class="tiny">{tick}</text>']
+    prev = None
+    for idx, chunk in enumerate(chunks):
+        x = left + idx * (bar_w + bar_gap)
+        pre_h, dec_h = chunk["prefill_ms"] / max_total * chart_h, chunk["decode_ms"] / max_total * chart_h
+        y_pre, y_dec = top + chart_h - pre_h, top + chart_h - pre_h - dec_h
+        color = "#2ca25f" if chunk["decision"] == "speak" else "#8b95a5"
+        body += [f'<rect x="{x:.1f}" y="{y_pre:.1f}" width="{bar_w:.1f}" height="{pre_h:.1f}" fill="#4c78a8"/>', f'<rect x="{x:.1f}" y="{y_dec:.1f}" width="{bar_w:.1f}" height="{dec_h:.1f}" fill="#f58518"/>', f'<circle cx="{x + bar_w / 2:.1f}" cy="{y_dec - 7:.1f}" r="3.2" fill="{color}"/>']
+        if idx % 5 == 0:
+            body.append(f'<text x="{x - 2:.1f}" y="{top + chart_h + 18}" class="tiny">{idx}</text>')
+        point = (x + bar_w / 2, top + chart_h - chunk["n_past"] / max_n_past * chart_h)
+        if prev:
+            body.append(f'<line x1="{prev[0]:.1f}" y1="{prev[1]:.1f}" x2="{point[0]:.1f}" y2="{point[1]:.1f}" stroke="#6f4e7c" stroke-width="1.5" opacity="0.65"/>')
+        prev = point
+    body += ['<rect x="845" y="92" width="250" height="88" fill="#ffffff" stroke="#d6dde8" rx="10"/>', '<rect x="865" y="112" width="22" height="12" fill="#4c78a8"/><text x="895" y="122" class="small">prefill</text>', '<rect x="865" y="136" width="22" height="12" fill="#f58518"/><text x="895" y="146" class="small">decode</text>', '<circle cx="876" cy="164" r="4" fill="#2ca25f"/><text x="895" y="168" class="small">SPEAK；紫线=n_past</text>']
+    write(path, svg_base(width, height, body))
+
+
+def overlap_svg(path: Path, events, start_ms=850.0, end_ms=1400.0):
+    width, height = 1180, 530
+    left, top, chart_w = 210, 86, 900
+    lanes = [
+        ("main.prefill", ["api.duplex.frame_total", "api.stream_prefill", "vision.encode", "audio.encode", "queue.llm.wait_space", "queue.llm.enqueue"]),
+        ("llm", ["llm.prefill", "wait.llm_prefill_done", "llm.decode", "api.llm_decode_loop"]),
+        ("tts", ["queue.tts.wait_space", "queue.tts.enqueue", "queue.tts.wait_data", "tts.infer"]),
+        ("t2w", ["queue.t2w.enqueue", "queue.t2w.wait_data", "t2w.infer", "t2w.write"]),
+    ]
+    colors = {
+        "api.duplex.frame_total":"#8da0cb", "api.stream_prefill":"#4c78a8", "vision.encode":"#77aadd", "audio.encode":"#72b7b2",
+        "queue.llm.wait_space":"#c7e9c0", "queue.llm.enqueue":"#74c476",
+        "llm.prefill":"#b279a2", "wait.llm_prefill_done":"#f58518", "llm.decode":"#e45756", "api.llm_decode_loop":"#ff9da6",
+        "queue.tts.wait_space":"#bae4b3", "queue.tts.enqueue":"#8cd17d", "queue.tts.wait_data":"#a1d99b", "tts.infer":"#54a24b",
+        "queue.t2w.enqueue":"#9ecae9", "queue.t2w.wait_data":"#c6dbef", "t2w.infer":"#3182bd", "t2w.write":"#9e9ac8",
+    }
+    stage_lane = {stage: lane for lane, stages in lanes for stage in stages}
+    lane_y = {}
+    body = ['<rect width="1180" height="530" fill="#ffffff"/>', '<text x="40" y="42" class="title">异步重叠时间线：约 0.85s 到 1.40s</text>', '<text x="40" y="66" class="subtitle">TTS/T2W 与下一轮 prefill/decode 同时运行；chunk 标签按日志原值显示</text>']
+    for tick in range(int(start_ms), int(end_ms) + 1, 50):
+        x = left + (tick - start_ms) / (end_ms - start_ms) * chart_w
+        body += [f'<line x1="{x:.1f}" y1="80" x2="{x:.1f}" y2="455" stroke="#edf1f7"/>', f'<text x="{x - 14:.1f}" y="478" class="tiny">{tick}</text>']
+    for idx, (lane, _) in enumerate(lanes):
+        y = top + idx * 92
+        lane_y[lane] = y
+        body += [f'<rect x="40" y="{y - 20}" width="1070" height="62" fill="#f6f8fb" stroke="#d6dde8" rx="10"/>', f'<text x="58" y="{y + 5}" class="label" font-weight="700">{esc(lane)}</text>']
+    starts = defaultdict(list)
+    bars = []
+    for event in sorted(events, key=lambda item: item["t_ms"]):
+        key = (event["stage"], event["chunk"])
+        if event["event"] == "start":
+            starts[key].append(event)
+        elif event["event"] == "end" and event["stage"] in stage_lane:
+            start = starts[key].pop(0) if starts[key] else None
+            begin = start["t_ms"] if start else event["t_ms"] - max(event["dur_ms"], 0)
+            finish = event["t_ms"]
+            if finish >= start_ms and begin <= end_ms:
+                bars.append((begin, finish, event["stage"], event["chunk"]))
+    offsets = {stage: (i % 3) * 16 for i, stage in enumerate(colors)}
+    for begin, finish, stage, chunk in bars:
+        lane = stage_lane[stage]
+        x = left + (max(begin, start_ms) - start_ms) / (end_ms - start_ms) * chart_w
+        w = max(2, (min(finish, end_ms) - max(begin, start_ms)) / (end_ms - start_ms) * chart_w)
+        y = lane_y[lane] - 4 + offsets.get(stage, 0)
+        body.append(f'<rect x="{x:.1f}" y="{y:.1f}" width="{w:.1f}" height="13" fill="{colors[stage]}" rx="3"/>')
+        if w > 62:
+            body.append(f'<text x="{x + 4:.1f}" y="{y + 10:.1f}" class="tiny">c{chunk} {esc(stage.split(".")[-1])}</text>')
+    write(path, svg_base(width, height, body))
+
+
+def gpu_utilization_svg(path: Path, gpu_samples, intervals):
+    width = 1180
+    left, chart_w = 80, 1010
+    device_ids = sorted({sample["device"] for sample in gpu_samples})
+    if not gpu_samples or not device_ids:
+        body = ['<rect width="1180" height="180" fill="#ffffff"/>', '<text x="40" y="42" class="title">GPU 利用率时间线</text>', '<text x="40" y="72" class="subtitle">未解析到 [DUPLEX_GPU] sample</text>']
+        write(path, svg_base(width, 180, body))
+        return
+
+    sample_min = min(sample["t_ms"] for sample in gpu_samples)
+    sample_max = max(sample["t_ms"] for sample in gpu_samples)
+    interval_min = min([interval["begin_ms"] for interval in intervals] + [sample_min])
+    interval_max = max([interval["end_ms"] for interval in intervals] + [sample_max])
+    start_ms = min(sample_min, interval_min)
+    end_ms = max(sample_max, interval_max)
+    span = max(1.0, end_ms - start_ms)
+    device_h = 115
+    stage_top = 96 + len(device_ids) * device_h
+    height = stage_top + 220
+    body = ['<rect width="1180" height="%d" fill="#ffffff"/>' % height, '<text x="40" y="42" class="title">GPU 利用率时间线</text>', '<text x="40" y="66" class="subtitle">蓝线=SM util，橙线=memory controller util；下方为主要阶段 interval</text>']
+
+    def x_of(t_ms):
+        return left + (t_ms - start_ms) / span * chart_w
+
+    for tick in range(int(start_ms // 100 * 100), int(end_ms) + 101, 100):
+        x = x_of(tick)
+        body += [f'<line x1="{x:.1f}" y1="84" x2="{x:.1f}" y2="{height - 40}" stroke="#edf1f7"/>', f'<text x="{x - 18:.1f}" y="{height - 18}" class="tiny">{tick}</text>']
+
+    for idx, device in enumerate(device_ids):
+        y0 = 90 + idx * device_h
+        body += [f'<rect x="40" y="{y0 - 10}" width="1070" height="92" fill="#f6f8fb" stroke="#d6dde8" rx="10"/>', f'<text x="50" y="{y0 + 10}" class="label" font-weight="700">device {device}</text>']
+        for pct in (0, 50, 100):
+            y = y0 + 70 - pct / 100.0 * 62
+            body += [f'<line x1="{left}" y1="{y:.1f}" x2="{left + chart_w}" y2="{y:.1f}" stroke="#e8edf5"/>', f'<text x="46" y="{y + 4:.1f}" class="tiny">{pct}%</text>']
+        samples = [sample for sample in gpu_samples if sample["device"] == device]
+        for key, color in (("sm_util_pct", "#2f6fed"), ("mem_util_pct", "#f58518")):
+            points = []
+            for sample in samples:
+                value = sample[key]
+                if value < 0:
+                    continue
+                points.append(f'{x_of(sample["t_ms"]):.1f},{y0 + 70 - min(100.0, value) / 100.0 * 62:.1f}')
+            if len(points) >= 2:
+                body.append(f'<polyline points="{" ".join(points)}" fill="none" stroke="{color}" stroke-width="1.8"/>')
+
+    stage_colors = {stage: color for stage, color in STAGE_ROWS}
+    focus_stages = ["llm.prefill", "llm.decode", "tts.infer", "t2w.infer", "vision.encode", "audio.encode"]
+    lane_y = {stage: stage_top + 22 + idx * 26 for idx, stage in enumerate(focus_stages)}
+    body += [f'<text x="40" y="{stage_top}" class="label" font-weight="700">stage intervals</text>']
+    for stage in focus_stages:
+        y = lane_y[stage]
+        body += [f'<text x="40" y="{y + 10}" class="tiny">{esc(stage)}</text>', f'<line x1="{left}" y1="{y + 5}" x2="{left + chart_w}" y2="{y + 5}" stroke="#edf1f7"/>']
+    for interval in intervals:
+        stage = interval["stage"]
+        if stage not in lane_y:
+            continue
+        x = x_of(interval["begin_ms"])
+        w = max(1.5, (interval["end_ms"] - interval["begin_ms"]) / span * chart_w)
+        y = lane_y[stage]
+        body.append(f'<rect x="{x:.1f}" y="{y:.1f}" width="{w:.1f}" height="11" fill="{stage_colors.get(stage, "#8b95a5")}" opacity="0.58" rx="3"/>')
+
+    body += ['<rect x="875" y="90" width="220" height="52" fill="#ffffff" stroke="#d6dde8" rx="10"/>', '<line x1="895" y1="110" x2="930" y2="110" stroke="#2f6fed" stroke-width="2"/><text x="940" y="114" class="small">SM util</text>', '<line x1="895" y1="132" x2="930" y2="132" stroke="#f58518" stroke-width="2"/><text x="940" y="136" class="small">mem util</text>']
+    write(path, svg_base(width, height, body))
+
+
+def write_csvs(out_dir: Path, stats, chunks, gpu_samples, gpu_stats, tts_tokens, token_stats):
+    with (out_dir / "omni-duplex-stage-stats.csv").open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["stage", "n", "total_ms", "avg_ms", "p50_ms", "p90_ms", "min_ms", "max_ms"])
+        for stage in sorted(stats):
+            row = stats[stage]
+            writer.writerow([stage, row["n"], f'{row["total"]:.3f}', f'{row["avg"]:.3f}', f'{row["p50"]:.3f}', f'{row["p90"]:.3f}', f'{row["min"]:.3f}', f'{row["max"]:.3f}'])
+    with (out_dir / "omni-duplex-chunk-summary.csv").open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["chunk", "prefill_ms", "decode_ms", "total_ms", "n_past", "decision", "text"])
+        for chunk in chunks:
+            writer.writerow([chunk["chunk"], f'{chunk["prefill_ms"]:.3f}', f'{chunk["decode_ms"]:.3f}', f'{chunk["total_ms"]:.3f}', chunk["n_past"], chunk["decision"], chunk["text"]])
+    with (out_dir / "omni-duplex-gpu-samples.csv").open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["sample_id", "t_ms", "device", "sm_util_pct", "mem_util_pct", "gpu_used_mb", "gpu_total_mb", "power_w", "temp_c", "graphics_clock_mhz", "mem_clock_mhz"])
+        for sample in gpu_samples:
+            writer.writerow([sample["sample_id"], f'{sample["t_ms"]:.3f}', sample["device"], sample["sm_util_pct"], sample["mem_util_pct"], sample["gpu_used_mb"], sample["gpu_total_mb"], sample["power_w"], sample["temp_c"], sample["graphics_clock_mhz"], sample["mem_clock_mhz"]])
+    with (out_dir / "omni-duplex-stage-gpu-stats.csv").open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["stage", "device", "n_intervals", "n_samples", "total_ms", "avg_sm_util_pct", "p50_sm_util_pct", "p90_sm_util_pct", "max_sm_util_pct", "avg_mem_util_pct", "max_mem_util_pct", "avg_power_w", "max_power_w", "estimated_samples", "stage_gpu_busy_ms"])
+        for key in sorted(gpu_stats):
+            row = gpu_stats[key]
+            writer.writerow([row["stage"], row["device"], row["n_intervals"], row["n_samples"], f'{row["total_ms"]:.3f}', f'{row["avg_sm_util_pct"]:.3f}', f'{row["p50_sm_util_pct"]:.3f}', f'{row["p90_sm_util_pct"]:.3f}', f'{row["max_sm_util_pct"]:.3f}', f'{row["avg_mem_util_pct"]:.3f}', f'{row["max_mem_util_pct"]:.3f}', f'{row["avg_power_w"]:.3f}', f'{row["max_power_w"]:.3f}', row["estimated_samples"], f'{row["stage_gpu_busy_ms"]:.3f}'])
+    with (out_dir / "omni-duplex-stage-token-speed.csv").open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["stage", "n", "tokens", "total_ms", "tokens_per_s", "ms_per_token", "avg_event_tokens_per_s", "p50_event_tokens_per_s", "avg_event_ms_per_token"])
+        for stage in TOKEN_SPEED_STAGES:
+            row = token_stats.get(stage, {})
+            writer.writerow([
+                stage,
+                int(row.get("n", 0)),
+                int(row.get("tokens", 0)),
+                f'{row.get("total_ms", 0.0):.3f}',
+                f'{row.get("tokens_per_s", 0.0):.3f}',
+                f'{row.get("ms_per_token", 0.0):.6f}',
+                f'{row.get("avg_event_tokens_per_s", 0.0):.3f}',
+                f'{row.get("p50_event_tokens_per_s", 0.0):.3f}',
+                f'{row.get("avg_event_ms_per_token", 0.0):.6f}',
+            ])
+    with (out_dir / "omni-duplex-tts-token-stats.csv").open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["chunk", "tts_chunk", "dur_ms", "llm_tokens", "filtered_llm_tokens", "condition_tokens", "compute_tokens", "audio_tokens_generated", "is_end_of_turn", "flush_only", "compute_tokens_per_s", "audio_tokens_per_ms", "audio_tokens_per_s", "ms_per_audio_token", "has_audio_token_detail"])
+        for row in tts_tokens:
+            writer.writerow([row["chunk"], row["tts_chunk"], f'{row["dur_ms"]:.3f}', row["llm_tokens"], row["filtered_llm_tokens"], row["condition_tokens"], row["compute_tokens"], row["audio_tokens_generated"], row["is_end_of_turn"], row["flush_only"], f'{row["compute_tokens_per_s"]:.3f}', f'{row["audio_tokens_per_ms"]:.6f}', f'{row["audio_tokens_per_s"]:.3f}', f'{row["ms_per_audio_token"]:.3f}', row["has_audio_token_detail"]])
+
+
+def stage_kind(stage: str) -> str:
+    if stage.startswith("api."):
+        return "api"
+    if stage.startswith("queue."):
+        return "queue"
+    if stage.startswith("wait."):
+        return "wait"
+    if stage.startswith("control."):
+        return "control"
+    if stage.startswith("session."):
+        return "session"
+    if stage.endswith(".write"):
+        return "io"
+    return "compute"
+
+
+def ordered_stage_names(stats):
+    preferred = [stage for stage, _ in STAGE_ROWS]
+    return preferred + [stage for stage in sorted(stats) if stage not in preferred]
+
+
+def write_stage_timing_table(path: Path, stats):
+    lines = [
+        "# Duplex 阶段用时统计表",
+        "",
+        "单位均为 ms。`total` 是该 stage 所有 end 事件的耗时总和；异步/父子阶段不要直接相加。",
+        "",
+        "| type | stage | n | total | avg | p50 | p90 | min | max |",
+        "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for stage in ordered_stage_names(stats):
+        row = stats.get(stage, {})
+        if not row:
+            continue
+        lines.append(
+            f"| `{stage_kind(stage)}` | `{stage}` | {int(row['n'])} | "
+            f"{row['total']:.1f} | {row['avg']:.1f} | {row['p50']:.1f} | "
+            f"{row['p90']:.1f} | {row['min']:.1f} | {row['max']:.1f} |"
+        )
+    lines.append("")
+    write(path, "\n".join(lines))
+
+
+def gpu_stage_summary(gpu_stats, stage):
+    rows = [row for (row_stage, _), row in gpu_stats.items() if row_stage == stage]
+    if not rows:
+        return None
+    total_samples = sum(row["n_samples"] for row in rows)
+    avg_sm = avg(row["avg_sm_util_pct"] for row in rows)
+    max_sm = max(row["max_sm_util_pct"] for row in rows)
+    avg_power = avg(row["avg_power_w"] for row in rows)
+    estimated = sum(row["estimated_samples"] for row in rows)
+    devices = ",".join(str(row["device"]) for row in sorted(rows, key=lambda item: item["device"]))
+    return {
+        "devices": devices,
+        "total_samples": total_samples,
+        "avg_sm": avg_sm,
+        "max_sm": max_sm,
+        "avg_power": avg_power,
+        "estimated": estimated,
+    }
+
+
+def write_report(path: Path, log_path: Path, text: str, events, chunks, stats, gpu_samples, gpu_stats, gpu_statuses, tts_tokens, token_stats):
+    decisions = Counter(c["decision"] for c in chunks)
+    event_counts = Counter((e["stage"], e["event"]) for e in events)
+    user_chunks = chunks[1:] if len(chunks) > 1 else chunks
+    speak = [c for c in chunks if c["decision"] == "speak"]
+    listen = [c for c in chunks if c["decision"] == "listen"]
+    gpu = [e["gpu_used_mb"] for e in events if e["gpu_used_mb"] >= 0]
+    rss = [e["rss_mb"] for e in events if e["rss_mb"] >= 0]
+    def st(stage, key="avg"):
+        return stats.get(stage, {}).get(key, 0.0)
+    tts_tokens_with_detail = [row for row in tts_tokens if row["has_audio_token_detail"]]
+    tts_audio_values = [row["audio_tokens_generated"] for row in tts_tokens_with_detail]
+    rss_range = f"{min(rss):.0f}-{max(rss):.0f} MB" if rss else "NA"
+    gpu_range = f"{min(gpu):.0f}-{max(gpu):.0f} MB" if gpu else "NA"
+    def speed(stage):
+        return token_stats.get(stage, {}).get("tokens_per_s", 0.0)
+    lines = [
+        "# Omni Duplex TTS GPU 实测性能报告",
+        "",
+        f"- 日志：`{log_path.name}`",
+        f"- 解析到 `{len(events)}` 条结构化 `[DUPLEX_PERF]` 事件；原始 marker 为 `{text.count('[DUPLEX_PERF]')}` 条。",
+        f"- Chunk：`{len(chunks)}`；SPEAK/LISTEN：`{decisions.get('speak', 0)}` / `{decisions.get('listen', 0)}`。",
+        f"- API 口径：平均 prefill `{avg(c['prefill_ms'] for c in chunks):.1f} ms`，平均 decode `{avg(c['decode_ms'] for c in chunks):.1f} ms`，平均每 chunk `{avg(c['total_ms'] for c in chunks):.1f} ms`。",
+        f"- 用户 chunk 口径（排除 `index=0`）：平均 prefill `{avg(c['prefill_ms'] for c in user_chunks):.1f} ms`，平均 decode `{avg(c['decode_ms'] for c in user_chunks):.1f} ms`，平均每 chunk `{avg(c['total_ms'] for c in user_chunks):.1f} ms`。",
+        f"- 阶段平均速度：`llm.prefill` `{speed('llm.prefill'):.2f} tok/s`，`llm.decode` `{speed('llm.decode'):.2f} tok/s`，`TTS.infer` `{speed('tts.infer'):.2f} compute tok/s`。",
+        f"- n_past：峰值 `{max(c['n_past'] for c in chunks)}`，最终 `{chunks[-1]['n_past']}`；RSS 约 `{rss_range}`，GPU used 约 `{gpu_range}`。",
+        "",
+        "## 图表",
+        "",
+        "![Omni Duplex 实测流水线](figures/omni-duplex-pipeline.svg)",
+        "",
+        "![阶段耗时均值](figures/omni-duplex-stage-latency.svg)",
+        "",
+        "![逐 chunk API 延迟](figures/omni-duplex-chunk-latency.svg)",
+        "",
+        "![异步重叠时间线](figures/omni-duplex-overlap-timeline.svg)",
+        "",
+        "![GPU 利用率时间线](figures/omni-duplex-gpu-utilization.svg)",
+        "",
+        "完整阶段用时统计表见 [`omni-duplex-stage-timing-table.md`](omni-duplex-stage-timing-table.md)，CSV 见 `omni-duplex-stage-stats.csv`、`omni-duplex-stage-token-speed.csv`、`omni-duplex-gpu-samples.csv`、`omni-duplex-stage-gpu-stats.csv` 和 `omni-duplex-tts-token-stats.csv`。",
+        "",
+        "## 主要结论",
+        "",
+        f"1. `vision.encode` / `audio.encode` 是输入侧 encoder 口径，平均约 `{st('vision.encode'):.1f}` / `{st('audio.encode'):.1f} ms`。",
+        f"2. LLM KV prefill 在后台线程执行，平均约 `{st('llm.prefill'):.1f} ms`，平均速度 `{speed('llm.prefill'):.2f} tok/s`；API `decode` 通过 `wait.llm_prefill_done` 等待它，因此当前 decode API 不是纯采样耗时。",
+        f"3. LLM decode 平均速度 `{speed('llm.decode'):.2f} tok/s`；SPEAK chunk 的 decode 均值约 `{avg(c['decode_ms'] for c in speak):.1f} ms`，LISTEN chunk 约 `{avg(c['decode_ms'] for c in listen):.1f} ms`。",
+        f"4. TTS/T2W 是后台链路。`tts.infer` 平均约 `{st('tts.infer'):.1f} ms`、`{speed('tts.infer'):.2f} compute tok/s`，`t2w.infer` 平均约 `{st('t2w.infer'):.1f} ms`，但它们可能与后续 chunk 重叠。",
+        "5. `[DUPLEX_PERF]` 带 `seq` 后可以按 `(t_ms, seq)` 稳定排序；TTS/T2W 仍建议继续增加稳定的 `utterance_id` / `audio_chunk_id` 来做跨线程归因。",
+        "",
+        "## GPU 利用率",
+        "",
+    ]
+    if gpu_samples:
+        lines.append(f"- 解析到 `{len(gpu_samples)}` 条 `[DUPLEX_GPU]` sample，覆盖 device：`{', '.join(str(d) for d in sorted({s['device'] for s in gpu_samples}))}`。")
+        for stage in ["tts.infer", "llm.decode", "llm.prefill", "t2w.infer"]:
+            row = gpu_stage_summary(gpu_stats, stage)
+            if row:
+                lines.append(f"- `{stage}`: avg SM `{row['avg_sm']:.1f}%`, max `{row['max_sm']:.1f}%`, avg power `{row['avg_power']:.1f} W`, samples `{row['total_samples']}`, estimated `{row['estimated']}`。")
+        lines.append("- 低 SM util + 高耗时的阶段优先检查 CPU、IO、队列和同步点；`stage_gpu_busy_ms` 仅用于单阶段观察，不应跨重叠阶段相加。")
+    elif gpu_statuses:
+        reasons = ", ".join(f"{status['event']}:{status['reason']}" for status in gpu_statuses)
+        lines.append(f"- 未解析到 GPU sample；状态：`{reasons}`。")
+    else:
+        lines.append("- 未解析到 `[DUPLEX_GPU]` sample。运行时设置 `OMNI_GPU_PROF=1` 可启用 NVML 采样。")
+    lines += [
+        "",
+        "## 阶段平均速度",
+        "",
+        "速度口径为该阶段所有 end 事件的 `compute tokens / total duration`；`llm.prefill` 的 token 包含文本控制标记 token 和音频/视觉 embedding token，`llm.decode` 包含模型采样 token 和手动 feed 的控制 token，`tts.infer` 包含 TTS 采样步数（含 EOS 等未输出 token）。",
+        "",
+        "| stage | n | tokens | total ms | tokens/s | ms/token |",
+        "| --- | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for stage in TOKEN_SPEED_STAGES:
+        row = token_stats.get(stage, {})
+        display_stage = "TTS.infer" if stage == "tts.infer" else stage
+        lines.append(
+            f"| `{display_stage}` | {int(row.get('n', 0))} | {int(row.get('tokens', 0))} | "
+            f"{row.get('total_ms', 0.0):.1f} | {row.get('tokens_per_s', 0.0):.2f} | "
+            f"{row.get('ms_per_token', 0.0):.4f} |"
+        )
+    lines += [
+        "",
+        "## TTS Token 规模",
+        "",
+    ]
+    if tts_tokens_with_detail:
+        lines.append(f"- 解析到 `{len(tts_tokens_with_detail)}` 次 `tts.infer` audio token 输出；总计 `{sum(tts_audio_values)}` 个 audio token。")
+        lines.append(f"- 每次 `tts.infer` 输出 token：平均 `{avg(tts_audio_values):.1f}`，p50 `{statistics.median(tts_audio_values):.1f}`，p90 `{pctl(tts_audio_values, 0.90):.1f}`，范围 `{min(tts_audio_values)}-{max(tts_audio_values)}`。")
+        per_token = [row["ms_per_audio_token"] for row in tts_tokens_with_detail if row["ms_per_audio_token"] > 0]
+        if per_token:
+            lines.append(f"- TTS 每 audio token 成本：平均 `{avg(per_token):.2f} ms/token`，p50 `{statistics.median(per_token):.2f} ms/token`。")
+            output_total_ms = sum(row["dur_ms"] for row in tts_tokens_with_detail)
+            output_tok_s = sum(tts_audio_values) * 1000.0 / output_total_ms if output_total_ms > 0 else 0.0
+            lines.append(f"- TTS compute 速度：`{speed('tts.infer'):.2f} tok/s`；有效 audio 输出速度：`{output_tok_s:.2f} audio tok/s`（总体口径）。")
+        lines += [
+            "",
+            "| chunk | tts_chunk | dur ms | llm tokens | filtered | condition | compute tokens | audio tokens | ms/audio token | end_of_turn | flush_only |",
+            "| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+        ]
+        for row in tts_tokens_with_detail:
+            lines.append(
+                f"| {row['chunk']} | {row['tts_chunk']} | {row['dur_ms']:.1f} | "
+                f"{row['llm_tokens']} | {row['filtered_llm_tokens']} | {row['condition_tokens']} | "
+                f"{row['compute_tokens']} | {row['audio_tokens_generated']} | {row['ms_per_audio_token']:.2f} | "
+                f"{row['is_end_of_turn']} | {row['flush_only']} |"
+            )
+    elif tts_tokens:
+        lines.append("- 当前日志里的 `tts.infer` detail 还没有 `audio_tokens_generated` 字段；请用更新后的二进制重新跑一次 benchmark 后再分析。")
+    else:
+        lines.append("- 未解析到 `tts.infer` end 事件。")
+    lines += [
+        "",
+        "## 阶段耗时表",
+        "",
+        "| type | stage | n | total ms | avg ms | p50 ms | p90 ms | max ms |",
+        "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for stage, _ in STAGE_ROWS:
+        row = stats.get(stage, {})
+        lines.append(f"| `{stage_kind(stage)}` | `{stage}` | {int(row.get('n', 0))} | {row.get('total', 0):.1f} | {row.get('avg', 0):.1f} | {row.get('p50', 0):.1f} | {row.get('p90', 0):.1f} | {row.get('max', 0):.1f} |")
+    lines += [
+        "",
+        "## 计时口径说明",
+        "",
+        "- `index=0` 是 session/ref audio 初始化，不能和普通用户音频 chunk 混在一起解释。",
+        "- `api.duplex.frame_total` 是 push frame 到 result 出队的端到端 API 包络；`api.stream_prefill` 主要覆盖 encoder submit 和入队。",
+        "- 异步 LLM KV 写入体现在 `llm.prefill` 和 `wait.llm_prefill_done`；这些内部阶段不要和 API 包络相加。",
+        "- TTS/T2W 的 `chunk` 来自随队列传递的 `perf_chunk_index`；若一次 drain 多个队列项，T2W window 仍按第一个有效 chunk 标注。",
+        "- 对端到端首响、RTF 和尾包 flush 的精确测量，仍建议在 LLM enqueue、TTS audio token、T2W wav 输出之间增加同一个稳定请求 ID。",
+        "",
+        "## 结构化事件完整性",
+        "",
+        "| stage/event | count |",
+        "| --- | ---: |",
+    ]
+    for (stage, event), count in sorted(event_counts.items()):
+        lines.append(f"| `{stage}` / `{event}` | {count} |")
+    lines.append("")
+    write(path, "\n".join(lines))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--log", type=Path, default=Path("/cache/hanqingzhe/llama.cpp-omni/duplex_omni_tts_gpu_4_7.log"))
+    parser.add_argument("--gpu-log", type=Path, default=None, help="Optional separate OMNI_GPU_PROF_FILE log")
+    parser.add_argument("--out-dir", type=Path, default=Path("/cache/hanqingzhe/llama.cpp-omni/docs/development"))
+    args = parser.parse_args()
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    text, events, chunks, gpu_samples, gpu_statuses = parse_log(args.log, args.gpu_log)
+    stats = stage_stats(events)
+    tts_tokens = tts_token_rows(events)
+    token_stats = stage_token_stats(events)
+    intervals = build_stage_intervals(events)
+    gpu_stats = stage_gpu_stats(intervals, gpu_samples)
+    figures = args.out_dir / "figures"
+    pipeline_svg(figures / "omni-duplex-pipeline.svg")
+    stage_latency_svg(figures / "omni-duplex-stage-latency.svg", stats)
+    chunk_latency_svg(figures / "omni-duplex-chunk-latency.svg", chunks)
+    overlap_svg(figures / "omni-duplex-overlap-timeline.svg", events)
+    gpu_utilization_svg(figures / "omni-duplex-gpu-utilization.svg", gpu_samples, intervals)
+    write_csvs(args.out_dir, stats, chunks, gpu_samples, gpu_stats, tts_tokens, token_stats)
+    write_stage_timing_table(args.out_dir / "omni-duplex-stage-timing-table.md", stats)
+    write_report(args.out_dir / "omni-duplex-tts-gpu-4-7-report.md", args.log, text, events, chunks, stats, gpu_samples, gpu_stats, gpu_statuses, tts_tokens, token_stats)
+    print(f"parsed_events={len(events)} raw_markers={text.count('[DUPLEX_PERF]')} chunks={len(chunks)} gpu_samples={len(gpu_samples)} tts_token_rows={len(tts_tokens)}")
+    print(f"wrote={args.out_dir / 'omni-duplex-tts-gpu-4-7-report.md'}")
+    print(f"stage_table={args.out_dir / 'omni-duplex-stage-timing-table.md'}")
+    print(f"figures={figures}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/omni/CMakeLists.txt
+++ b/tools/omni/CMakeLists.txt
@@ -44,6 +44,7 @@ endif()
 
 target_link_libraries     (omni PUBLIC ggml llama common)
 target_link_libraries     (omni PRIVATE Threads::Threads)
+target_link_libraries     (omni PRIVATE ${CMAKE_DL_LIBS})
 target_include_directories(omni PUBLIC  .)
 target_include_directories(omni PRIVATE ../..)
 target_include_directories(omni PRIVATE ../../vendor)

--- a/tools/omni/convert/prepare_o45_gptq_for_gguf.py
+++ b/tools/omni/convert/prepare_o45_gptq_for_gguf.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Prepare a MiniCPM-o 4.5 GPTQ HF checkout for GGUF conversion.
+
+The omni conversion scripts in this directory expect component-specific model
+folders. A GPTQ checkout is sharded and keeps the LLM in qweight/qzeros/scales
+form, so this script only splits and renames tensors. It intentionally keeps
+the LLM GPTQ tensors packed; use a convert_hf_to_gguf.py with GPTQ support for
+the final LLM GGUF conversion.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+from pathlib import Path
+from typing import Callable
+
+
+TOKENIZER_FILES = (
+    "added_tokens.json",
+    "merges.txt",
+    "special_tokens_map.json",
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "vocab.json",
+)
+
+
+def load_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+
+
+def copy_tokenizer_files(src: Path, dst: Path) -> None:
+    dst.mkdir(parents=True, exist_ok=True)
+    for name in TOKENIZER_FILES:
+        in_path = src / name
+        if in_path.exists():
+            shutil.copy2(in_path, dst / name)
+
+    tok_cfg_path = dst / "tokenizer_config.json"
+    if tok_cfg_path.exists():
+        tok_cfg = load_json(tok_cfg_path)
+        tok_cfg.pop("auto_map", None)
+        tok_cfg["tokenizer_class"] = "PreTrainedTokenizerFast"
+        save_json(tok_cfg_path, tok_cfg)
+
+
+def sharded_weight_map(model_dir: Path) -> dict[str, str]:
+    index_path = model_dir / "model.safetensors.index.json"
+    if not index_path.exists():
+        raise FileNotFoundError(f"missing sharded index: {index_path}")
+    index = load_json(index_path)
+    weight_map = index.get("weight_map")
+    if not isinstance(weight_map, dict):
+        raise ValueError(f"invalid weight_map in {index_path}")
+    return weight_map
+
+
+def shard_names(weight_map: dict[str, str]) -> list[str]:
+    return sorted(set(weight_map.values()))
+
+
+def collect_tensors(
+    model_dir: Path,
+    weight_map: dict[str, str],
+    keep: Callable[[str], bool],
+    rename: Callable[[str], str],
+    *,
+    as_float: bool = False,
+) -> dict[str, "object"]:
+    from safetensors import safe_open
+
+    tensors = {}
+    for shard in shard_names(weight_map):
+        shard_keys = [key for key, part in weight_map.items() if part == shard and keep(key)]
+        if not shard_keys:
+            continue
+        with safe_open(model_dir / shard, framework="pt", device="cpu") as f:
+            for key in shard_keys:
+                tensor = f.get_tensor(key)
+                if as_float:
+                    tensor = tensor.float()
+                tensors[rename(key)] = tensor
+    return tensors
+
+
+def prepare_configs(model_dir: Path, work_dir: Path, root_config: dict) -> None:
+    llm_dir = work_dir / "llm"
+    tts_dir = work_dir / "tts"
+    vpm_dir = work_dir / "vpm"
+    apm_dir = work_dir / "apm"
+
+    llm_config = dict(root_config)
+    llm_config["architectures"] = ["Qwen3ForCausalLM"]
+    llm_config["model_type"] = "qwen3"
+    llm_config["auto_map"] = {}
+    for key in ("audio_config", "tts_config", "vision_config", "slice_config"):
+        llm_config.pop(key, None)
+    save_json(llm_dir / "config.json", llm_config)
+
+    tts_config = dict(root_config["tts_config"])
+    tts_config["auto_map"] = {}
+    tts_config["model_type"] = "llama"
+    tts_config["architectures"] = ["LlamaForCausalLM"]
+    tts_config.setdefault(
+        "vocab_size",
+        int(tts_config.get("num_audio_tokens", 6562)) + int(tts_config.get("num_text_tokens", 152064)),
+    )
+    tts_config.setdefault("rms_norm_eps", 1e-6)
+    tts_config.setdefault("rope_theta", 10000.0)
+    tts_config.setdefault("tie_word_embeddings", False)
+    save_json(tts_dir / "config.json", tts_config)
+
+    for component_dir in (vpm_dir, apm_dir):
+        component_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(model_dir / "config.json", component_dir / "config.json")
+
+    copy_tokenizer_files(model_dir, llm_dir)
+    copy_tokenizer_files(model_dir, tts_dir)
+
+
+def prepare_llm(model_dir: Path, work_dir: Path, weight_map: dict[str, str]) -> None:
+    from safetensors import safe_open
+    from safetensors.torch import save_file
+
+    llm_dir = work_dir / "llm"
+    llm_dir.mkdir(parents=True, exist_ok=True)
+
+    out_weight_map: dict[str, str] = {}
+    total_size = 0
+    part_idx = 0
+    parts = shard_names(weight_map)
+    for shard in parts:
+        tensors = {}
+        shard_keys = [key for key, part in weight_map.items() if part == shard and key.startswith("llm.")]
+        if not shard_keys:
+            continue
+
+        part_idx += 1
+        out_name = f"model-{part_idx:05d}-of-{len(parts):05d}.safetensors"
+        with safe_open(model_dir / shard, framework="pt", device="cpu") as f:
+            for key in shard_keys:
+                new_key = key.removeprefix("llm.")
+                tensor = f.get_tensor(key)
+                tensors[new_key] = tensor
+                out_weight_map[new_key] = out_name
+                total_size += tensor.numel() * tensor.element_size()
+
+        save_file(tensors, llm_dir / out_name, metadata={"format": "pt"})
+
+    save_json(
+        llm_dir / "model.safetensors.index.json",
+        {"metadata": {"total_size": total_size}, "weight_map": out_weight_map},
+    )
+    print(f"prepared LLM shards: {llm_dir}")
+
+
+def prepare_tts(model_dir: Path, work_dir: Path, weight_map: dict[str, str]) -> None:
+    from safetensors.torch import save_file
+
+    tts_dir = work_dir / "tts"
+    tensors = collect_tensors(
+        model_dir,
+        weight_map,
+        lambda key: key.startswith("tts."),
+        lambda key: key.removeprefix("tts."),
+    )
+    save_file(tensors, tts_dir / "model.safetensors", metadata={"format": "pt"})
+    print(f"prepared TTS model: {tts_dir}")
+
+
+def prepare_vpm(model_dir: Path, work_dir: Path, weight_map: dict[str, str]) -> None:
+    import torch
+
+    vpm_dir = work_dir / "vpm"
+    projector = collect_tensors(
+        model_dir,
+        weight_map,
+        lambda key: key.startswith("resampler"),
+        lambda key: key,
+        as_float=True,
+    )
+    clip = collect_tensors(
+        model_dir,
+        weight_map,
+        lambda key: key.startswith("vpm."),
+        lambda key: key.removeprefix("vpm."),
+        as_float=True,
+    )
+
+    torch.save(projector, vpm_dir / "minicpmv.projector")
+    torch.save(clip, vpm_dir / "minicpmv.clip")
+    if (model_dir / "added_tokens.json").exists():
+        (vpm_dir / "added_tokens.json").write_text("{}\n", encoding="utf-8")
+    print(f"prepared VPM tensors: {vpm_dir}")
+
+
+def prepare_apm(model_dir: Path, work_dir: Path, weight_map: dict[str, str]) -> None:
+    import torch
+
+    apm_dir = work_dir / "apm"
+    whisper = collect_tensors(
+        model_dir,
+        weight_map,
+        lambda key: key.startswith("apm.") or key.startswith("audio_projection_layer"),
+        lambda key: key,
+        as_float=True,
+    )
+    torch.save(whisper, apm_dir / "minicpmo.whisper")
+    print(f"prepared APM tensors: {apm_dir}")
+
+
+def prepare_projector_src(model_dir: Path, work_dir: Path, weight_map: dict[str, str]) -> None:
+    from safetensors.torch import save_file
+
+    projector_dir = work_dir / "projector_src"
+    projector_dir.mkdir(parents=True, exist_ok=True)
+    tensors = collect_tensors(
+        model_dir,
+        weight_map,
+        lambda key: key.startswith("tts.projector_semantic."),
+        lambda key: key,
+    )
+    save_file(tensors, projector_dir / "model.safetensors", metadata={"format": "pt"})
+    print(f"prepared projector source: {projector_dir}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", required=True, type=Path, help="MiniCPM-o 4.5 GPTQ HF model directory")
+    parser.add_argument("--work-dir", required=True, type=Path, help="intermediate component directory")
+    args = parser.parse_args()
+
+    model_dir = args.model.resolve()
+    work_dir = args.work_dir.resolve()
+    if not (model_dir / "config.json").exists():
+        raise FileNotFoundError(f"missing config.json in {model_dir}")
+
+    work_dir.mkdir(parents=True, exist_ok=True)
+    root_config = load_json(model_dir / "config.json")
+    weight_map = sharded_weight_map(model_dir)
+
+    prepare_configs(model_dir, work_dir, root_config)
+    prepare_llm(model_dir, work_dir, weight_map)
+    prepare_tts(model_dir, work_dir, weight_map)
+    prepare_vpm(model_dir, work_dir, weight_map)
+    prepare_apm(model_dir, work_dir, weight_map)
+    prepare_projector_src(model_dir, work_dir, weight_map)
+
+    print("done")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/omni/omni.cpp
+++ b/tools/omni/omni.cpp
@@ -22,6 +22,7 @@
 #include <iostream>
 #include <algorithm>
 #include <cerrno>
+#include <cctype>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -65,6 +66,7 @@
     #include <sys/wait.h>
     #include <unistd.h>
     #include <dirent.h>
+    #include <dlfcn.h>
 #endif
 
 // ============================================================
@@ -139,6 +141,14 @@ static bool reset_python_t2w_cache(struct omni_context * ctx_omni);
 // Forward declarations
 //
 void print_with_timestamp(const char* format, ...);
+static bool omni_tts_debug_dump_enabled();
+static bool omni_gpu_prof_enabled();
+void omni_perf_mark(struct omni_context * ctx_omni,
+                    const char * stage,
+                    const char * event,
+                    int chunk_index,
+                    double duration_ms,
+                    const char * detail);
 
 // ==================== 特殊 Token 分类 ====================
 // 
@@ -269,6 +279,7 @@ struct LLMOut {
     // 此状态随数据一起传递，避免全局状态 current_turn_ended 的时序问题
     // 只有当 LLM 检测到 TURN_EOS/TTS_EOS/EOS 时才设置为 true
     bool is_end_of_turn = false;
+    int perf_chunk_index = -1;  // 性能日志归属的输入 chunk，随 TTS 队列传递
 };
 
  struct TTSThreadInfo{
@@ -996,9 +1007,12 @@ static bool eval_id_with_hidden(struct omni_context * ctx_omni, common_params* p
     return eval_tokens_with_hidden(ctx_omni, params, tokens, 1, n_past, hidden_states);
 }
 
-static bool eval_string(struct omni_context * ctx_omni, common_params* params, const char* str, int n_batch, int * n_past, bool add_bos, bool get_emb = false) {
+static bool eval_string(struct omni_context * ctx_omni, common_params* params, const char* str, int n_batch, int * n_past, bool add_bos, bool get_emb = false, int * n_tokens_out = nullptr) {
     std::string              str2     = str;
     std::vector<llama_token> embd_inp = common_tokenize(ctx_omni->ctx_llama, str2, add_bos, true);
+    if (n_tokens_out != nullptr) {
+        *n_tokens_out = (int) embd_inp.size();
+    }
     return eval_tokens(ctx_omni, params, embd_inp, n_batch, n_past, get_emb);
 }
 
@@ -2195,7 +2209,7 @@ bool prefill_with_emb_tts(struct omni_context* ctx_omni, common_params* params, 
     
     // Check if we need to save all hidden states (for alignment testing)
     const char* save_hidden_states_dir = getenv("TTS_SAVE_HIDDEN_STATES_DIR");
-    bool save_all_hidden_states = (save_hidden_states_dir != nullptr);
+    bool save_all_hidden_states = omni_tts_debug_dump_enabled() && save_hidden_states_dir != nullptr;
     
     for (int i = 0; i < n_pos; i += n_batch) {
         int n_eval = n_pos - i;
@@ -2560,8 +2574,6 @@ static int nucleus_sampling_with_min_keep_tts(
 //    - 非 final chunk：采样到 EOS 时不 prefill，避免污染 KV cache
 //    - final chunk：采样到 EOS 时正常 prefill
 static llama_token sample_tts_token_simplex(struct common_sampler * smpl, struct omni_context * ctx_omni, common_params* params, int * n_past_tts, const std::vector<llama_token> * all_generated_tokens, int token_index_in_chunk, bool force_no_eos = false, bool is_final_text_chunk = false) {
-    const char* logits_debug_dir = getenv("TTS_LOGITS_DEBUG_DIR");
-    
     const int audio_bos_token_id = 151687;
     const int num_audio_tokens = 6562;
     const int eos_relative_idx = num_audio_tokens - 1;  // EOS token relative index: 6561
@@ -2763,7 +2775,8 @@ static llama_token sample_tts_token_simplex(struct common_sampler * smpl, struct
 
 llama_token sample_tts_token(struct common_sampler * smpl, struct omni_context * ctx_omni, common_params* params, int * n_past_tts, const std::vector<llama_token> * all_generated_tokens, const std::vector<llama_token> * chunk_generated_tokens, int token_index_in_chunk, bool force_no_eos, bool is_final_text_chunk = false) {
     // Debug: Save logits directory (set via environment variable)
-    const char* logits_debug_dir = getenv("TTS_LOGITS_DEBUG_DIR");
+    const bool tts_debug_dump = omni_tts_debug_dump_enabled();
+    const char* logits_debug_dir = tts_debug_dump ? getenv("TTS_LOGITS_DEBUG_DIR") : nullptr;
     
     // TTS model constants
     const int audio_bos_token_id = 151687;
@@ -2901,7 +2914,7 @@ llama_token sample_tts_token(struct common_sampler * smpl, struct omni_context *
     }
     
     // Save hidden state and logits for comparison (before evaluation)
-    const char* output_dir = getenv("TTS_OUTPUT_DIR");
+    const char* output_dir = tts_debug_dump ? getenv("TTS_OUTPUT_DIR") : nullptr;
     if (output_dir != nullptr) {
         // Save hidden state (for first token only)
         if (token_index_in_chunk == 0) {
@@ -3753,29 +3766,589 @@ static bool duplex_decode(omni_context * ctx_omni,
 
 // 读取 omni_output 互斥
 std::mutex buffer_mutex;
+static std::mutex g_omni_line_write_mutex;
+static std::atomic<uint64_t> g_omni_perf_seq{0};
 
-void print_with_timestamp(const char* format, ...)
-{
-    // 获取当前时间
+static std::string omni_format_v(const char * format, va_list args) {
+    if (format == nullptr) {
+        return "";
+    }
+    va_list args_copy;
+    va_copy(args_copy, args);
+    const int len = vsnprintf(nullptr, 0, format, args_copy);
+    va_end(args_copy);
+    if (len <= 0) {
+        return "";
+    }
+    std::vector<char> buffer((size_t) len + 1);
+    vsnprintf(buffer.data(), buffer.size(), format, args);
+    return std::string(buffer.data(), (size_t) len);
+}
+
+static std::string omni_wall_timestamp() {
     auto now = std::chrono::system_clock::now();
     auto in_time_t = std::chrono::system_clock::to_time_t(now);
     auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()) % 1000;
-    
-    // 格式化时间戳
+
     std::tm buf;
 #ifdef _WIN32
     localtime_s(&buf, &in_time_t);
 #else
     localtime_r(&in_time_t, &buf);
 #endif
-    std::cout << std::put_time(&buf, "%H:%M:%S") << '.' << std::setfill('0') << std::setw(3) << ms.count() << " ";
-    
-    // 打印格式化字符串
+
+    std::ostringstream ss;
+    ss << std::put_time(&buf, "%H:%M:%S") << '.'
+       << std::setfill('0') << std::setw(3) << ms.count();
+    return ss.str();
+}
+
+static void omni_write_timestamped_line(const std::string & line) {
+    std::string output = omni_wall_timestamp() + " " + line;
+    if (output.empty() || output.back() != '\n') {
+        output.push_back('\n');
+    }
+
+    std::lock_guard<std::mutex> lock(g_omni_line_write_mutex);
+    fwrite(output.data(), 1, output.size(), stdout);
+    fflush(stdout);
+}
+
+void print_with_timestamp(const char* format, ...)
+{
     va_list args;
     va_start(args, format);
-    vprintf(format, args);
+    std::string line = omni_format_v(format, args);
     va_end(args);
+
+    omni_write_timestamped_line(line);
 }
+
+static void omni_perf_write_line(const char * kind, const std::string & line) {
+    const bool is_gpu_line = kind != nullptr && strcmp(kind, "DUPLEX_GPU") == 0;
+    const char * gpu_file = is_gpu_line ? std::getenv("OMNI_GPU_PROF_FILE") : nullptr;
+    if (!is_gpu_line || gpu_file == nullptr || gpu_file[0] == '\0') {
+        omni_write_timestamped_line(line);
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(g_omni_line_write_mutex);
+    std::ofstream out(gpu_file, std::ios::app);
+    if (out.good()) {
+        out << omni_wall_timestamp() << " " << line;
+        if (line.empty() || line.back() != '\n') {
+            out << "\n";
+        }
+    }
+}
+
+static bool omni_tts_debug_dump_enabled() {
+    const char * value = std::getenv("OMNI_TTS_DEBUG_DUMP");
+    if (value == nullptr) {
+        return false;
+    }
+    std::string normalized(value);
+    std::transform(normalized.begin(), normalized.end(), normalized.begin(),
+                   [](unsigned char c) { return (char) std::tolower(c); });
+    return !normalized.empty() && normalized != "0" && normalized != "false" &&
+           normalized != "off" && normalized != "no";
+}
+
+static bool omni_gpu_prof_enabled() {
+    const char * value = std::getenv("OMNI_GPU_PROF");
+    if (value == nullptr) {
+        return false;
+    }
+    std::string normalized(value);
+    std::transform(normalized.begin(), normalized.end(), normalized.begin(),
+                   [](unsigned char c) { return (char) std::tolower(c); });
+    return !normalized.empty() && normalized != "0" && normalized != "false" &&
+           normalized != "off" && normalized != "no";
+}
+
+static double omni_perf_now_ms() {
+    static const auto t0 = std::chrono::steady_clock::now();
+    const auto now = std::chrono::steady_clock::now();
+    return std::chrono::duration<double, std::milli>(now - t0).count();
+}
+
+static double omni_perf_rss_mb() {
+#if defined(__linux__)
+    std::ifstream statm("/proc/self/statm");
+    long long total_pages = 0;
+    long long resident_pages = 0;
+    if (!(statm >> total_pages >> resident_pages)) {
+        return -1.0;
+    }
+    const long page_size = sysconf(_SC_PAGESIZE);
+    if (page_size <= 0) {
+        return -1.0;
+    }
+    return (double) resident_pages * (double) page_size / (1024.0 * 1024.0);
+#else
+    return -1.0;
+#endif
+}
+
+static bool omni_perf_gpu_memory_mb(double & used_mb, double & total_mb) {
+    used_mb = -1.0;
+    total_mb = -1.0;
+#ifdef GGML_USE_CUDA
+    const int device_count = ggml_backend_cuda_get_device_count();
+    if (device_count <= 0) {
+        return false;
+    }
+    size_t free_bytes_sum = 0;
+    size_t total_bytes_sum = 0;
+    for (int i = 0; i < device_count; ++i) {
+        size_t free_bytes = 0;
+        size_t total_bytes = 0;
+        ggml_backend_cuda_get_device_memory(i, &free_bytes, &total_bytes);
+        free_bytes_sum += free_bytes;
+        total_bytes_sum += total_bytes;
+    }
+    if (total_bytes_sum == 0) {
+        return false;
+    }
+    used_mb = (double) (total_bytes_sum - free_bytes_sum) / (1024.0 * 1024.0);
+    total_mb = (double) total_bytes_sum / (1024.0 * 1024.0);
+    return true;
+#else
+    return false;
+#endif
+}
+
+#if !defined(_WIN32)
+using nvmlReturn_t = int;
+using nvmlDevice_t = void *;
+
+struct nvmlUtilization_t {
+    unsigned int gpu;
+    unsigned int memory;
+};
+
+struct nvmlMemory_t {
+    unsigned long long total;
+    unsigned long long free;
+    unsigned long long used;
+};
+
+static constexpr nvmlReturn_t OMNI_NVML_SUCCESS = 0;
+static constexpr unsigned int OMNI_NVML_TEMPERATURE_GPU = 0;
+static constexpr unsigned int OMNI_NVML_CLOCK_GRAPHICS = 0;
+static constexpr unsigned int OMNI_NVML_CLOCK_MEM = 2;
+
+class OmniNvmlLoader {
+public:
+    ~OmniNvmlLoader() {
+        unload();
+    }
+
+    bool load(std::string & reason) {
+        if (loaded) {
+            return true;
+        }
+
+        handle = dlopen("libnvidia-ml.so.1", RTLD_LAZY | RTLD_LOCAL);
+        if (handle == nullptr) {
+            handle = dlopen("libnvidia-ml.so", RTLD_LAZY | RTLD_LOCAL);
+        }
+        if (handle == nullptr) {
+            reason = "nvml_not_found";
+            return false;
+        }
+
+        if (!load_symbol(nvmlInit_v2, "nvmlInit_v2") ||
+            !load_symbol(nvmlShutdown, "nvmlShutdown") ||
+            !load_symbol(nvmlDeviceGetCount_v2, "nvmlDeviceGetCount_v2") ||
+            !load_symbol(nvmlDeviceGetHandleByIndex_v2, "nvmlDeviceGetHandleByIndex_v2") ||
+            !load_symbol(nvmlDeviceGetUtilizationRates, "nvmlDeviceGetUtilizationRates") ||
+            !load_symbol(nvmlDeviceGetMemoryInfo, "nvmlDeviceGetMemoryInfo") ||
+            !load_symbol(nvmlDeviceGetPowerUsage, "nvmlDeviceGetPowerUsage") ||
+            !load_symbol(nvmlDeviceGetTemperature, "nvmlDeviceGetTemperature") ||
+            !load_symbol(nvmlDeviceGetClockInfo, "nvmlDeviceGetClockInfo")) {
+            reason = "nvml_symbol_missing";
+            unload();
+            return false;
+        }
+
+        loaded = true;
+        return true;
+    }
+
+    void unload() {
+        if (handle != nullptr) {
+            dlclose(handle);
+        }
+        handle = nullptr;
+        loaded = false;
+    }
+
+    using nvmlInit_v2_fn = nvmlReturn_t (*)();
+    using nvmlShutdown_fn = nvmlReturn_t (*)();
+    using nvmlDeviceGetCount_v2_fn = nvmlReturn_t (*)(unsigned int *);
+    using nvmlDeviceGetHandleByIndex_v2_fn = nvmlReturn_t (*)(unsigned int, nvmlDevice_t *);
+    using nvmlDeviceGetUtilizationRates_fn = nvmlReturn_t (*)(nvmlDevice_t, nvmlUtilization_t *);
+    using nvmlDeviceGetMemoryInfo_fn = nvmlReturn_t (*)(nvmlDevice_t, nvmlMemory_t *);
+    using nvmlDeviceGetPowerUsage_fn = nvmlReturn_t (*)(nvmlDevice_t, unsigned int *);
+    using nvmlDeviceGetTemperature_fn = nvmlReturn_t (*)(nvmlDevice_t, unsigned int, unsigned int *);
+    using nvmlDeviceGetClockInfo_fn = nvmlReturn_t (*)(nvmlDevice_t, unsigned int, unsigned int *);
+
+    nvmlInit_v2_fn nvmlInit_v2 = nullptr;
+    nvmlShutdown_fn nvmlShutdown = nullptr;
+    nvmlDeviceGetCount_v2_fn nvmlDeviceGetCount_v2 = nullptr;
+    nvmlDeviceGetHandleByIndex_v2_fn nvmlDeviceGetHandleByIndex_v2 = nullptr;
+    nvmlDeviceGetUtilizationRates_fn nvmlDeviceGetUtilizationRates = nullptr;
+    nvmlDeviceGetMemoryInfo_fn nvmlDeviceGetMemoryInfo = nullptr;
+    nvmlDeviceGetPowerUsage_fn nvmlDeviceGetPowerUsage = nullptr;
+    nvmlDeviceGetTemperature_fn nvmlDeviceGetTemperature = nullptr;
+    nvmlDeviceGetClockInfo_fn nvmlDeviceGetClockInfo = nullptr;
+
+private:
+    template <typename T>
+    bool load_symbol(T & fn, const char * name) {
+        fn = reinterpret_cast<T>(dlsym(handle, name));
+        return fn != nullptr;
+    }
+
+    void * handle = nullptr;
+    bool loaded = false;
+};
+#endif
+
+class OmniGpuPerfSampler {
+public:
+    bool start() {
+        if (running.load()) {
+            return true;
+        }
+        if (!omni_gpu_prof_enabled()) {
+            return false;
+        }
+
+        interval_ms = omni_gpu_prof_interval_ms();
+
+#if defined(_WIN32)
+        omni_perf_write_line("DUPLEX_GPU", "[DUPLEX_GPU] event=unavailable reason=\"nvml_unsupported_platform\"");
+        return false;
+#else
+        std::string reason;
+        if (!nvml.load(reason)) {
+            omni_perf_write_line("DUPLEX_GPU", "[DUPLEX_GPU] event=unavailable reason=\"" + reason + "\"");
+            return false;
+        }
+        if (nvml.nvmlInit_v2() != OMNI_NVML_SUCCESS) {
+            omni_perf_write_line("DUPLEX_GPU", "[DUPLEX_GPU] event=unavailable reason=\"nvml_init_failed\"");
+            nvml.unload();
+            return false;
+        }
+        if (nvml.nvmlDeviceGetCount_v2(&device_count) != OMNI_NVML_SUCCESS || device_count == 0) {
+            omni_perf_write_line("DUPLEX_GPU", "[DUPLEX_GPU] event=unavailable reason=\"nvml_no_devices\"");
+            nvml.nvmlShutdown();
+            nvml.unload();
+            return false;
+        }
+
+        running = true;
+        worker = std::thread(&OmniGpuPerfSampler::run, this);
+        return true;
+#endif
+    }
+
+    void stop() {
+        if (!running.exchange(false)) {
+            return;
+        }
+        cv.notify_all();
+        if (worker.joinable()) {
+            worker.join();
+        }
+#if !defined(_WIN32)
+        if (device_count > 0) {
+            nvml.nvmlShutdown();
+        }
+        nvml.unload();
+        device_count = 0;
+#endif
+    }
+
+    ~OmniGpuPerfSampler() {
+        stop();
+    }
+
+private:
+    static int omni_gpu_prof_interval_ms() {
+        const char * value = std::getenv("OMNI_GPU_PROF_INTERVAL_MS");
+        if (value == nullptr || value[0] == '\0') {
+            return 20;
+        }
+        char * end = nullptr;
+        long parsed = std::strtol(value, &end, 10);
+        if (end == value || parsed <= 0) {
+            return 20;
+        }
+        return (int) std::max<long>(1, std::min<long>(parsed, 1000));
+    }
+
+#if !defined(_WIN32)
+    static std::string fmt_na_or_int(bool ok, unsigned int value) {
+        return ok ? std::to_string(value) : "NA";
+    }
+
+    static std::string fmt_na_or_mb(bool ok, unsigned long long bytes) {
+        if (!ok) {
+            return "NA";
+        }
+        std::ostringstream ss;
+        ss << std::fixed << std::setprecision(2)
+           << (double) bytes / (1024.0 * 1024.0);
+        return ss.str();
+    }
+
+    static std::string fmt_na_or_power(bool ok, unsigned int milliwatts) {
+        if (!ok) {
+            return "NA";
+        }
+        std::ostringstream ss;
+        ss << std::fixed << std::setprecision(2) << (double) milliwatts / 1000.0;
+        return ss.str();
+    }
+
+    void run() {
+        auto next = std::chrono::steady_clock::now();
+        while (running.load()) {
+            sample_once();
+            next += std::chrono::milliseconds(interval_ms);
+            std::unique_lock<std::mutex> lock(wait_mutex);
+            cv.wait_until(lock, next, [&] { return !running.load(); });
+            if (next < std::chrono::steady_clock::now() - std::chrono::milliseconds(interval_ms)) {
+                next = std::chrono::steady_clock::now();
+            }
+        }
+    }
+
+    void sample_once() {
+        for (unsigned int device = 0; device < device_count; ++device) {
+            nvmlDevice_t handle = nullptr;
+            if (nvml.nvmlDeviceGetHandleByIndex_v2(device, &handle) != OMNI_NVML_SUCCESS) {
+                continue;
+            }
+
+            nvmlUtilization_t util{};
+            nvmlMemory_t mem{};
+            unsigned int power_mw = 0;
+            unsigned int temp_c = 0;
+            unsigned int graphics_clock = 0;
+            unsigned int mem_clock = 0;
+
+            const bool has_util = nvml.nvmlDeviceGetUtilizationRates(handle, &util) == OMNI_NVML_SUCCESS;
+            const bool has_mem = nvml.nvmlDeviceGetMemoryInfo(handle, &mem) == OMNI_NVML_SUCCESS;
+            const bool has_power = nvml.nvmlDeviceGetPowerUsage(handle, &power_mw) == OMNI_NVML_SUCCESS;
+            const bool has_temp = nvml.nvmlDeviceGetTemperature(handle, OMNI_NVML_TEMPERATURE_GPU, &temp_c) == OMNI_NVML_SUCCESS;
+            const bool has_graphics_clock = nvml.nvmlDeviceGetClockInfo(handle, OMNI_NVML_CLOCK_GRAPHICS, &graphics_clock) == OMNI_NVML_SUCCESS;
+            const bool has_mem_clock = nvml.nvmlDeviceGetClockInfo(handle, OMNI_NVML_CLOCK_MEM, &mem_clock) == OMNI_NVML_SUCCESS;
+
+            const uint64_t sample_id = next_sample_id++;
+            std::ostringstream line;
+            line << "[DUPLEX_GPU] sample_id=" << sample_id
+                 << " t_ms=" << std::fixed << std::setprecision(3) << omni_perf_now_ms()
+                 << " device=" << device
+                 << " sm_util_pct=" << fmt_na_or_int(has_util, util.gpu)
+                 << " mem_util_pct=" << fmt_na_or_int(has_util, util.memory)
+                 << " gpu_used_mb=" << fmt_na_or_mb(has_mem, mem.used)
+                 << " gpu_total_mb=" << fmt_na_or_mb(has_mem, mem.total)
+                 << " power_w=" << fmt_na_or_power(has_power, power_mw)
+                 << " temp_c=" << fmt_na_or_int(has_temp, temp_c)
+                 << " graphics_clock_mhz=" << fmt_na_or_int(has_graphics_clock, graphics_clock)
+                 << " mem_clock_mhz=" << fmt_na_or_int(has_mem_clock, mem_clock);
+            omni_perf_write_line("DUPLEX_GPU", line.str());
+        }
+    }
+
+    OmniNvmlLoader nvml;
+    unsigned int device_count = 0;
+#endif
+
+    std::atomic<bool> running{false};
+    std::thread worker;
+    std::mutex wait_mutex;
+    std::condition_variable cv;
+    int interval_ms = 20;
+    uint64_t next_sample_id = 0;
+};
+
+static std::mutex g_omni_gpu_sampler_mutex;
+static std::unique_ptr<OmniGpuPerfSampler> g_omni_gpu_sampler;
+
+static void omni_gpu_perf_sampler_start() {
+    if (!omni_gpu_prof_enabled()) {
+        return;
+    }
+    std::lock_guard<std::mutex> lock(g_omni_gpu_sampler_mutex);
+    if (!g_omni_gpu_sampler) {
+        g_omni_gpu_sampler = std::make_unique<OmniGpuPerfSampler>();
+        if (!g_omni_gpu_sampler->start()) {
+            g_omni_gpu_sampler.reset();
+        }
+    }
+}
+
+static void omni_gpu_perf_sampler_stop() {
+    std::lock_guard<std::mutex> lock(g_omni_gpu_sampler_mutex);
+    if (g_omni_gpu_sampler) {
+        g_omni_gpu_sampler->stop();
+        g_omni_gpu_sampler.reset();
+    }
+}
+
+static double omni_perf_tokens_per_s(long long tokens, double duration_ms) {
+    if (tokens <= 0 || duration_ms <= 0.0) {
+        return 0.0;
+    }
+    return (double) tokens * 1000.0 / duration_ms;
+}
+
+static std::string omni_perf_speed_detail(long long tokens, double duration_ms) {
+    std::ostringstream oss;
+    oss << ",tokens_per_s=" << std::fixed << std::setprecision(2)
+        << omni_perf_tokens_per_s(tokens, duration_ms);
+    if (tokens > 0 && duration_ms > 0.0) {
+        oss << ",ms_per_token=" << std::setprecision(4)
+            << (duration_ms / (double) tokens);
+    } else {
+        oss << ",ms_per_token=0.0000";
+    }
+    return oss.str();
+}
+
+static OmniPerfTokenStats * omni_perf_stage_stats(struct omni_context * ctx_omni, const char * stage) {
+    if (ctx_omni == nullptr || stage == nullptr) {
+        return nullptr;
+    }
+    if (std::strcmp(stage, "llm.prefill") == 0) {
+        return &ctx_omni->perf_llm_prefill;
+    }
+    if (std::strcmp(stage, "llm.decode") == 0) {
+        return &ctx_omni->perf_llm_decode;
+    }
+    if (std::strcmp(stage, "tts.infer") == 0) {
+        return &ctx_omni->perf_tts_infer;
+    }
+    return nullptr;
+}
+
+static void omni_perf_record_tokens(struct omni_context * ctx_omni, const char * stage, long long tokens, double duration_ms) {
+    if (tokens <= 0 || duration_ms < 0.0) {
+        return;
+    }
+    OmniPerfTokenStats * stats = omni_perf_stage_stats(ctx_omni, stage);
+    if (stats == nullptr) {
+        return;
+    }
+    std::lock_guard<std::mutex> lock(ctx_omni->perf_token_stats_mtx);
+    stats->calls += 1;
+    stats->tokens += tokens;
+    stats->duration_ms += duration_ms;
+}
+
+static void omni_perf_print_token_stats(struct omni_context * ctx_omni) {
+    if (ctx_omni == nullptr) {
+        return;
+    }
+    std::lock_guard<std::mutex> lock(ctx_omni->perf_token_stats_mtx);
+    const auto print_one = [](const char * stage, const OmniPerfTokenStats & stats) {
+        if (stats.calls <= 0) {
+            return;
+        }
+        const double tokens_per_s = omni_perf_tokens_per_s(stats.tokens, stats.duration_ms);
+        const double ms_per_token = stats.tokens > 0 ? stats.duration_ms / (double) stats.tokens : 0.0;
+        print_with_timestamp("[DUPLEX_PERF_SUMMARY] stage=%s calls=%lld tokens=%lld total_ms=%.3f avg_tokens_per_s=%.2f avg_ms_per_token=%.4f\n",
+                             stage, stats.calls, stats.tokens, stats.duration_ms, tokens_per_s, ms_per_token);
+    };
+    print_one("llm.prefill", ctx_omni->perf_llm_prefill);
+    print_one("llm.decode", ctx_omni->perf_llm_decode);
+    print_one("tts.infer", ctx_omni->perf_tts_infer);
+}
+
+void omni_perf_mark(struct omni_context * ctx_omni,
+                    const char * stage,
+                    const char * event,
+                    int chunk_index,
+                    double duration_ms,
+                    const char * detail) {
+    double gpu_used_mb = -1.0;
+    double gpu_total_mb = -1.0;
+    const bool has_gpu = omni_perf_gpu_memory_mb(gpu_used_mb, gpu_total_mb);
+    const double rss_mb = omni_perf_rss_mb();
+    const int n_past = ctx_omni ? ctx_omni->n_past : -1;
+    const char * safe_stage = stage ? stage : "unknown";
+    const char * safe_event = event ? event : "mark";
+    const char * safe_detail = detail ? detail : "";
+    const uint64_t seq = g_omni_perf_seq++;
+
+    std::ostringstream line;
+    if (has_gpu) {
+        line << "[DUPLEX_PERF] seq=" << seq
+             << " stage=" << safe_stage
+             << " event=" << safe_event
+             << " chunk=" << chunk_index
+             << " t_ms=" << std::fixed << std::setprecision(3) << omni_perf_now_ms()
+             << " dur_ms=" << duration_ms
+             << " rss_mb=" << std::setprecision(2) << rss_mb
+             << " gpu_used_mb=" << gpu_used_mb
+             << " gpu_total_mb=" << gpu_total_mb
+             << " n_past=" << n_past
+             << " detail=\"" << safe_detail << "\"";
+    } else {
+        line << "[DUPLEX_PERF] seq=" << seq
+             << " stage=" << safe_stage
+             << " event=" << safe_event
+             << " chunk=" << chunk_index
+             << " t_ms=" << std::fixed << std::setprecision(3) << omni_perf_now_ms()
+             << " dur_ms=" << duration_ms
+             << " rss_mb=" << std::setprecision(2) << rss_mb
+             << " gpu_used_mb=NA gpu_total_mb=NA"
+             << " n_past=" << n_past
+             << " detail=\"" << safe_detail << "\"";
+    }
+    omni_perf_write_line("DUPLEX_PERF", line.str());
+}
+
+struct OmniPerfScope {
+    omni_context * ctx;
+    const char * stage;
+    int chunk_index;
+    std::string detail;
+    long long tokens = 0;
+    bool has_tokens = false;
+    std::chrono::steady_clock::time_point start;
+
+    OmniPerfScope(omni_context * ctx_, const char * stage_, int chunk_index_, const std::string & detail_)
+        : ctx(ctx_), stage(stage_), chunk_index(chunk_index_), detail(detail_),
+          start(std::chrono::steady_clock::now()) {
+        omni_perf_mark(ctx, stage, "start", chunk_index, -1.0, detail.c_str());
+    }
+
+    void set_detail(const std::string & detail_) {
+        detail = detail_;
+    }
+
+    void set_tokens(long long tokens_) {
+        tokens = tokens_;
+        has_tokens = true;
+    }
+
+    ~OmniPerfScope() {
+        const auto end = std::chrono::steady_clock::now();
+        const double duration_ms = std::chrono::duration<double, std::milli>(end - start).count();
+        std::string final_detail = detail;
+        if (has_tokens) {
+            final_detail += omni_perf_speed_detail(tokens, duration_ms);
+            omni_perf_record_tokens(ctx, stage, tokens, duration_ms);
+        }
+        omni_perf_mark(ctx, stage, "end", chunk_index, duration_ms, final_detail.c_str());
+    }
+};
 
 static struct llama_model * llama_init(common_params * params, std::string model_path) {
     llama_backend_init();
@@ -4351,6 +4924,9 @@ struct omni_context * omni_init(struct common_params * params, int media_type, b
         ctx_omni->special_token_tts_pad = find_token("<|tts_pad|>");
     }
         
+    // Optional GPU utilization sampler uses the same steady-clock base as DUPLEX_PERF.
+    omni_gpu_perf_sampler_start();
+
     // ANE/CoreML warmup: pre-load models into NPU to avoid first-inference latency
     omni_warmup_ane(ctx_omni);
 
@@ -4461,6 +5037,9 @@ void omni_free(struct omni_context * ctx_omni) {
             ctx_omni->t2w_thread.join(); // Wait for the thread to finish
         }
     }
+
+    omni_perf_print_token_stats(ctx_omni);
+    omni_gpu_perf_sampler_stop();
     
     delete ctx_omni->ctx_vision;
     audition_free(ctx_omni->ctx_audio);
@@ -4699,6 +5278,25 @@ void llm_thread_func(omni_context* ctx_omni, common_params* params){
             // 后续轮次在 stream_decode 结束时添加
             // 不再需要在这里动态添加
 
+            int perf_chunk_index = -1;
+            if (!llm_embeds.empty()) {
+                perf_chunk_index = llm_embeds.front()->index;
+            }
+            const int kv_prefill_start_n_past = ctx_omni->n_past;
+            auto kv_prefill_t0 = std::chrono::steady_clock::now();
+            std::string kv_prefill_detail = "items=" + std::to_string(llm_embeds.size());
+            long long perf_prefill_text_tokens = 0;
+            long long perf_prefill_embed_tokens = 0;
+            auto eval_prefill_string = [&](const char * text) {
+                int n_text_tokens = 0;
+                bool ok = eval_string(ctx_omni, params, text, params->n_batch, &ctx_omni->n_past, false, false, &n_text_tokens);
+                if (ok) {
+                    perf_prefill_text_tokens += n_text_tokens;
+                }
+                return ok;
+            };
+            omni_perf_mark(ctx_omni, "llm.prefill", "start", perf_chunk_index, -1.0, kv_prefill_detail.c_str());
+
             // 🔧 [重构] 逐个处理嵌入数据，正确添加特殊标记
             // 遍历所有嵌入数据
             for (int il = 0; il < (int)llm_embeds.size(); ++il) {
@@ -4720,27 +5318,31 @@ void llm_thread_func(omni_context* ctx_omni, common_params* params){
                     
                     // 🔧 [与 Python 对齐] 根据模式决定是否添加 <unit>
                     if (ctx_omni->duplex_mode) {
-                        eval_string(ctx_omni, params, "<unit><image>", params->n_batch, &ctx_omni->n_past, false);
+                        eval_prefill_string("<unit><image>");
                     } else {
-                        eval_string(ctx_omni, params, "<image>", params->n_batch, &ctx_omni->n_past, false);
+                        eval_prefill_string("<image>");
                     }
                     
                     // Prefill overview embedding (第一个 chunk)
-                    prefill_with_emb(ctx_omni, params, embeds->vision_embed[0].data(), tokens_per_chunk, 
-                                    params->n_batch, &ctx_omni->n_past);
-                    eval_string(ctx_omni, params, "</image>", params->n_batch, &ctx_omni->n_past, false);
+                    if (prefill_with_emb(ctx_omni, params, embeds->vision_embed[0].data(), tokens_per_chunk,
+                                         params->n_batch, &ctx_omni->n_past)) {
+                        perf_prefill_embed_tokens += tokens_per_chunk;
+                    }
+                    eval_prefill_string("</image>");
                     
                     // 🔧 [高清模式 V2.6 schema] 如果有 slices，添加 <slice> 标记
                     // 格式: <image>(overview)</image><slice>(slice1)</slice><slice>(slice2)</slice>\n
                     if (has_slices) {
                         for (int i = 1; i < n_chunks; i++) {
-                            eval_string(ctx_omni, params, "<slice>", params->n_batch, &ctx_omni->n_past, false);
-                            prefill_with_emb(ctx_omni, params, embeds->vision_embed[i].data(), tokens_per_chunk,
-                                            params->n_batch, &ctx_omni->n_past);
-                            eval_string(ctx_omni, params, "</slice>", params->n_batch, &ctx_omni->n_past, false);
+                            eval_prefill_string("<slice>");
+                            if (prefill_with_emb(ctx_omni, params, embeds->vision_embed[i].data(), tokens_per_chunk,
+                                                 params->n_batch, &ctx_omni->n_past)) {
+                                perf_prefill_embed_tokens += tokens_per_chunk;
+                            }
+                            eval_prefill_string("</slice>");
                         }
                         // V2.6 格式在 slices 后添加换行
-                        eval_string(ctx_omni, params, "\n", params->n_batch, &ctx_omni->n_past, false);
+                        eval_prefill_string("\n");
                     }
                     
                     print_with_timestamp("Omni模式: %d vision chunks (%d tokens each), %d audio tokens, has_slices=%d\n", 
@@ -4750,12 +5352,14 @@ void llm_thread_func(omni_context* ctx_omni, common_params* params){
                     if (has_audio) {
                         if (!ctx_omni->duplex_mode) {
                             // 单工格式：<|audio_start|> + audio + <|audio_end|>
-                            eval_string(ctx_omni, params, "<|audio_start|>", params->n_batch, &ctx_omni->n_past, false);
+                            eval_prefill_string("<|audio_start|>");
                         }
-                        prefill_with_emb(ctx_omni, params, embeds->audio_embed.data(), n_audio_tokens,
-                                        params->n_batch, &ctx_omni->n_past);
+                        if (prefill_with_emb(ctx_omni, params, embeds->audio_embed.data(), n_audio_tokens,
+                                             params->n_batch, &ctx_omni->n_past)) {
+                            perf_prefill_embed_tokens += n_audio_tokens;
+                        }
                         if (!ctx_omni->duplex_mode) {
-                            eval_string(ctx_omni, params, "<|audio_end|>", params->n_batch, &ctx_omni->n_past, false);
+                            eval_prefill_string("<|audio_end|>");
                         }
                     }
                 }
@@ -4767,19 +5371,21 @@ void llm_thread_func(omni_context* ctx_omni, common_params* params){
                     // 🔧 [根据模式选择格式]
                     if (ctx_omni->duplex_mode) {
                         // 双工格式：<unit> + audio_embedding（无 audio_start/end）
-                        eval_string(ctx_omni, params, "<unit>", params->n_batch, &ctx_omni->n_past, false);
+                        eval_prefill_string("<unit>");
                     } else {
                         // 单工格式：<|audio_start|> + audio + <|audio_end|>
-                        eval_string(ctx_omni, params, "<|audio_start|>", params->n_batch, &ctx_omni->n_past, false);
+                        eval_prefill_string("<|audio_start|>");
                     }
                     
                     // Prefill 音频 embedding
-                    prefill_with_emb(ctx_omni, params, embeds->audio_embed.data(), n_audio_tokens,
-                                    params->n_batch, &ctx_omni->n_past);
+                    if (prefill_with_emb(ctx_omni, params, embeds->audio_embed.data(), n_audio_tokens,
+                                         params->n_batch, &ctx_omni->n_past)) {
+                        perf_prefill_embed_tokens += n_audio_tokens;
+                    }
                     
                     // 单工格式需要 <|audio_end|>
                     if (!ctx_omni->duplex_mode) {
-                        eval_string(ctx_omni, params, "<|audio_end|>", params->n_batch, &ctx_omni->n_past, false);
+                        eval_prefill_string("<|audio_end|>");
                     }
                 }
                 // 子分支3：纯文本输入（turn-based chat 文本对话）
@@ -4803,6 +5409,22 @@ void llm_thread_func(omni_context* ctx_omni, common_params* params){
                 
                 // 释放嵌入数据的内存（由生产者线程分配）
                 delete embeds;
+            }
+            {
+                const double kv_prefill_ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - kv_prefill_t0).count();
+                const long long n_past_delta = ctx_omni->n_past - kv_prefill_start_n_past;
+                long long perf_prefill_tokens = perf_prefill_text_tokens + perf_prefill_embed_tokens;
+                if (perf_prefill_tokens <= 0 && n_past_delta > 0) {
+                    perf_prefill_tokens = n_past_delta;
+                }
+                std::string detail = kv_prefill_detail +
+                                     ",tokens=" + std::to_string(perf_prefill_tokens) +
+                                     ",text_tokens=" + std::to_string(perf_prefill_text_tokens) +
+                                     ",embed_tokens=" + std::to_string(perf_prefill_embed_tokens) +
+                                     ",n_past_delta=" + std::to_string(n_past_delta) +
+                                     omni_perf_speed_detail(perf_prefill_tokens, kv_prefill_ms);
+                omni_perf_record_tokens(ctx_omni, "llm.prefill", perf_prefill_tokens, kv_prefill_ms);
+                omni_perf_mark(ctx_omni, "llm.prefill", "end", perf_chunk_index, kv_prefill_ms, detail.c_str());
             }
             
             // 🔧 [诊断] 打印 prefill 结束后的 n_past
@@ -4966,7 +5588,8 @@ static bool generate_audio_tokens_local_simplex(
     int chunk_idx,
     std::vector<int32_t>& output_audio_tokens,
     const std::string& output_dir = "",
-    bool is_final_text_chunk = false  // 🔧 [与 Python 对齐] 是否是最后一个 text chunk
+    bool is_final_text_chunk = false,  // 🔧 [与 Python 对齐] 是否是最后一个 text chunk
+    int * compute_tokens_out = nullptr
 ) {
     print_with_timestamp("TTS Simplex: generating audio tokens for chunk %d (n_tokens=%d, tts_n_embd=%d)\n",
                         chunk_idx, n_tokens, tts_n_embd);
@@ -5069,6 +5692,7 @@ static bool generate_audio_tokens_local_simplex(
     print_with_timestamp("TTS Simplex: sampler created\n");
     
     output_audio_tokens.clear();
+    int compute_tokens = 0;
     
     // 🔧 [与 Python 对齐] 统一使用 tts_token_buffer 管理，和 Python _token_buffer 一致
     // Python chunk_size=25，每凑够 25 个才 yield
@@ -5110,6 +5734,7 @@ static bool generate_audio_tokens_local_simplex(
             LOG_ERR("TTS Simplex: sample_tts_token failed at step %d\n", t);
             break;
         }
+        compute_tokens++;
         
         int relative_idx = sampled_token_abs - audio_bos_token_id;
         if (relative_idx < 0 || relative_idx >= num_audio_tokens) {
@@ -5213,6 +5838,7 @@ static bool generate_audio_tokens_local_simplex(
                     LOG_ERR("TTS Simplex Phase2: sample failed at step %d\n", t2);
                     break;
                 }
+                compute_tokens++;
                 
                 int relative_idx = sampled_token_abs - audio_bos_token_id;
                 if (relative_idx < 0 || relative_idx >= num_audio_tokens) {
@@ -5326,13 +5952,16 @@ static bool generate_audio_tokens_local_simplex(
                         ctx_omni->tts_n_past_accumulated, ctx_omni->tts_all_generated_tokens.size());
     
     // Save tokens to file if output_dir is specified
-    if (!output_dir.empty() && !output_audio_tokens.empty()) {
+    if (omni_tts_debug_dump_enabled() && !output_dir.empty() && !output_audio_tokens.empty()) {
         std::string tokens_file = output_dir + "/audio_tokens_chunk_" + std::to_string(chunk_idx) + ".bin";
         FILE* f = fopen(tokens_file.c_str(), "wb");
         if (f) {
             fwrite(output_audio_tokens.data(), sizeof(int32_t), output_audio_tokens.size(), f);
             fclose(f);
         }
+    }
+    if (compute_tokens_out != nullptr) {
+        *compute_tokens_out = compute_tokens;
     }
     
     return !output_audio_tokens.empty();
@@ -5351,10 +5980,15 @@ static bool generate_audio_tokens_local(
     int chunk_idx,
     std::vector<int32_t>& output_audio_tokens,
     bool is_end_of_turn = false,  // 🔧 [与 Python 对齐] 是否是轮次结束
-    const std::string& output_dir = ""
+    const std::string& output_dir = "",
+    int perf_chunk_index = -1,
+    int * compute_tokens_out = nullptr
 ) {
     print_with_timestamp("TTS Local: generating audio tokens for chunk %d (n_tokens=%d, tts_n_embd=%d, emb_size=%zu)\n", 
                          chunk_idx, n_tokens, tts_n_embd, merged_embeddings.size());
+    if (perf_chunk_index < 0 && ctx_omni) {
+        perf_chunk_index = ctx_omni->perf_current_chunk_index.load();
+    }
     
     // 🔧 [安全检查] 验证输入参数
     // 🔧 [修复尾音问题] 当 is_end_of_turn=true 时，允许 n_tokens=0
@@ -5503,6 +6137,7 @@ static bool generate_audio_tokens_local(
     
     // 3. Generate audio tokens with streaming to T2W queue
     output_audio_tokens.clear();
+    int compute_tokens = 0;
     // Python: self.all_generated_tokens 是类成员变量，跨 chunk 持续累积
     // 用于：1. 正确判断是否是整个生成过程的第一个 token（re-forward condition）
     
@@ -5557,6 +6192,7 @@ static bool generate_audio_tokens_local(
             LOG_ERR("TTS Local: sample_tts_token failed at step %d\n", t);
             break;
         }
+        compute_tokens++;
         
         // Convert to relative index and check EOS
         int relative_idx = sampled_token_abs - audio_bos_token_id;
@@ -5603,12 +6239,19 @@ static bool generate_audio_tokens_local(
             t2w_out->is_final = false;
             t2w_out->is_chunk_end = false;  // 🔧 中间推送，不是 chunk 结束
             t2w_out->round_idx = ctx_omni->simplex_round_idx;  // 🔧 传递轮次索引
+            t2w_out->perf_chunk_index = perf_chunk_index;
             
+            auto enqueue_t0 = std::chrono::steady_clock::now();
+            std::string enqueue_detail = "tokens=" + std::to_string(t2w_out->audio_tokens.size()) +
+                                         ",is_final=0,is_chunk_end=0";
+            omni_perf_mark(ctx_omni, "queue.t2w.enqueue", "start", perf_chunk_index, -1.0, enqueue_detail.c_str());
             {
                 std::lock_guard<std::mutex> lock(ctx_omni->t2w_thread_info->mtx);
                 ctx_omni->t2w_thread_info->queue.push(t2w_out);
             }
             ctx_omni->t2w_thread_info->cv.notify_one();
+            double enqueue_ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - enqueue_t0).count();
+            omni_perf_mark(ctx_omni, "queue.t2w.enqueue", "end", perf_chunk_index, enqueue_ms, enqueue_detail.c_str());
             stream_buffer.clear();
         }
         
@@ -5632,12 +6275,20 @@ static bool generate_audio_tokens_local(
         t2w_out->is_final = is_end_of_turn;
         t2w_out->is_chunk_end = !is_end_of_turn;  // 非 turn 结束时才用 is_chunk_end
         t2w_out->round_idx = ctx_omni->simplex_round_idx;  // 🔧 传递轮次索引
+        t2w_out->perf_chunk_index = perf_chunk_index;
         
+        auto enqueue_t0 = std::chrono::steady_clock::now();
+        std::string enqueue_detail = "tokens=" + std::to_string(t2w_out->audio_tokens.size()) +
+                                     ",is_final=" + std::to_string(t2w_out->is_final ? 1 : 0) +
+                                     ",is_chunk_end=" + std::to_string(t2w_out->is_chunk_end ? 1 : 0);
+        omni_perf_mark(ctx_omni, "queue.t2w.enqueue", "start", perf_chunk_index, -1.0, enqueue_detail.c_str());
         {
             std::lock_guard<std::mutex> lock(ctx_omni->t2w_thread_info->mtx);
             ctx_omni->t2w_thread_info->queue.push(t2w_out);
         }
         ctx_omni->t2w_thread_info->cv.notify_one();
+        double enqueue_ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - enqueue_t0).count();
+        omni_perf_mark(ctx_omni, "queue.t2w.enqueue", "end", perf_chunk_index, enqueue_ms, enqueue_detail.c_str());
     }
     
     // Cleanup sampler
@@ -5648,13 +6299,16 @@ static bool generate_audio_tokens_local(
     ctx_omni->tts_n_past_accumulated = n_past_tts;
     
     // Save tokens to file if output_dir is specified
-    if (!output_dir.empty() && !output_audio_tokens.empty()) {
+    if (omni_tts_debug_dump_enabled() && !output_dir.empty() && !output_audio_tokens.empty()) {
         std::string tokens_file = output_dir + "/audio_tokens_chunk_" + std::to_string(chunk_idx) + ".bin";
         FILE* f = fopen(tokens_file.c_str(), "wb");
         if (f) {
             fwrite(output_audio_tokens.data(), sizeof(int32_t), output_audio_tokens.size(), f);
             fclose(f);
         }
+    }
+    if (compute_tokens_out != nullptr) {
+        *compute_tokens_out = compute_tokens;
     }
     
     return !output_audio_tokens.empty();
@@ -5923,6 +6577,7 @@ void tts_thread_func_duplex(struct omni_context * ctx_omni, common_params *param
     const std::string tts_output_dir = base_output_dir + "/tts_txt";
     const std::string llm_debug_output_dir = base_output_dir + "/llm_debug";
     const std::string tts_wav_output_dir = base_output_dir + "/tts_wav";
+    const bool tts_debug_dump = omni_tts_debug_dump_enabled();
     
     // Helper function to create directory
     auto create_dir = [](const std::string& dir_path) {
@@ -5934,8 +6589,10 @@ void tts_thread_func_duplex(struct omni_context * ctx_omni, common_params *param
     };
     
     // 创建输出目录
-    create_dir(tts_output_dir);
-    create_dir(llm_debug_output_dir);
+    if (tts_debug_dump) {
+        create_dir(tts_output_dir);
+        create_dir(llm_debug_output_dir);
+    }
     create_dir(tts_wav_output_dir);
     
     // TTS model constants
@@ -5997,14 +6654,19 @@ void tts_thread_func_duplex(struct omni_context * ctx_omni, common_params *param
         
         // 🔧 [修复双工缺字问题] 从 LLMOut 获取 is_end_of_turn 状态
         bool accumulated_is_end_of_turn = false;
+        int current_perf_chunk_index = -1;
             
         // Wait for queue
         if (!llm_finish || (llm_finish && llm_text.empty())) {
             std::unique_lock<std::mutex> lock(ctx_omni->tts_thread_info->mtx);
             auto& queue = ctx_omni->tts_thread_info->queue;
+            auto wait_t0 = std::chrono::steady_clock::now();
+            omni_perf_mark(ctx_omni, "queue.tts.wait_data", "start", -1, -1.0, nullptr);
             ctx_omni->tts_thread_info->cv.wait(lock, [&] { 
                 return !queue.empty() || !tts_thread_running || ctx_omni->break_event.load(); 
             });
+            double wait_ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - wait_t0).count();
+            omni_perf_mark(ctx_omni, "queue.tts.wait_data", "end", -1, wait_ms, nullptr);
             
             if (ctx_omni->break_event.load()) {
                 lock.unlock();
@@ -6020,6 +6682,7 @@ void tts_thread_func_duplex(struct omni_context * ctx_omni, common_params *param
             current_chunk_hidden_states.clear();
             current_chunk_n_embd = 0;
             accumulated_is_end_of_turn = false;
+            current_perf_chunk_index = -1;
             
             // 累积所有队列中的数据
             while (!queue.empty()) {
@@ -6027,6 +6690,9 @@ void tts_thread_func_duplex(struct omni_context * ctx_omni, common_params *param
                 llm_finish |= llm_out->llm_finish;
                 bool item_is_eot = llm_out->is_end_of_turn;
                 accumulated_is_end_of_turn |= item_is_eot;
+                if (current_perf_chunk_index < 0 && llm_out->perf_chunk_index >= 0) {
+                    current_perf_chunk_index = llm_out->perf_chunk_index;
+                }
                 
                 if (!ctx_omni->speek_done || ctx_omni->duplex_mode) {
                     llm_text += llm_out->text;
@@ -6085,6 +6751,7 @@ void tts_thread_func_duplex(struct omni_context * ctx_omni, common_params *param
                         t2w_out->is_final = false;
                         t2w_out->is_chunk_end = true;
                         t2w_out->round_idx = ctx_omni->simplex_round_idx;  // 🔧 传递轮次索引
+                        t2w_out->perf_chunk_index = current_perf_chunk_index;
                         {
                             std::lock_guard<std::mutex> lock(ctx_omni->t2w_thread_info->mtx);
                             ctx_omni->t2w_thread_info->queue.push(t2w_out);
@@ -6152,6 +6819,7 @@ void tts_thread_func_duplex(struct omni_context * ctx_omni, common_params *param
                     t2w_out->is_final = false;
                     t2w_out->is_chunk_end = true;
                     t2w_out->round_idx = ctx_omni->simplex_round_idx;  // 🔧 传递轮次索引
+                    t2w_out->perf_chunk_index = current_perf_chunk_index;
                     {
                         std::lock_guard<std::mutex> lock(ctx_omni->t2w_thread_info->mtx);
                         ctx_omni->t2w_thread_info->queue.push(t2w_out);
@@ -6172,6 +6840,7 @@ void tts_thread_func_duplex(struct omni_context * ctx_omni, common_params *param
                     t2w_out->is_final = true;
                     t2w_out->is_chunk_end = false;
                     t2w_out->round_idx = ctx_omni->simplex_round_idx;  // 🔧 传递轮次索引
+                    t2w_out->perf_chunk_index = current_perf_chunk_index;
                     {
                         std::lock_guard<std::mutex> lock(ctx_omni->t2w_thread_info->mtx);
                         ctx_omni->t2w_thread_info->queue.push(t2w_out);
@@ -6220,21 +6889,39 @@ void tts_thread_func_duplex(struct omni_context * ctx_omni, common_params *param
                 continue;
             }
             
-            // Filter special tokens
-            int n_tokens_orig = (int)(current_chunk_hidden_states.size() / current_chunk_n_embd);
-            std::vector<llama_token> filtered_token_ids = current_chunk_token_ids;
-            std::vector<float> filtered_hidden_states = current_chunk_hidden_states;
-            filter_special_tokens(filtered_token_ids, filtered_hidden_states, current_chunk_n_embd);
-            int n_tokens_filtered = (int)(filtered_hidden_states.size() / current_chunk_n_embd);
-            
-            if (n_tokens_filtered <= 0) {
-                continue;
-            }
-            
-            // Compute merged embeddings
-            const int tts_n_embd = llama_n_embd(llama_get_model(ctx_omni->ctx_tts_llama));
-            std::vector<float> merged_embeddings;
-            bool merged_success = false;
+            {
+                std::string tts_infer_detail = "tts_chunk=" + std::to_string(current_chunk_idx) +
+                                               ",llm_tokens=" + std::to_string(current_chunk_token_ids.size()) +
+                                               ",is_end_of_turn=" + std::to_string(accumulated_is_end_of_turn ? 1 : 0);
+                OmniPerfScope tts_infer_scope(ctx_omni, "tts.infer", current_perf_chunk_index, tts_infer_detail);
+                int tts_filtered_llm_tokens = 0;
+                int tts_condition_tokens = 0;
+                int tts_audio_tokens_generated = 0;
+                int tts_compute_tokens = 0;
+                bool tts_flush_only = false;
+
+                // Filter special tokens
+                std::vector<llama_token> filtered_token_ids = current_chunk_token_ids;
+                std::vector<float> filtered_hidden_states = current_chunk_hidden_states;
+                filter_special_tokens(filtered_token_ids, filtered_hidden_states, current_chunk_n_embd);
+                int n_tokens_filtered = (int)(filtered_hidden_states.size() / current_chunk_n_embd);
+                tts_filtered_llm_tokens = n_tokens_filtered;
+
+                if (n_tokens_filtered <= 0) {
+                    tts_infer_detail = "tts_chunk=" + std::to_string(current_chunk_idx) +
+                                       ",llm_tokens=" + std::to_string(current_chunk_token_ids.size()) +
+                                       ",filtered_llm_tokens=0,condition_tokens=0,compute_tokens=0,audio_tokens_generated=0" +
+                                       ",tokens=0" +
+                                       ",is_end_of_turn=" + std::to_string(accumulated_is_end_of_turn ? 1 : 0);
+                    tts_infer_scope.set_detail(tts_infer_detail);
+                    tts_infer_scope.set_tokens(0);
+                    continue;
+                }
+
+                // Compute merged embeddings
+                const int tts_n_embd = llama_n_embd(llama_get_model(ctx_omni->ctx_tts_llama));
+                std::vector<float> merged_embeddings;
+                bool merged_success = false;
             
             if (ctx_omni->emb_text_weight && ctx_omni->projector_semantic_linear1_weight) {
                 // Step 1: emb_text
@@ -6270,6 +6957,7 @@ void tts_thread_func_duplex(struct omni_context * ctx_omni, common_params *param
                         if (tts_emb_text(ctx_omni, audio_bos_token_id, audio_bos_embed.data(), tts_n_embd)) {
                             merged_embeddings.insert(merged_embeddings.end(), audio_bos_embed.begin(), audio_bos_embed.end());
                             n_tokens_filtered += 1;
+                            tts_condition_tokens = n_tokens_filtered;
                         }
                         
                         merged_success = true;
@@ -6279,7 +6967,7 @@ void tts_thread_func_duplex(struct omni_context * ctx_omni, common_params *param
             
             // 🔧 [双工模式] 保存 LLM debug 数据（追加模式，统一放在 llm_debug 目录）
             // Save LLM debug data: text, token_ids, hidden_states, and merged embeddings
-            {
+            if (tts_debug_dump) {
                 // 1. Save LLM text output (追加模式，只记录纯文本，不记录 special tokens)
                 {
                     // 从 llm_text 中过滤掉 special tokens
@@ -6366,26 +7054,42 @@ void tts_thread_func_duplex(struct omni_context * ctx_omni, common_params *param
             bool should_call_tts = (merged_success && !merged_embeddings.empty()) || 
                                    (accumulated_is_end_of_turn && ctx_omni->duplex_mode);
             
-            if (should_call_tts) {
-                std::vector<int32_t> audio_tokens_out;
-                bool is_end_of_turn = accumulated_is_end_of_turn;
-                
-                if (merged_embeddings.empty() && is_end_of_turn) {
-                    print_with_timestamp("TTS Duplex: is_end_of_turn=true with empty embeddings, calling TTS to flush\n");
-                    n_tokens_filtered = 0;
-                }
-                
-                bool tts_gen_success = generate_audio_tokens_local(ctx_omni, params, merged_embeddings,
-                                                n_tokens_filtered, tts_n_embd, current_chunk_idx,
-                                                audio_tokens_out, is_end_of_turn, tts_wav_output_dir);
-                
-                if (tts_gen_success) {
-                    all_audio_tokens.insert(all_audio_tokens.end(), audio_tokens_out.begin(), audio_tokens_out.end());
-                    
-                    if (is_end_of_turn && ctx_omni->duplex_mode) {
-                        turn_eos_flushed = true;
+                if (should_call_tts) {
+                    std::vector<int32_t> audio_tokens_out;
+                    bool is_end_of_turn = accumulated_is_end_of_turn;
+
+                    if (merged_embeddings.empty() && is_end_of_turn) {
+                        print_with_timestamp("TTS Duplex: is_end_of_turn=true with empty embeddings, calling TTS to flush\n");
+                        n_tokens_filtered = 0;
+                    }
+
+                    bool tts_gen_success = generate_audio_tokens_local(ctx_omni, params, merged_embeddings,
+                                                    n_tokens_filtered, tts_n_embd, current_chunk_idx,
+                                                    audio_tokens_out, is_end_of_turn, tts_wav_output_dir,
+                                                    current_perf_chunk_index, &tts_compute_tokens);
+                    tts_condition_tokens = n_tokens_filtered + 1 + (is_end_of_turn ? 1 : 0);
+                    tts_audio_tokens_generated = (int) audio_tokens_out.size();
+
+                    if (tts_gen_success) {
+                        all_audio_tokens.insert(all_audio_tokens.end(), audio_tokens_out.begin(), audio_tokens_out.end());
+
+                        if (is_end_of_turn && ctx_omni->duplex_mode) {
+                            turn_eos_flushed = true;
+                        }
                     }
                 }
+                tts_infer_detail = "tts_chunk=" + std::to_string(current_chunk_idx) +
+                                   ",llm_tokens=" + std::to_string(current_chunk_token_ids.size()) +
+                                   ",filtered_llm_tokens=" + std::to_string(tts_filtered_llm_tokens) +
+                                   ",condition_tokens=" + std::to_string(tts_condition_tokens) +
+                                   ",compute_tokens=" + std::to_string(tts_compute_tokens) +
+                                   ",audio_tokens_generated=" + std::to_string(tts_audio_tokens_generated) +
+                                   ",tokens=" + std::to_string(tts_compute_tokens) +
+                                   ",output_tokens=" + std::to_string(tts_audio_tokens_generated) +
+                                   ",is_end_of_turn=" + std::to_string(accumulated_is_end_of_turn ? 1 : 0) +
+                                   ",flush_only=" + std::to_string(tts_flush_only ? 1 : 0);
+                tts_infer_scope.set_detail(tts_infer_detail);
+                tts_infer_scope.set_tokens(tts_compute_tokens);
             }
             
             ++chunk_idx;
@@ -6409,6 +7113,7 @@ void tts_thread_func_duplex(struct omni_context * ctx_omni, common_params *param
                         t2w_out->is_final = false;
                         t2w_out->is_chunk_end = true;
                         t2w_out->round_idx = ctx_omni->simplex_round_idx;  // 🔧 传递轮次索引
+                        t2w_out->perf_chunk_index = current_perf_chunk_index;
                         {
                             std::lock_guard<std::mutex> lock(ctx_omni->t2w_thread_info->mtx);
                             ctx_omni->t2w_thread_info->queue.push(t2w_out);
@@ -6424,6 +7129,7 @@ void tts_thread_func_duplex(struct omni_context * ctx_omni, common_params *param
                         t2w_out->audio_tokens.clear();
                         t2w_out->is_final = true;
                         t2w_out->round_idx = ctx_omni->simplex_round_idx;  // 🔧 传递轮次索引
+                        t2w_out->perf_chunk_index = current_perf_chunk_index;
                         {
                             std::lock_guard<std::mutex> lock(ctx_omni->t2w_thread_info->mtx);
                             ctx_omni->t2w_thread_info->queue.push(t2w_out);
@@ -6458,11 +7164,25 @@ void tts_thread_func_duplex(struct omni_context * ctx_omni, common_params *param
                 std::vector<float> empty_embeddings;
                 std::vector<int32_t> audio_tokens_out;
                 int n_tokens_for_tts = 0;
+                int tts_compute_tokens = 0;
                 int current_chunk_idx = chunk_idx;
+                std::string tts_infer_detail = "tts_chunk=" + std::to_string(current_chunk_idx) +
+                                               ",llm_tokens=0,filtered_llm_tokens=0,condition_tokens=0,compute_tokens=0,audio_tokens_generated=0,is_end_of_turn=1,flush_only=1";
+                OmniPerfScope tts_infer_scope(ctx_omni, "tts.infer", current_perf_chunk_index, tts_infer_detail);
                 
                 bool tts_gen_success = generate_audio_tokens_local(ctx_omni, params, empty_embeddings,
                                                 n_tokens_for_tts, tts_n_embd, current_chunk_idx,
-                                                audio_tokens_out, true, tts_wav_output_dir);
+                                                audio_tokens_out, true, tts_wav_output_dir,
+                                                current_perf_chunk_index, &tts_compute_tokens);
+                tts_infer_detail = "tts_chunk=" + std::to_string(current_chunk_idx) +
+                                   ",llm_tokens=0,filtered_llm_tokens=0,condition_tokens=2" +
+                                   ",compute_tokens=" + std::to_string(tts_compute_tokens) +
+                                   ",audio_tokens_generated=" + std::to_string(audio_tokens_out.size()) +
+                                   ",tokens=" + std::to_string(tts_compute_tokens) +
+                                   ",output_tokens=" + std::to_string(audio_tokens_out.size()) +
+                                   ",is_end_of_turn=1,flush_only=1";
+                tts_infer_scope.set_detail(tts_infer_detail);
+                tts_infer_scope.set_tokens(tts_compute_tokens);
                 
                 if (tts_gen_success) {
                     all_audio_tokens.insert(all_audio_tokens.end(), audio_tokens_out.begin(), audio_tokens_out.end());
@@ -6473,6 +7193,7 @@ void tts_thread_func_duplex(struct omni_context * ctx_omni, common_params *param
                         t2w_out->is_final = true;
                         t2w_out->is_chunk_end = false;
                         t2w_out->round_idx = ctx_omni->simplex_round_idx;  // 🔧 传递轮次索引
+                        t2w_out->perf_chunk_index = current_perf_chunk_index;
                         {
                             std::lock_guard<std::mutex> lock(ctx_omni->t2w_thread_info->mtx);
                             ctx_omni->t2w_thread_info->queue.push(t2w_out);
@@ -6567,6 +7288,7 @@ void tts_thread_func(struct omni_context * ctx_omni, common_params *params) {
     std::string tts_output_dir = current_round_dir + "/tts_txt";
     std::string llm_debug_output_dir = current_round_dir + "/llm_debug";
     std::string tts_wav_output_dir = current_round_dir + "/tts_wav";
+    const bool tts_debug_dump = omni_tts_debug_dump_enabled();
     
     // 记录上一次创建目录的 round_idx，避免重复创建
     int last_created_round_idx = -1;
@@ -6580,8 +7302,10 @@ void tts_thread_func(struct omni_context * ctx_omni, common_params *params) {
         
         // 只在新的 round 时创建目录
         if (ctx_omni->simplex_round_idx != last_created_round_idx || ctx_omni->duplex_mode) {
-            create_dir(tts_output_dir);
-            create_dir(llm_debug_output_dir);
+            if (tts_debug_dump) {
+                create_dir(tts_output_dir);
+                create_dir(llm_debug_output_dir);
+            }
             create_dir(tts_wav_output_dir);
             last_created_round_idx = ctx_omni->simplex_round_idx;
             
@@ -6614,7 +7338,9 @@ void tts_thread_func(struct omni_context * ctx_omni, common_params *params) {
             fclose(f_timing);
         }
     };
-    create_wav_timing_file();
+    if (tts_debug_dump) {
+        create_wav_timing_file();
+    }
 
     print_with_timestamp("TTS thread started\n");
 
@@ -6926,7 +7652,9 @@ void tts_thread_func(struct omni_context * ctx_omni, common_params *params) {
             // 确保每轮数据保存在独立的 round_XXX 子目录下
             if (chunk_idx == 0 && !ctx_omni->duplex_mode) {
                 update_output_dirs();
-                create_wav_timing_file();
+                if (tts_debug_dump) {
+                    create_wav_timing_file();
+                }
             }
             
             // Save current chunk_idx to ensure consistent directory naming
@@ -7024,7 +7752,7 @@ void tts_thread_func(struct omni_context * ctx_omni, common_params *params) {
             }
             
             // Save LLM debug data: text, token_ids, hidden_states, and merged embeddings
-            {
+            if (tts_debug_dump) {
                 // Create chunk-specific directory
                 std::string chunk_dir = llm_debug_output_dir + "/chunk_" + std::to_string(current_chunk_idx);
                 create_dir(chunk_dir);
@@ -7132,18 +7860,20 @@ void tts_thread_func(struct omni_context * ctx_omni, common_params *params) {
                 if (tts_gen_success) {
                     tts_success = true;
                     
-                    // Save audio tokens for external token2wav processing (backup)
-                    // token2wav expects relative token IDs (0-6561)
-                    std::string tokens_txt_file = tts_wav_output_dir + "/audio_tokens_chunk_" + 
-                                                  std::to_string(current_chunk_idx) + ".txt";
-                    FILE* f_tokens = fopen(tokens_txt_file.c_str(), "w");
-                    if (f_tokens) {
-                        for (size_t i = 0; i < audio_tokens.size(); ++i) {
-                            fprintf(f_tokens, "%d", audio_tokens[i]);
-                            if (i < audio_tokens.size() - 1) fprintf(f_tokens, ",");
+                    if (tts_debug_dump) {
+                        // Save audio tokens for external token2wav processing (backup)
+                        // token2wav expects relative token IDs (0-6561)
+                        std::string tokens_txt_file = tts_wav_output_dir + "/audio_tokens_chunk_" +
+                                                      std::to_string(current_chunk_idx) + ".txt";
+                        FILE* f_tokens = fopen(tokens_txt_file.c_str(), "w");
+                        if (f_tokens) {
+                            for (size_t i = 0; i < audio_tokens.size(); ++i) {
+                                fprintf(f_tokens, "%d", audio_tokens[i]);
+                                if (i < audio_tokens.size() - 1) fprintf(f_tokens, ",");
+                            }
+                            fprintf(f_tokens, "\n");
+                            fclose(f_tokens);
                         }
-                        fprintf(f_tokens, "\n");
-                        fclose(f_tokens);
                     }
                     
                     // Accumulate all audio tokens for final WAV generation
@@ -8344,7 +9074,11 @@ void t2w_thread_func_python(struct omni_context * ctx_omni, common_params *param
         }
         
         std::unique_lock<std::mutex> lock(mtx);
+        auto wait_t0 = std::chrono::steady_clock::now();
+        omni_perf_mark(ctx_omni, "queue.t2w.wait_data", "start", -1, -1.0, "backend=python");
         cv.wait(lock, [&] { return !queue.empty() || !t2w_thread_running; });
+        double wait_ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - wait_t0).count();
+        omni_perf_mark(ctx_omni, "queue.t2w.wait_data", "end", -1, wait_ms, "backend=python");
         
         if (!t2w_thread_running && queue.empty()) {
             break;
@@ -8360,6 +9094,7 @@ void t2w_thread_func_python(struct omni_context * ctx_omni, common_params *param
         bool is_final = false;
         bool is_chunk_end = false;
         int received_round_idx = -1;  // 🔧 从队列中获取的 round_idx
+        int received_perf_chunk_index = -1;
         
         while (!queue.empty()) {
             T2WOut *t2w_out = queue.front();
@@ -8370,6 +9105,9 @@ void t2w_thread_func_python(struct omni_context * ctx_omni, common_params *param
             // 🔧 使用最新的 round_idx（最后一个有效的值）
             if (t2w_out->round_idx >= 0) {
                 received_round_idx = t2w_out->round_idx;
+            }
+            if (received_perf_chunk_index < 0 && t2w_out->perf_chunk_index >= 0) {
+                received_perf_chunk_index = t2w_out->perf_chunk_index;
             }
             delete t2w_out;
         }
@@ -8432,7 +9170,19 @@ void t2w_thread_func_python(struct omni_context * ctx_omni, common_params *param
             double inference_time_ms = 0;
             double audio_duration = 0;
             
-            if (process_python_t2w_tokens(ctx_omni, window, is_last_window, wav_path, inference_time_ms, audio_duration)) {
+            auto t2w_perf_t0 = std::chrono::steady_clock::now();
+            std::string t2w_detail = "backend=python,window_tokens=" + std::to_string(window.size()) +
+                                     ",is_last=" + std::to_string(is_last_window ? 1 : 0);
+            omni_perf_mark(ctx_omni, "t2w.infer", "start", received_perf_chunk_index, -1.0, t2w_detail.c_str());
+            bool t2w_ok = process_python_t2w_tokens(ctx_omni, window, is_last_window, wav_path, inference_time_ms, audio_duration);
+            {
+                double t2w_perf_ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t2w_perf_t0).count();
+                std::string detail = t2w_detail + ",ok=" + std::to_string(t2w_ok ? 1 : 0) +
+                                     ",audio_s=" + std::to_string(audio_duration) +
+                                     ",infer_ms=" + std::to_string(inference_time_ms);
+                omni_perf_mark(ctx_omni, "t2w.infer", "end", received_perf_chunk_index, t2w_perf_ms, detail.c_str());
+            }
+            if (t2w_ok) {
                 if (audio_duration > 0) {
                     auto wav_complete_time = std::chrono::high_resolution_clock::now();
                     auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -8621,7 +9371,11 @@ void t2w_thread_func_cpp(struct omni_context * ctx_omni, common_params *params) 
         std::unique_lock<std::mutex> lock(mtx);
         
         // Wait for queue to have data or thread to stop
+        auto wait_t0 = std::chrono::steady_clock::now();
+        omni_perf_mark(ctx_omni, "queue.t2w.wait_data", "start", -1, -1.0, "backend=cpp");
         cv.wait(lock, [&] { return !queue.empty() || !t2w_thread_running || ctx_omni->break_event.load(); });
+        double wait_ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - wait_t0).count();
+        omni_perf_mark(ctx_omni, "queue.t2w.wait_data", "end", -1, wait_ms, "backend=cpp");
         auto dequeue_time = std::chrono::steady_clock::now();
         
         if (!t2w_thread_running && queue.empty()) {
@@ -8639,6 +9393,7 @@ void t2w_thread_func_cpp(struct omni_context * ctx_omni, common_params *params) 
         bool is_final = false;
         bool is_chunk_end = false;  // 标记 TTS chunk 结束
         int received_round_idx = -1;  // 🔧 保存传入的 round_idx
+        int received_perf_chunk_index = -1;
         
         std::chrono::steady_clock::time_point oldest_enqueue_time = dequeue_time;
         bool have_enqueue_time = false;
@@ -8656,6 +9411,9 @@ void t2w_thread_func_cpp(struct omni_context * ctx_omni, common_params *params) 
             // 🔧 保存最后一个有效的 round_idx（优先使用非负值）
             if (t2w_out->round_idx >= 0) {
                 received_round_idx = t2w_out->round_idx;
+            }
+            if (received_perf_chunk_index < 0 && t2w_out->perf_chunk_index >= 0) {
+                received_perf_chunk_index = t2w_out->perf_chunk_index;
             }
             delete t2w_out;
         }
@@ -8749,13 +9507,23 @@ void t2w_thread_func_cpp(struct omni_context * ctx_omni, common_params *params) 
             auto t2w_start = std::chrono::high_resolution_clock::now();
             
             std::vector<float> chunk_wav;
-            if (ctx_omni->token2wav_session->feed_window(window, is_last_window, chunk_wav)) {
+            std::string t2w_detail = "backend=cpp,window_tokens=" + std::to_string(window.size()) +
+                                     ",is_last=" + std::to_string(is_last_window ? 1 : 0);
+            omni_perf_mark(ctx_omni, "t2w.infer", "start", received_perf_chunk_index, -1.0, t2w_detail.c_str());
+            bool t2w_ok = ctx_omni->token2wav_session->feed_window(window, is_last_window, chunk_wav);
+            if (t2w_ok) {
                 auto t2w_end = std::chrono::high_resolution_clock::now();
                 double t2w_ms = std::chrono::duration<double, std::milli>(t2w_end - t2w_start).count();
+                std::string detail = t2w_detail + ",ok=1,wav_samples=" + std::to_string(chunk_wav.size());
+                omni_perf_mark(ctx_omni, "t2w.infer", "end", received_perf_chunk_index, t2w_ms, detail.c_str());
                 
                 if (!chunk_wav.empty()) {
                     // Write WAV file
                     std::string wav_path = tts_wav_output_dir + "/wav_" + std::to_string(ctx_omni->wav_turn_base + wav_idx) + ".wav";
+                    auto t2w_write_t0 = std::chrono::steady_clock::now();
+                    std::string write_detail = "backend=cpp,wav_samples=" + std::to_string(chunk_wav.size()) +
+                                               ",path=" + wav_path;
+                    omni_perf_mark(ctx_omni, "t2w.write", "start", received_perf_chunk_index, -1.0, write_detail.c_str());
                     
                     const int16_t num_channels = 1;
                     const int16_t bits_per_sample = 16;
@@ -8807,8 +9575,14 @@ void t2w_thread_func_cpp(struct omni_context * ctx_omni, common_params *params) 
                                             ctx_omni->wav_turn_base + wav_idx, audio_duration, t2w_ms, rtf, (long long)elapsed_ms, queue_wait_ms);
                         wav_idx++;
                     }
+                    double t2w_write_ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t2w_write_t0).count();
+                    omni_perf_mark(ctx_omni, "t2w.write", "end", received_perf_chunk_index, t2w_write_ms, write_detail.c_str());
                 }
             } else {
+                auto t2w_end = std::chrono::high_resolution_clock::now();
+                double t2w_ms = std::chrono::duration<double, std::milli>(t2w_end - t2w_start).count();
+                std::string detail = t2w_detail + ",ok=0";
+                omni_perf_mark(ctx_omni, "t2w.infer", "end", received_perf_chunk_index, t2w_ms, detail.c_str());
                 LOG_ERR("T2W线程: feed_window 失败\n");
             }
             
@@ -9462,7 +10236,7 @@ static void duplex_do_prefill_one(omni_context * ctx_omni, common_params * param
 
 // ---------------------------------------------------------------------------
 // llm thread 的辅助：执行一轮 duplex decode。
-// 语义与老 stream_decode 的 duplex 分支（L9398-L9817 + 尾部 response unit 注册 + 
+// 语义与老 stream_decode 的 duplex 分支（L9398-L9817 + 尾部 response unit 注册 +
 // round boundary）一致，但抽掉了 simplex 相关分支与冗余的 llama_mtx 加锁，
 // 因为新路径下 ctx_llama 已由 llm 线程独占。
 // 返回 false 表示内部异常或被 break 打断。
@@ -9938,6 +10712,9 @@ static bool duplex_decode(omni_context * ctx_omni,
 // ============================================================================
 
 bool stream_prefill(struct omni_context * ctx_omni, std::string aud_fname, std::string img_fname, int index, int max_slice_nums, std::string text) {
+    if (ctx_omni) {
+        ctx_omni->perf_current_chunk_index.store(index);
+    }
 
     // 🔧 [Duplex Pipeline Stage 1] 路由：
     //   duplex_mode && async && index > 0 && system prompt 已初始化 时，走新 duplex 路径。
@@ -9947,6 +10724,9 @@ bool stream_prefill(struct omni_context * ctx_omni, std::string aud_fname, std::
         && ctx_omni->system_prompt_initialized && ctx_omni->duplex != nullptr) {
         return duplex_prefill(ctx_omni, aud_fname, img_fname, index, max_slice_nums);
     }
+
+    std::string prefill_detail = "aud=" + aud_fname + ",img=" + (img_fname.empty() ? "none" : img_fname);
+    OmniPerfScope perf_scope(ctx_omni, "api.stream_prefill", index, prefill_detail);
 
     // 只有在新一轮开始时 (index == 0) 才需要等待上一轮 TTS 完成
     // 同一轮内的后续 prefill (index >= 1) 不需要等待
@@ -9968,7 +10748,7 @@ bool stream_prefill(struct omni_context * ctx_omni, std::string aud_fname, std::
         }
         // 等待完成后重置 speek_done，为下一轮做准备
         ctx_omni->speek_done = false;
-        
+
         // 🔧 [多轮对话修复] 清理 TTS 队列中的残留数据，避免混淆
         if (ctx_omni->tts_thread_info && !ctx_omni->duplex_mode) {
             std::lock_guard<std::mutex> tts_lock(ctx_omni->tts_thread_info->mtx);
@@ -9983,7 +10763,7 @@ bool stream_prefill(struct omni_context * ctx_omni, std::string aud_fname, std::
     } else if (ctx_omni->use_tts && index == 0 && !ctx_omni->duplex_mode) {
         // 否则 LLM 输出会被丢弃（因为 speek_done 初始值为 true）
         ctx_omni->speek_done = false;
-        
+
         // 🔧 [多轮对话修复] 首次初始化时也要清理队列
         if (ctx_omni->tts_thread_info) {
             std::lock_guard<std::mutex> tts_lock(ctx_omni->tts_thread_info->mtx);
@@ -9996,13 +10776,13 @@ bool stream_prefill(struct omni_context * ctx_omni, std::string aud_fname, std::
         }
     } else if (ctx_omni->use_tts) {
     }
-    
+
     // ctx_omni->need_speek = false;
     const int hidden_size = llama_n_embd(llama_get_model(ctx_omni->ctx_llama));
-    
+
     std::string voice_clone_prompt = "";
     std::string assistant_prompt = "";
-    
+
     if (ctx_omni->media_type == 1){ // audio
         // 如果 audio_voice_clone_prompt 以 "<|" 开头（特殊 token），不添加前缀
         // 这允许完全控制 prompt 格式（例如使用 system 而不是 user）
@@ -10037,7 +10817,7 @@ bool stream_prefill(struct omni_context * ctx_omni, std::string aud_fname, std::
         print_with_timestamp("stream_prefill: n_past = %d\n voice_clone_prompt = %s\n assistant_prompt = %s\n", ctx_omni->n_past, voice_clone_prompt.c_str(), assistant_prompt.c_str());
         // tc-todo
         // llama_kv_cache_clear(ctx_omni->ctx_llama);
-        
+
         // 🔧 [对齐 Python 双工模型] 初始化格式
         // Python 双工模型的 _init_duplex_session：
         //   1. feed prefix_system_prompt（包含 <|audio_start|>）
@@ -10056,10 +10836,22 @@ bool stream_prefill(struct omni_context * ctx_omni, std::string aud_fname, std::
             eval_string(ctx_omni, ctx_omni->params, voice_clone_prompt.c_str(), ctx_omni->params->n_batch, &ctx_omni->n_past, false);
             
             // Step 2: 获取并 prefill 参考音频的 APM embedding
+            auto audio_encode_t0 = std::chrono::steady_clock::now();
+            omni_perf_mark(ctx_omni, "session.init.ref_audio_encode", "start", index, -1.0, aud_fname.c_str());
             auto * audio_embeds = omni_audio_embed_make_with_filename(ctx_omni->ctx_audio, ctx_omni->params->cpuparams.n_threads, aud_fname);
+            {
+                double encode_ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - audio_encode_t0).count();
+                std::string detail = "n_pos=" + std::to_string(audio_embeds ? audio_embeds->n_pos : 0);
+                omni_perf_mark(ctx_omni, "session.init.ref_audio_encode", "end", index, encode_ms, detail.c_str());
+            }
             if (audio_embeds != nullptr && audio_embeds->n_pos > 0) {
+                auto ref_prefill_t0 = std::chrono::steady_clock::now();
+                omni_perf_mark(ctx_omni, "session.init.ref_audio_prefill", "start", index, -1.0, nullptr);
                 prefill_with_emb(ctx_omni, ctx_omni->params, audio_embeds->embed, audio_embeds->n_pos, 
                                 ctx_omni->params->n_batch, &ctx_omni->n_past);
+                double ref_prefill_ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - ref_prefill_t0).count();
+                std::string detail = "n_pos=" + std::to_string(audio_embeds->n_pos);
+                omni_perf_mark(ctx_omni, "session.init.ref_audio_prefill", "end", index, ref_prefill_ms, detail.c_str());
                 omni_embed_free(audio_embeds);
             } else {
             }
@@ -10083,11 +10875,23 @@ bool stream_prefill(struct omni_context * ctx_omni, std::string aud_fname, std::
             eval_string(ctx_omni, ctx_omni->params, voice_clone_prompt.c_str(), ctx_omni->params->n_batch, &ctx_omni->n_past, false);
             
             // Step 2: 获取并 prefill 参考音频的 APM embedding
+            auto ref_encode_t0 = std::chrono::steady_clock::now();
+            omni_perf_mark(ctx_omni, "session.init.ref_audio_encode", "start", index, -1.0, system_ref_audio.c_str());
             auto * ref_audio_embeds = omni_audio_embed_make_with_filename(ctx_omni->ctx_audio, ctx_omni->params->cpuparams.n_threads, system_ref_audio);
+            {
+                double encode_ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - ref_encode_t0).count();
+                std::string detail = "n_pos=" + std::to_string(ref_audio_embeds ? ref_audio_embeds->n_pos : 0);
+                omni_perf_mark(ctx_omni, "session.init.ref_audio_encode", "end", index, encode_ms, detail.c_str());
+            }
             if (ref_audio_embeds != nullptr && ref_audio_embeds->n_pos > 0) {
                 print_with_timestamp("system prompt ref_audio embedding: n_pos=%d\n", ref_audio_embeds->n_pos);
+                auto ref_prefill_t0 = std::chrono::steady_clock::now();
+                omni_perf_mark(ctx_omni, "session.init.ref_audio_prefill", "start", index, -1.0, nullptr);
                 prefill_with_emb(ctx_omni, ctx_omni->params, ref_audio_embeds->embed, ref_audio_embeds->n_pos, 
                                 ctx_omni->params->n_batch, &ctx_omni->n_past);
+                double ref_prefill_ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - ref_prefill_t0).count();
+                std::string detail = "n_pos=" + std::to_string(ref_audio_embeds->n_pos);
+                omni_perf_mark(ctx_omni, "session.init.ref_audio_prefill", "end", index, ref_prefill_ms, detail.c_str());
                 omni_embed_free(ref_audio_embeds);
             } else {
                 print_with_timestamp("WARNING: failed to load system prompt ref_audio: %s\n", system_ref_audio.c_str());
@@ -10171,16 +10975,27 @@ bool stream_prefill(struct omni_context * ctx_omni, std::string aud_fname, std::
                     LOG_INF("%s: [临时] max_slice_nums=%d for this prefill\n", __func__, max_slice_nums);
                 }
                 std::vector<std::vector<float>> vision_chunks;
+                auto vision_encode_t0 = std::chrono::steady_clock::now();
+                omni_perf_mark(ctx_omni, "vision.encode", "start", index, -1.0, img_fname.c_str());
                 if (!omni_image_embed_make_chunks_with_filename(ctx_omni->ctx_vision, 
                         ctx_omni->params->cpuparams.n_threads, img_fname, vision_chunks)) {
+                    double vision_encode_ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - vision_encode_t0).count();
+                    omni_perf_mark(ctx_omni, "vision.encode", "end", index, vision_encode_ms, "failed");
                     LOG_ERR("%s: failed to create vision embeddings for %s\n", __func__, img_fname.c_str());
                     return false;
+                }
+                {
+                    double vision_encode_ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - vision_encode_t0).count();
+                    std::string detail = "chunks=" + std::to_string(vision_chunks.size());
+                    omni_perf_mark(ctx_omni, "vision.encode", "end", index, vision_encode_ms, detail.c_str());
                 }
                 
                 int n_chunks = (int)vision_chunks.size();
                 int tokens_per_chunk = (int)vision_chunks[0].size() / hidden_size;
                 bool has_slices = (n_chunks > 1);
                 
+                auto vision_prefill_t0 = std::chrono::steady_clock::now();
+                omni_perf_mark(ctx_omni, "llm.prefill", "start", index, -1.0, "mode=sync,modality=vision");
                 std::string prefix = "<unit>";
                 eval_string(ctx_omni, ctx_omni->params, prefix.c_str(), ctx_omni->params->n_batch, &ctx_omni->n_past, false);
                 
@@ -10198,19 +11013,38 @@ bool stream_prefill(struct omni_context * ctx_omni, std::string aud_fname, std::
                     }
                     eval_string(ctx_omni, ctx_omni->params, "\n", ctx_omni->params->n_batch, &ctx_omni->n_past, false);
                 }
+                {
+                    double vision_prefill_ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - vision_prefill_t0).count();
+                    std::string detail = "chunks=" + std::to_string(n_chunks) + ",tokens_per_chunk=" + std::to_string(tokens_per_chunk);
+                    detail = "mode=sync,modality=vision," + detail;
+                    omni_perf_mark(ctx_omni, "llm.prefill", "end", index, vision_prefill_ms, detail.c_str());
+                }
                 LOG_INF("%s: prefilled %d vision chunks (%d tokens each)\n", __func__, n_chunks, tokens_per_chunk);
             }
             if (aud_fname.length() > 0) {
                 print_with_timestamp("stream_prefill(index=%d): processing user audio: %s\n", index, aud_fname.c_str());
+                auto audio_encode_t0 = std::chrono::steady_clock::now();
+                omni_perf_mark(ctx_omni, "audio.encode", "start", index, -1.0, aud_fname.c_str());
                 auto * embeds = omni_audio_embed_make_with_filename(ctx_omni->ctx_audio, ctx_omni->params->cpuparams.n_threads, aud_fname);
+                {
+                    double audio_encode_ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - audio_encode_t0).count();
+                    std::string detail = "n_pos=" + std::to_string(embeds ? embeds->n_pos : 0);
+                    omni_perf_mark(ctx_omni, "audio.encode", "end", index, audio_encode_ms, detail.c_str());
+                }
                 // 🔧 [修复] 音频太短时会在 audition_audio_preprocess 中自动 pad 静音到 100ms
                 // 这里做安全检查，如果仍然失败则跳过该帧音频
                 if (embeds != nullptr && embeds->n_pos > 0) {
                     print_with_timestamp("stream_prefill(index=%d): user audio embedding: n_pos=%d\n", index, embeds->n_pos);
                     // 🔧 添加音频标记，与 index=0 保持一致
+                    auto audio_prefill_t0 = std::chrono::steady_clock::now();
+                    omni_perf_mark(ctx_omni, "llm.prefill", "start", index, -1.0, "mode=sync,modality=audio");
                     eval_string(ctx_omni, ctx_omni->params, "<|audio_start|>", ctx_omni->params->n_batch, &ctx_omni->n_past, false);
                     prefill_with_emb(ctx_omni, ctx_omni->params, embeds->embed, embeds->n_pos, ctx_omni->params->n_batch, &ctx_omni->n_past);
                     eval_string(ctx_omni, ctx_omni->params, "<|audio_end|>", ctx_omni->params->n_batch, &ctx_omni->n_past, false);
+                    double audio_prefill_ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - audio_prefill_t0).count();
+                    std::string detail = "n_pos=" + std::to_string(embeds->n_pos);
+                    detail = "mode=sync,modality=audio," + detail;
+                    omni_perf_mark(ctx_omni, "llm.prefill", "end", index, audio_prefill_ms, detail.c_str());
                     omni_embed_free(embeds);
                 } else {
                     LOG_WRN("%s: audio encoding failed, skipping audio for this frame\n", __func__);
@@ -10233,11 +11067,20 @@ bool stream_prefill(struct omni_context * ctx_omni, std::string aud_fname, std::
                         vision_set_max_slice_nums(ctx_omni->ctx_vision, max_slice_nums);
                         LOG_INF("%s: [临时] max_slice_nums=%d for this prefill\n", __func__, max_slice_nums);
                     }
+                    auto vision_encode_t0 = std::chrono::steady_clock::now();
+                    omni_perf_mark(ctx_omni, "vision.encode", "start", index, -1.0, img_fname.c_str());
                     if (!omni_image_embed_make_chunks_with_filename(ctx_omni->ctx_vision, 
                             ctx_omni->params->cpuparams.n_threads, img_fname, omni_embeds->vision_embed)) {
+                        double vision_encode_ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - vision_encode_t0).count();
+                        omni_perf_mark(ctx_omni, "vision.encode", "end", index, vision_encode_ms, "failed");
                         LOG_ERR("%s: failed to create vision embeddings for %s\n", __func__, img_fname.c_str());
                         delete omni_embeds;
                         return false;
+                    }
+                    {
+                        double vision_encode_ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - vision_encode_t0).count();
+                        std::string detail = "chunks=" + std::to_string(omni_embeds->vision_embed.size());
+                        omni_perf_mark(ctx_omni, "vision.encode", "end", index, vision_encode_ms, detail.c_str());
                     }
                     LOG_INF("%s: vision_embed has %d chunks\n", __func__, (int)omni_embeds->vision_embed.size());
                 }
@@ -10246,7 +11089,14 @@ bool stream_prefill(struct omni_context * ctx_omni, std::string aud_fname, std::
             // 只有在音频路径非空时才处理音频
             if (aud_fname.length() > 0) {
                 LOG_INF("%s: aud_fname:%s\n", __func__, aud_fname.c_str());
+                auto audio_encode_t0 = std::chrono::steady_clock::now();
+                omni_perf_mark(ctx_omni, "audio.encode", "start", index, -1.0, aud_fname.c_str());
                 auto * audio_embeds = omni_audio_embed_make_with_filename(ctx_omni->ctx_audio, ctx_omni->params->cpuparams.n_threads, aud_fname);
+                {
+                    double audio_encode_ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - audio_encode_t0).count();
+                    std::string detail = "n_pos=" + std::to_string(audio_embeds ? audio_embeds->n_pos : 0);
+                    omni_perf_mark(ctx_omni, "audio.encode", "end", index, audio_encode_ms, detail.c_str());
+                }
                 // 🔧 [修复] 音频太短时会在 audition_audio_preprocess 中自动 pad 静音到 100ms
                 // 这里做安全检查，如果仍然失败则跳过该帧音频（保持 audio_embed 为空）
                 if (audio_embeds != nullptr && audio_embeds->n_pos > 0) {
@@ -10267,13 +11117,27 @@ bool stream_prefill(struct omni_context * ctx_omni, std::string aud_fname, std::
             // 🔧 [整合] <|im_start|>user\n 已在 sys prompt 末尾添加，后续轮次在 stream_decode 结束时添加
             // 不再需要在这里设置 is_round_start 标记
             
+            std::string enqueue_detail = "audio_values=" + std::to_string(omni_embeds->audio_embed.size()) +
+                                         ",vision_chunks=" + std::to_string(omni_embeds->vision_embed.size());
+            auto wait_space_t0 = std::chrono::steady_clock::now();
+            omni_perf_mark(ctx_omni, "queue.llm.wait_space", "start", index, -1.0, enqueue_detail.c_str());
             std::unique_lock<std::mutex> lock(ctx_omni->llm_thread_info->mtx);
             ctx_omni->llm_thread_info->cv.wait(lock, [&] { return ctx_omni->llm_thread_info->queue.size() < ctx_omni->llm_thread_info->MAX_QUEUE_SIZE; });
+            {
+                double wait_space_ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - wait_space_t0).count();
+                omni_perf_mark(ctx_omni, "queue.llm.wait_space", "end", index, wait_space_ms, enqueue_detail.c_str());
+            }
+            auto enqueue_t0 = std::chrono::steady_clock::now();
+            omni_perf_mark(ctx_omni, "queue.llm.enqueue", "start", index, -1.0, enqueue_detail.c_str());
             ctx_omni->llm_thread_info->queue.push(omni_embeds);
 
             //notify the llm
             lock.unlock();
             ctx_omni->llm_thread_info->cv.notify_all();
+            {
+                double enqueue_ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - enqueue_t0).count();
+                omni_perf_mark(ctx_omni, "queue.llm.enqueue", "end", index, enqueue_ms, enqueue_detail.c_str());
+            }
         }
     }
     // 🔧 [诊断] 打印 stream_prefill 结束时的状态
@@ -10292,6 +11156,11 @@ bool stream_decode(struct omni_context * ctx_omni, std::string debug_dir, int ro
         && ctx_omni->system_prompt_initialized && ctx_omni->duplex != nullptr) {
         return duplex_decode(ctx_omni, debug_dir, round_idx);
     }
+
+    const int perf_chunk_index = round_idx >= 0
+        ? round_idx
+        : (ctx_omni ? ctx_omni->perf_current_chunk_index.load() : -1);
+    OmniPerfScope perf_scope(ctx_omni, "api.stream_decode", perf_chunk_index, "debug_dir=" + debug_dir);
 
     // NOTE: 不再自动归档旧输出目录，因为这会导致同一 session 中每轮对话的输出被移走
     // 如果需要归档，可以在新 session 开始时（omni_init）手动调用
@@ -10389,9 +11258,13 @@ bool stream_decode(struct omni_context * ctx_omni, std::string debug_dir, int ro
         //ctx_omni->llm_thread.join();
         ctx_omni->llm_thread_info->cv.notify_all();
         print_with_timestamp("wait prefill done\n");
+        auto wait_prefill_t0 = std::chrono::steady_clock::now();
+        omni_perf_mark(ctx_omni, "wait.llm_prefill_done", "start", perf_chunk_index, -1.0, nullptr);
         std::unique_lock<std::mutex> lock(ctx_omni->llm_thread_info->mtx);
         g_decode_cv.wait(lock, []{ return prefill_done; });
         prefill_done = false;
+        double wait_prefill_ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - wait_prefill_t0).count();
+        omni_perf_mark(ctx_omni, "wait.llm_prefill_done", "end", perf_chunk_index, wait_prefill_ms, nullptr);
     }
 
     // 🔧 [unit 记账] 现在 prefill 已经写完 KV、unit_history 里也已经
@@ -10443,6 +11316,8 @@ bool stream_decode(struct omni_context * ctx_omni, std::string debug_dir, int ro
         // 这里直接发 __IS_LISTEN__ 到 text_queue 走 LISTEN 分支，不启动 LLM 采样。
         // 用户音频的 KV cache 已经在 stream_prefill 阶段写入，所以不会丢失上下文。
         if (ctx_omni->force_listen_used < ctx_omni->force_listen_count) {
+            auto force_listen_t0 = std::chrono::steady_clock::now();
+            omni_perf_mark(ctx_omni, "control.force_listen", "start", perf_chunk_index, -1.0, nullptr);
             ctx_omni->force_listen_used++;
             ctx_omni->slide_last_was_listen = true;
             ctx_omni->ended_with_listen = true;
@@ -10459,6 +11334,10 @@ bool stream_decode(struct omni_context * ctx_omni, std::string debug_dir, int ro
                 ctx_omni->text_streaming = false;
                 ctx_omni->text_cv.notify_all();
             }
+            double force_listen_ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - force_listen_t0).count();
+            std::string detail = "used=" + std::to_string(ctx_omni->force_listen_used) +
+                                 ",count=" + std::to_string(ctx_omni->force_listen_count);
+            omni_perf_mark(ctx_omni, "control.force_listen", "end", perf_chunk_index, force_listen_ms, detail.c_str());
             return true;
         }
     } else if (ctx_omni->use_tts) {
@@ -10508,6 +11387,11 @@ bool stream_decode(struct omni_context * ctx_omni, std::string debug_dir, int ro
     bool local_is_end_of_turn = false;
     // 🔧 [P0-打断检测] 双工模式下记录当前 chunk 生成的 token 数
     int current_chunk_tokens = 0;
+    int perf_decode_total_tokens = 0;
+    int perf_decode_compute_tokens = 0;
+    int perf_decode_valid_tts_tokens = 0;
+    auto llm_sample_t0 = std::chrono::steady_clock::now();
+    omni_perf_mark(ctx_omni, "api.llm_decode_loop", "start", perf_chunk_index, -1.0, nullptr);
     for (int il = 0; il < max_tgt_len; ) {
         // 🔧 [P0-打断检测] 外层循环也检测 break_event
         if (ctx_omni->break_event.load()) {
@@ -10525,6 +11409,7 @@ bool stream_decode(struct omni_context * ctx_omni, std::string debug_dir, int ro
         
         int jl = 0;  // 计数有效的 TTS token 数量
         int total_tokens_generated = 0;  // 计数总共生成的 token 数量（包括被过滤的）
+        int manual_control_tokens = 0;   // 手动 feed 进 LLM KV 的控制 token，同样消耗推理
         // 收集当前chunk的token IDs和hidden states用于TTS条件生成
         // 🔧 [优化] 只收集有效的 TTS token，确保每次给 TTS 的都是 step_size 个有效 token
         std::vector<llama_token> chunk_token_ids;
@@ -10540,6 +11425,10 @@ bool stream_decode(struct omni_context * ctx_omni, std::string debug_dir, int ro
         // - 单工模式: 无限制，LLM 生成直到 EOS
         int max_chunk_tokens = ctx_omni->duplex_mode ? ctx_omni->max_new_speak_tokens_per_chunk : 0;
         bool chunk_limit_reached = (max_chunk_tokens > 0 && current_chunk_tokens >= max_chunk_tokens);
+        const int llm_infer_start_n_past = ctx_omni->n_past;
+        auto llm_infer_t0 = std::chrono::steady_clock::now();
+        std::string llm_infer_start_detail = "step_size=" + std::to_string(step_size);
+        omni_perf_mark(ctx_omni, "llm.decode", "start", perf_chunk_index, -1.0, llm_infer_start_detail.c_str());
         {
             fflush(stdout);
             // 🔧 [重要] 循环直到收集到 step_size 个有效 token，而不是生成 step_size 个 token
@@ -10602,6 +11491,9 @@ bool stream_decode(struct omni_context * ctx_omni, std::string debug_dir, int ro
                 // }
                 if (!llm_first_token_logged) {
                     llm_first_token_logged = true;
+                    double first_token_ms = std::chrono::duration<double, std::milli>(
+                        std::chrono::steady_clock::now() - llm_sample_t0).count();
+                    omni_perf_mark(ctx_omni, "llm.decode.first_token", "mark", perf_chunk_index, first_token_ms, nullptr);
                 }
                 if (tmp == nullptr) {
                     LOG_ERR("llama_loop returned nullptr!");
@@ -10713,8 +11605,10 @@ bool stream_decode(struct omni_context * ctx_omni, std::string debug_dir, int ro
                 std::lock_guard<std::mutex> llama_lock(ctx_omni->llama_mtx);
                 // Feed chunk_eos token to model (update KV cache)
                 std::vector<llama_token> chunk_eos_tokens = {ctx_omni->special_token_chunk_eos};
-                eval_tokens(ctx_omni, ctx_omni->params, chunk_eos_tokens, 
-                           ctx_omni->params->n_batch, &ctx_omni->n_past);
+                if (eval_tokens(ctx_omni, ctx_omni->params, chunk_eos_tokens,
+                                ctx_omni->params->n_batch, &ctx_omni->n_past)) {
+                    manual_control_tokens += (int) chunk_eos_tokens.size();
+                }
             }
             // 这样 SSE 流会结束，客户端可以再次调用 decode
             llm_finish = true;
@@ -10727,8 +11621,22 @@ bool stream_decode(struct omni_context * ctx_omni, std::string debug_dir, int ro
             std::lock_guard<std::mutex> llama_lock(ctx_omni->llama_mtx);
             // Feed </unit> token to model (update KV cache)
             std::vector<llama_token> unit_end_tokens = {ctx_omni->special_token_unit_end};
-            eval_tokens(ctx_omni, ctx_omni->params, unit_end_tokens, 
-                       ctx_omni->params->n_batch, &ctx_omni->n_past);
+            if (eval_tokens(ctx_omni, ctx_omni->params, unit_end_tokens,
+                            ctx_omni->params->n_batch, &ctx_omni->n_past)) {
+                manual_control_tokens += (int) unit_end_tokens.size();
+            }
+        }
+        {
+            double llm_infer_ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - llm_infer_t0).count();
+            const int compute_tokens = total_tokens_generated + manual_control_tokens;
+            std::string detail = "tokens=" + std::to_string(compute_tokens) +
+                                 ",sampled_tokens=" + std::to_string(total_tokens_generated) +
+                                 ",control_tokens=" + std::to_string(manual_control_tokens) +
+                                 ",valid_tts_tokens=" + std::to_string(chunk_token_ids.size()) +
+                                 ",n_past_delta=" + std::to_string(ctx_omni->n_past - llm_infer_start_n_past) +
+                                 omni_perf_speed_detail(compute_tokens, llm_infer_ms);
+            omni_perf_record_tokens(ctx_omni, "llm.decode", compute_tokens, llm_infer_ms);
+            omni_perf_mark(ctx_omni, "llm.decode", "end", perf_chunk_index, llm_infer_ms, detail.c_str());
         }
         fflush(stdout);
         if (!response.empty()) {
@@ -10741,6 +11649,9 @@ bool stream_decode(struct omni_context * ctx_omni, std::string debug_dir, int ro
         }
         // 🔧 使用总生成的 token 数量更新 il（用于和 max_tgt_len 比较）
         il += total_tokens_generated;
+        perf_decode_total_tokens += total_tokens_generated;
+        perf_decode_compute_tokens += total_tokens_generated + manual_control_tokens;
+        perf_decode_valid_tts_tokens += (int) chunk_token_ids.size();
         
         // 🔧 [统一处理] 移除响应中的所有特殊结束 token
         // 注意: <|speak|> 不是结束 token，而是开始说话的标记，应该被移除但不截断后面内容
@@ -10798,6 +11709,7 @@ bool stream_decode(struct omni_context * ctx_omni, std::string debug_dir, int ro
                 // 🔧 [修复双工缺字问题] 传递 is_end_of_turn 状态
                 // 此状态随数据一起传递，确保 TTS 处理的是与当前 chunk 对应的状态
                 llm_out->is_end_of_turn = local_is_end_of_turn;
+                llm_out->perf_chunk_index = perf_chunk_index;
                 
                 // 🔧 [诊断日志] 打印 LLM 推送给 TTS 的数据
                 {
@@ -10818,11 +11730,22 @@ bool stream_decode(struct omni_context * ctx_omni, std::string debug_dir, int ro
                 
                 fflush(stdout);
                 fflush(stdout);
+                std::string tts_enqueue_detail = "tokens=" + std::to_string(chunk_token_ids.size()) +
+                                                 ",llm_finish=" + std::to_string(llm_finish ? 1 : 0) +
+                                                 ",text_bytes=" + std::to_string(response.size());
                 std::unique_lock<std::mutex> lock(ctx_omni->tts_thread_info->mtx);
                 fflush(stdout);
+                auto tts_wait_space_t0 = std::chrono::steady_clock::now();
+                omni_perf_mark(ctx_omni, "queue.tts.wait_space", "start", perf_chunk_index, -1.0, tts_enqueue_detail.c_str());
                 ctx_omni->tts_thread_info->cv.wait(lock, [&] { return ctx_omni->tts_thread_info->queue.size() < ctx_omni->tts_thread_info->MAX_QUEUE_SIZE; });
+                {
+                    double tts_wait_space_ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - tts_wait_space_t0).count();
+                    omni_perf_mark(ctx_omni, "queue.tts.wait_space", "end", perf_chunk_index, tts_wait_space_ms, tts_enqueue_detail.c_str());
+                }
                 fflush(stdout);
                 fflush(stdout);
+                auto tts_enqueue_t0 = std::chrono::steady_clock::now();
+                omni_perf_mark(ctx_omni, "queue.tts.enqueue", "start", perf_chunk_index, -1.0, tts_enqueue_detail.c_str());
                 // 🔧 [关键修复 - 与 Python 对齐] 在双工模式下，LLM 始终推送数据到 TTS 队列
                 // 因为双工模式下每个 chunk 都需要独立处理，不能因为上一个 chunk 完成（speek_done=true）就丢弃新数据
                 // Python 双工模型：每次 streaming_generate 调用都会独立处理 LLM 输出并生成 TTS
@@ -10842,6 +11765,10 @@ bool stream_decode(struct omni_context * ctx_omni, std::string debug_dir, int ro
                     fflush(stdout);
                 }
                 fflush(stdout);
+                {
+                    double tts_enqueue_ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - tts_enqueue_t0).count();
+                    omni_perf_mark(ctx_omni, "queue.tts.enqueue", "end", perf_chunk_index, tts_enqueue_ms, tts_enqueue_detail.c_str());
+                }
             }
             fflush(stdout);
         }else{
@@ -10849,6 +11776,13 @@ bool stream_decode(struct omni_context * ctx_omni, std::string debug_dir, int ro
         }
         fflush(stdout);
         if (llm_finish) break;
+    }
+    {
+        double llm_sample_ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - llm_sample_t0).count();
+        std::string detail = "tokens=" + std::to_string(perf_decode_compute_tokens) +
+                             ",sampled_tokens=" + std::to_string(perf_decode_total_tokens) +
+                             ",valid_tts_tokens=" + std::to_string(perf_decode_valid_tts_tokens);
+        omni_perf_mark(ctx_omni, "api.llm_decode_loop", "end", perf_chunk_index, llm_sample_ms, detail.c_str());
     }
     fflush(stdout);
     // 🔧 [P1-SSE响应] 推送轮次结束标记
@@ -11116,6 +12050,8 @@ static void duplex_session_decode_worker_func(omni_context * ctx_omni) {
 
         if (inf.prefill_failed) {
             r.ok = false;
+            auto t_fail = std::chrono::high_resolution_clock::now();
+            r.ms_total = std::chrono::duration<double, std::milli>(t_fail - inf.t_push).count();
         } else {
             // 等本帧 LLM 完成
             auto t_dec_start = std::chrono::high_resolution_clock::now();
@@ -11141,6 +12077,15 @@ static void duplex_session_decode_worker_func(omni_context * ctx_omni) {
             r.ms_total  = std::chrono::duration<double, std::milli>(t_dec_end - inf.t_push).count();
         }
         r.ms_prefill_submit = std::chrono::duration<double, std::milli>(inf.t_prefilled - inf.t_push).count();
+        {
+            std::string frame_detail = "user_seq=" + std::to_string(r.user_seq) +
+                                       ",prefill_submit_ms=" + std::to_string(r.ms_prefill_submit) +
+                                       ",decode_ms=" + std::to_string(r.ms_decode) +
+                                       ",ok=" + std::to_string(r.ok ? 1 : 0) +
+                                       ",is_speak=" + std::to_string(r.is_speak ? 1 : 0);
+            omni_perf_mark(ctx_omni, "api.duplex.frame_total", "end",
+                           (int)r.frame_id, r.ms_total, frame_detail.c_str());
+        }
 
         {
             std::unique_lock<std::mutex> lk(sess->done_mtx);
@@ -11197,6 +12142,13 @@ int64_t omni_duplex_push_frame(struct omni_context * ctx_omni,
     pf.frame    = frame;
     pf.frame_id = sess->frame_id_counter.fetch_add(1) + 1;  // chunk 0 已被 session_begin 占用
     pf.t_push   = std::chrono::high_resolution_clock::now();
+    {
+        std::string frame_detail = "user_seq=" + std::to_string(frame.user_seq) +
+                                   ",audio=" + frame.aud_fname +
+                                   ",image=" + (frame.img_fname.empty() ? "none" : frame.img_fname);
+        omni_perf_mark(ctx_omni, "api.duplex.frame_total", "start",
+                       (int)pf.frame_id, -1.0, frame_detail.c_str());
+    }
 
     {
         std::unique_lock<std::mutex> lk(sess->pending_mtx);

--- a/tools/omni/omni.h
+++ b/tools/omni/omni.h
@@ -77,6 +77,7 @@ struct T2WOut {
     bool is_final = false;  // Whether this is the final chunk (turn end)
     bool is_chunk_end = false;  // Whether this is the end of a TTS chunk (flush buffer, but not final)
     int round_idx = -1;  // 🔧 [修复目录同步] 轮次索引，由 TTS 线程设置，T2W 线程使用此值确定输出目录
+    int perf_chunk_index = -1;  // 性能日志归属的输入 chunk，随队列数据传递避免异步错归属
     std::chrono::steady_clock::time_point enqueue_time = std::chrono::steady_clock::now();
 };
 
@@ -146,6 +147,12 @@ struct projector_model {
     ggml_backend_t backend = nullptr;
     ggml_backend_buffer_type_t buf_type = nullptr;
     bool initialized = false;
+};
+
+struct OmniPerfTokenStats {
+    long long calls = 0;
+    long long tokens = 0;
+    double duration_ms = 0.0;
 };
 
 struct omni_context {
@@ -407,6 +414,11 @@ struct omni_context {
     
     // Timestamp for stream_decode start (used for WAV file naming)
     std::chrono::high_resolution_clock::time_point stream_decode_start_time;
+    std::atomic<int> perf_current_chunk_index{-1};
+    std::mutex perf_token_stats_mtx;
+    OmniPerfTokenStats perf_llm_prefill;
+    OmniPerfTokenStats perf_llm_decode;
+    OmniPerfTokenStats perf_tts_infer;
     
     // C++ Token2Wav session for audio synthesis
     std::unique_ptr<omni::flow::Token2WavSession> token2wav_session;
@@ -477,6 +489,13 @@ struct omni_context * omni_init(struct common_params * params, int media_type, b
                                 bool duplex_mode = false,
                                 llama_model * existing_model = nullptr, llama_context * existing_ctx = nullptr,
                                 const std::string & base_output_dir = "./tools/omni/output");
+
+void omni_perf_mark(struct omni_context * ctx_omni,
+                    const char * stage,
+                    const char * event,
+                    int chunk_index = -1,
+                    double duration_ms = -1.0,
+                    const char * detail = nullptr);
 
 void omni_free(struct omni_context * ctx_omni);
 

--- a/tools/omni/test/test-duplex.cpp
+++ b/tools/omni/test/test-duplex.cpp
@@ -137,7 +137,7 @@ static void duplex_test_case(struct omni_context * ctx_omni,
     });
 
     int speak = 0, listen = 0, completed = 0;
-    double sum_decode = 0, sum_e2e = 0;
+    double sum_prefill = 0, sum_decode = 0, sum_e2e = 0;
 
     for (int il = 0; il < cnt && !g_is_interrupted; ++il) {
         OmniDuplexFrameResult r;
@@ -146,12 +146,13 @@ static void duplex_test_case(struct omni_context * ctx_omni,
             break;
         }
         (r.is_speak ? speak : listen)++;
+        sum_prefill += r.ms_prefill_submit;
         sum_decode += r.ms_decode;
         sum_e2e    += r.ms_total;
         completed++;
 
-        printf("--- Chunk %lld/%d --- decode %.1fms | e2e %.1fms | n_past %d | %s\n",
-               (long long)r.user_seq, cnt, r.ms_decode, r.ms_total, r.n_past_after,
+        printf("--- Chunk %lld/%d --- prefill %.1fms | decode %.1fms | e2e %.1fms | n_past %d | %s\n",
+               (long long)r.user_seq, cnt, r.ms_prefill_submit, r.ms_decode, r.ms_total, r.n_past_after,
                r.is_speak ? ("<|speak|> \"" + (r.text.size() > 60 ? r.text.substr(0,60)+"..." : r.text) + "\"").c_str()
                           : "<|listen|>");
     }
@@ -161,8 +162,9 @@ static void duplex_test_case(struct omni_context * ctx_omni,
 
     double total_s = std::chrono::duration<double>(
         std::chrono::high_resolution_clock::now() - total_t0).count();
-    printf("\n=== Summary: %d/%d chunks, %.3fs | avg decode %.1fms | avg e2e %.1fms | speak %d listen %d ===\n",
+    printf("\n=== Summary: %d/%d chunks, %.3fs | avg prefill %.1fms | avg decode %.1fms | avg e2e %.1fms | speak %d listen %d ===\n",
            completed, cnt, total_s,
+           completed ? sum_prefill / completed : 0,
            completed ? sum_decode / completed : 0,
            completed ? sum_e2e    / completed : 0,
            speak, listen);


### PR DESCRIPTION
## 概述
这个 PR 增加了双工链路的性能打点和分析工具。
当前将双工性能阶段分为几类：
- **API **：`api.duplex.frame_total`、`api.stream_prefill`、`api.stream_decode`，用于观察端到端或 API 调用级延迟。
- **计算阶段**：`vision.encode`、`audio.encode`、`llm.prefill`、`llm.decode`、`tts.infer`、`t2w.infer`，用于观察模型、编码器、TTS 和 vocoder 的实际计算耗时。
- **队列 / 等待阶段**：`queue.llm.*`、`wait.llm_prefill_done`、`queue.tts.*`、`queue.t2w.*`，用于把调度、排队、反压和异步等待从计算耗时中分离出来。
- **控制 / IO 阶段**：例如 `control.force_listen`、`t2w.write`，用于统计策略控制和 WAV 写出成本。
分析脚本会生成阶段耗时表、chunk 延迟图、异步重叠时间线和 token 速度统计。同时也会解析 `[DUPLEX_GPU]` 采样，输出 GPU 利用率、显存、功耗、温度以及按阶段聚合的 GPU 使用情况。