### PR TITLE
Opt/r4.1 t2w ane

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -573,11 +573,14 @@ struct common_params {
     int image_max_tokens = -1;
 
     // omni models (see tools/omni)
-    std::string tts_model               = ""; // TTS weights GGUF
-    std::string apm_model               = ""; // audio encoder GGUF
-    std::string vpm_model               = ""; // vision encoder GGUF
-    std::string projector_model         = ""; // projector GGUF
-    std::string vision_coreml_model_path = ""; // path to CoreML .mlmodelc for vision ANE
+    std::string tts_model                = ""; // TTS weights GGUF
+    std::string apm_model                = ""; // audio encoder GGUF
+    std::string vpm_model                = ""; // vision encoder GGUF
+    std::string projector_model          = ""; // projector GGUF
+
+    // Apple Neural Engine (CoreML) support
+    std::string vision_coreml_model_path     = ""; // path to CoreML .mlmodelc for vision ANE
+    std::string token2wav_coreml_model_path  = ""; // path to CoreML model (.mlmodelc/.mlpackage) for token2wav DiT
 
     // finetune
     struct lr_opt lr;

--- a/tools/omni/CMakeLists.txt
+++ b/tools/omni/CMakeLists.txt
@@ -33,6 +33,8 @@ if(ENABLE_COREML)
         coreml/omni_coreml.mm
         coreml/coreml_minicpmo45_vit_all_f16.h
         coreml/coreml_minicpmo45_vit_all_f16.m
+        coreml/coreml_t2w_dit.h
+        coreml/coreml_t2w_dit.mm
     )
     # Define compile-time macro for code guards
     target_compile_definitions(omni PRIVATE ENABLE_COREML)
@@ -40,6 +42,7 @@ if(ENABLE_COREML)
     # Enable ARC for Objective-C files
     set_source_files_properties(coreml/omni_coreml.mm PROPERTIES COMPILE_FLAGS "-fobjc-arc")
     set_source_files_properties(coreml/coreml_minicpmo45_vit_all_f16.m PROPERTIES COMPILE_FLAGS "-fobjc-arc")
+    set_source_files_properties(coreml/coreml_t2w_dit.mm PROPERTIES COMPILE_FLAGS "-fobjc-arc")
 endif()
 
 target_link_libraries     (omni PUBLIC ggml llama llama-common)
@@ -186,4 +189,20 @@ target_include_directories(${TARGET_VOXCPM2_CLI} PRIVATE voxcpm2)
 target_compile_features(${TARGET_VOXCPM2_CLI} PRIVATE cxx_std_17)
 if(LLAMA_TOOLS_INSTALL)
     install(TARGETS ${TARGET_VOXCPM2_CLI} RUNTIME)
+endif()
+
+# Token2Mel-DiT CoreML 单元测试（仅 macOS + CoreML enable 时有效）
+if(ENABLE_COREML)
+    set(TARGET_T2W_DIT_ANE_TEST llama-omni-test-t2w-dit-ane)
+    add_executable         (${TARGET_T2W_DIT_ANE_TEST} test/test_t2w_dit_ane.cpp)
+    set_target_properties  (${TARGET_T2W_DIT_ANE_TEST} PROPERTIES OUTPUT_NAME llama-omni-test-t2w-dit-ane)
+    target_link_libraries  (${TARGET_T2W_DIT_ANE_TEST} PRIVATE common omni Threads::Threads)
+    target_compile_features(${TARGET_T2W_DIT_ANE_TEST} PRIVATE cxx_std_17)
+
+    # CoreML 端到端 test：用真实 prompt + 真实 mu 跑完整 5-step ODE × N chunks
+    set(TARGET_T2W_ANE_E2E llama-omni-test-t2w-ane-end2end)
+    add_executable         (${TARGET_T2W_ANE_E2E} test/test_t2w_ane_end2end.cpp)
+    set_target_properties  (${TARGET_T2W_ANE_E2E} PROPERTIES OUTPUT_NAME llama-omni-test-t2w-ane-end2end)
+    target_link_libraries  (${TARGET_T2W_ANE_E2E} PRIVATE common omni Threads::Threads)
+    target_compile_features(${TARGET_T2W_ANE_E2E} PRIVATE cxx_std_17)
 endif()

--- a/tools/omni/coreml/coreml_t2w_dit.h
+++ b/tools/omni/coreml/coreml_t2w_dit.h
@@ -1,0 +1,98 @@
+// coreml_t2w_dit.h
+//
+// Token2Mel DiT estimator -> ANE 桥接（C ABI），独立于 ggml。
+//
+// 用途：MiniCPM-o-4.5 token2wav 的 DiT estimator 跑在 Apple Neural Engine 上，
+//   彻底绕开 Metal command queue 在双工模式下被 LLM 抢资源的瓶颈。
+//
+// mlpackage 由 tools/convert/o45_tts/ane_export_dit.py 生成，输入/输出 schema:
+//
+//   inputs:
+//     x            (B=2, 80,                                T=56)        fp32
+//     mu           (B=2, 80,                                T=56)        fp32
+//     t            (B=2,)                                                 fp32
+//     spks         (B=2, 80)                                              fp32
+//     cond         (B=2, 80,                                T=56)        fp32
+//     cnn_cache_in (depth*B=32,                  1024,      2)            fp32
+//     att_cache_in (depth*B=32, num_heads=8, max_cache_len=600, head_dim*2=128) fp32
+//     attn_mask    (B=2, T=56, T + max_cache_len=656)                     fp32 additive
+//                                                                         (0 = valid, -1e4 = masked)
+//
+//   outputs:
+//     feat            (B=2, 80, T=56)
+//     cnn_cache_out   (depth*B=32, 1024, 2)
+//     att_cache_out   (depth*B=32, 8, 600, 128)
+//
+// 一次 predict 完成一个 timestep；调用方需要在外部循环 n_timesteps（cosine
+// schedule + Euler ODE + CFG），并为每个 timestep 维护一份独立的 cnn/att cache。
+
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+
+#if __cplusplus
+extern "C" {
+#endif
+
+typedef void * t2w_dit_handle_t;
+
+// 模型几何信息（mlpackage 加载时从 metadata 读取，便于调用方校验形状）
+typedef struct {
+    int32_t depth;             // 16
+    int32_t batch;             // 2  (CFG cond + uncond batched)
+    int32_t chunk_size;        // 56  mel frames per call
+    int32_t max_cache_len;     // 600 attention cache padding length
+    int32_t cnn_cache_channels; // 1024 (= in_channels + out_channels of conv block)
+    int32_t cnn_cache_t;       // 2
+    int32_t num_heads;         // 8
+    int32_t head_dim;          // 64
+    int32_t mel_channels;      // 80
+    int32_t spk_dim;           // 80
+} t2w_dit_dims_t;
+
+// 加载 mlpackage（路径），默认 compute_units = CPUAndNeuralEngine。
+// 环境变量 OMNI_T2W_DIT_COMPUTE_UNITS 可覆盖：
+//   "ane"     -> CPUAndNeuralEngine（默认，目标场景）
+//   "all"     -> All
+//   "cpu_gpu" -> CPUAndGPU
+//   "cpu"     -> CPUOnly
+// 失败返回 nullptr。
+t2w_dit_handle_t t2w_dit_load(const char * mlpackage_path);
+
+// 读取模型几何。
+// 失败返回非 0。
+int t2w_dit_get_dims(t2w_dit_handle_t h, t2w_dit_dims_t * out);
+
+// 单次 forward。所有指针指向 contiguous fp32 buffer，layout 见文件顶部 schema。
+// 输出 buffer 由调用方分配；分配大小见 t2w_dit_predict_buffer_sizes。
+// 失败返回非 0。
+int t2w_dit_predict(t2w_dit_handle_t h,
+                    const float * x,            // (B*80*T)
+                    const float * mu,           // (B*80*T)
+                    const float * t,            // (B,)
+                    const float * spks,         // (B*80)
+                    const float * cond,         // (B*80*T)
+                    const float * cnn_cache_in, // (depth*B*1024*2)
+                    const float * att_cache_in, // (depth*B*8*max_cache_len*128)
+                    const float * attn_mask,    // (B*T*(T+max_cache_len))
+                    float * feat_out,           // (B*80*T)
+                    float * cnn_cache_out,      // (depth*B*1024*2)
+                    float * att_cache_out);     // (depth*B*8*max_cache_len*128)
+
+// 计算各 buffer 需要的元素数量（fp32 个数），方便调用方分配。
+// nelem_* 任一可为 nullptr（不需要时跳过）。
+int t2w_dit_predict_buffer_sizes(t2w_dit_handle_t h,
+                                  size_t * nelem_x_mu_cond_feat,
+                                  size_t * nelem_t,
+                                  size_t * nelem_spks,
+                                  size_t * nelem_cnn_cache,
+                                  size_t * nelem_att_cache,
+                                  size_t * nelem_attn_mask);
+
+// 释放。
+void t2w_dit_free(t2w_dit_handle_t h);
+
+#if __cplusplus
+}  // extern "C"
+#endif

--- a/tools/omni/coreml/coreml_t2w_dit.h
+++ b/tools/omni/coreml/coreml_t2w_dit.h
@@ -1,11 +1,11 @@
 // coreml_t2w_dit.h
 //
-// Token2Mel DiT estimator -> ANE 桥接（C ABI），独立于 ggml。
+// Token2Mel DiT estimator -> CoreML 桥接（C ABI），独立于 ggml。
 //
 // 用途：MiniCPM-o-4.5 token2wav 的 DiT estimator 跑在 Apple Neural Engine 上，
 //   彻底绕开 Metal command queue 在双工模式下被 LLM 抢资源的瓶颈。
 //
-// mlpackage 由 tools/convert/o45_tts/ane_export_dit.py 生成，输入/输出 schema:
+// CoreML 模型由 tools/convert/o45_tts/ane_export_dit.py 生成，输入/输出 schema:
 //
 //   inputs:
 //     x            (B=2, 80,                                T=56)        fp32
@@ -37,7 +37,7 @@ extern "C" {
 
 typedef void * t2w_dit_handle_t;
 
-// 模型几何信息（mlpackage 加载时从 metadata 读取，便于调用方校验形状）
+// CoreML 模型几何信息（加载时从 metadata 读取，便于调用方校验形状）
 typedef struct {
     int32_t depth;             // 16
     int32_t batch;             // 2  (CFG cond + uncond batched)
@@ -51,14 +51,14 @@ typedef struct {
     int32_t spk_dim;           // 80
 } t2w_dit_dims_t;
 
-// 加载 mlpackage（路径），默认 compute_units = CPUAndNeuralEngine。
+// 加载 CoreML 模型（路径），默认 compute_units = CPUAndNeuralEngine。
 // 环境变量 OMNI_T2W_DIT_COMPUTE_UNITS 可覆盖：
 //   "ane"     -> CPUAndNeuralEngine（默认，目标场景）
 //   "all"     -> All
 //   "cpu_gpu" -> CPUAndGPU
 //   "cpu"     -> CPUOnly
 // 失败返回 nullptr。
-t2w_dit_handle_t t2w_dit_load(const char * mlpackage_path);
+t2w_dit_handle_t t2w_dit_load(const char * model_path);
 
 // 读取模型几何。
 // 失败返回非 0。

--- a/tools/omni/coreml/coreml_t2w_dit.mm
+++ b/tools/omni/coreml/coreml_t2w_dit.mm
@@ -1,0 +1,479 @@
+// coreml_t2w_dit.mm
+//
+// Token2Mel DiT estimator → ANE 桥接实现。
+//
+// 不依赖 Xcode 自动生成的 typed wrapper class（model 输入太多、有 stateful
+// streaming 形状），用通用 MLModel + MLDictionaryFeatureProvider，从 mlpackage
+// metadata 直接读 schema 并构造 IO。
+
+#import <CoreML/CoreML.h>
+#import <Accelerate/Accelerate.h>
+#import "coreml_t2w_dit.h"
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+
+#if __cplusplus
+extern "C" {
+#endif
+
+// ----------------------------------------------------------------------------
+// 内部 handle 结构
+// ----------------------------------------------------------------------------
+
+typedef struct t2w_dit_ctx {
+    MLModel * __strong         model;
+    t2w_dit_dims_t             dims;
+    bool                       prof_enabled;
+    int64_t                    n_calls;
+    double                     ms_total;
+    double                     ms_predict;
+} t2w_dit_ctx_t;
+
+// 默认 dims（与 ane_export_dit.py 写死的常量一致；mlpackage metadata 也存了一份，
+// 后面 t2w_dit_load 会从 metadata 覆盖以校验一致性）。
+static void fill_default_dims(t2w_dit_dims_t * d) {
+    d->depth              = 16;
+    d->batch              = 2;
+    d->chunk_size         = 56;
+    d->max_cache_len      = 600;
+    d->cnn_cache_channels = 1024;
+    d->cnn_cache_t        = 2;
+    d->num_heads          = 8;
+    d->head_dim           = 64;
+    d->mel_channels       = 80;
+    d->spk_dim            = 80;
+}
+
+static int parse_int_md(NSDictionary * md, NSString * key, int fallback) {
+    id v = md[key];
+    if ([v isKindOfClass:[NSString class]]) {
+        return [(NSString *) v intValue];
+    }
+    return fallback;
+}
+
+// ----------------------------------------------------------------------------
+// load
+// ----------------------------------------------------------------------------
+
+t2w_dit_handle_t t2w_dit_load(const char * mlpackage_path) {
+    @autoreleasepool {
+        if (!mlpackage_path) {
+            NSLog(@"[t2w_dit] error: mlpackage_path is null");
+            return nullptr;
+        }
+        NSString * pathStr = [NSString stringWithUTF8String:mlpackage_path];
+        NSFileManager * fm = [NSFileManager defaultManager];
+        if (![fm fileExistsAtPath:pathStr]) {
+            NSLog(@"[t2w_dit] error: file not found: %@", pathStr);
+            return nullptr;
+        }
+        NSURL * url = [NSURL fileURLWithPath:pathStr];
+        NSError * err = nil;
+
+        // C++ 端 CoreML 不像 Python 那样自动编译 .mlpackage。
+        // 这里：若传入是 .mlpackage（或非 .mlmodelc），先用 MLModel:compileModelAtURL
+        // 编译为 .mlmodelc 缓存到工作目录，避免每次启动重复编译。
+        if (![pathStr hasSuffix:@".mlmodelc"]) {
+            // 缓存路径：在 mlpackage 同目录下，<name>.mlmodelc
+            NSString * stem = [pathStr.lastPathComponent stringByDeletingPathExtension];
+            NSString * parent = [pathStr stringByDeletingLastPathComponent];
+            NSString * cachedPath = [parent stringByAppendingPathComponent:
+                                        [stem stringByAppendingString:@".mlmodelc"]];
+            NSURL * cachedURL = [NSURL fileURLWithPath:cachedPath];
+
+            // 没有 cache 才重编译（编译要 5-30s，是大头）
+            if (![fm fileExistsAtPath:cachedPath]) {
+                NSLog(@"[t2w_dit] compiling mlpackage -> %@ ...", cachedPath);
+                NSURL * tmpURL = [MLModel compileModelAtURL:url error:&err];
+                if (err || !tmpURL) {
+                    NSLog(@"[t2w_dit] error: compileModelAtURL failed: %@",
+                          err.localizedDescription);
+                    return nullptr;
+                }
+                // compileModelAtURL 把结果放到 NSTemporaryDirectory，需要复制到我们要的路径
+                if ([fm fileExistsAtPath:cachedPath]) {
+                    [fm removeItemAtURL:cachedURL error:nil];
+                }
+                BOOL moved = [fm moveItemAtURL:tmpURL toURL:cachedURL error:&err];
+                if (!moved) {
+                    // moveItemAtURL 跨卷可能失败 → 退回 copyItemAtURL
+                    err = nil;
+                    BOOL copied = [fm copyItemAtURL:tmpURL toURL:cachedURL error:&err];
+                    if (!copied) {
+                        NSLog(@"[t2w_dit] error: cache install failed: %@",
+                              err.localizedDescription);
+                        // fallback: 直接用临时路径加载（不缓存）
+                        cachedURL = tmpURL;
+                    }
+                }
+                NSLog(@"[t2w_dit] compiled & cached: %@", cachedURL.path);
+            } else {
+                NSLog(@"[t2w_dit] using cached mlmodelc: %@", cachedPath);
+            }
+            url = cachedURL;
+        }
+
+        // compute units 选择
+        MLModelConfiguration * cfg = [[MLModelConfiguration alloc] init];
+        const char * cu_env = getenv("OMNI_T2W_DIT_COMPUTE_UNITS");
+        NSString * cu_str = cu_env ? [NSString stringWithUTF8String:cu_env] : @"ane";
+        if ([cu_str isEqualToString:@"all"]) {
+            cfg.computeUnits = MLComputeUnitsAll;
+        } else if ([cu_str isEqualToString:@"cpu_gpu"]) {
+            cfg.computeUnits = MLComputeUnitsCPUAndGPU;
+        } else if ([cu_str isEqualToString:@"cpu"]) {
+            cfg.computeUnits = MLComputeUnitsCPUOnly;
+        } else {
+            cfg.computeUnits = MLComputeUnitsCPUAndNeuralEngine;
+        }
+
+        // 加载编译后的 .mlmodelc
+        MLModel * model = [MLModel modelWithContentsOfURL:url configuration:cfg error:&err];
+        if (!model || err) {
+            NSLog(@"[t2w_dit] error: failed to load model: %@", err.localizedDescription);
+            return nullptr;
+        }
+
+        t2w_dit_ctx_t * ctx = (t2w_dit_ctx_t *) calloc(1, sizeof(t2w_dit_ctx_t));
+        if (!ctx) {
+            NSLog(@"[t2w_dit] error: calloc failed");
+            return nullptr;
+        }
+        ctx->model = model;
+        fill_default_dims(&ctx->dims);
+
+        // 用 mlpackage 自定义 metadata 校验/覆盖 dims。
+        NSDictionary * userMD = model.modelDescription.metadata[MLModelCreatorDefinedKey];
+        if ([userMD isKindOfClass:[NSDictionary class]]) {
+            ctx->dims.depth         = parse_int_md(userMD, @"depth",         ctx->dims.depth);
+            ctx->dims.chunk_size    = parse_int_md(userMD, @"chunk_size",    ctx->dims.chunk_size);
+            ctx->dims.max_cache_len = parse_int_md(userMD, @"max_cache_len", ctx->dims.max_cache_len);
+            ctx->dims.num_heads     = parse_int_md(userMD, @"num_heads",     ctx->dims.num_heads);
+            ctx->dims.head_dim      = parse_int_md(userMD, @"head_dim",      ctx->dims.head_dim);
+            ctx->dims.mel_channels  = parse_int_md(userMD, @"out_channels",  ctx->dims.mel_channels);
+            // spk 已经被 spk_embed_affine_layer 投影到 out_channels=80
+            ctx->dims.spk_dim       = ctx->dims.mel_channels;
+        }
+
+        ctx->prof_enabled = (getenv("OMNI_T2W_DIT_PROF") != nullptr);
+        ctx->n_calls   = 0;
+        ctx->ms_total  = 0.0;
+        ctx->ms_predict = 0.0;
+
+        NSLog(@"[t2w_dit] loaded mlpackage: %@", pathStr);
+        NSLog(@"[t2w_dit]   compute_units = %@", cu_str);
+        NSLog(@"[t2w_dit]   depth=%d batch=%d chunk=%d cache=%d heads=%d head_dim=%d",
+              ctx->dims.depth, ctx->dims.batch, ctx->dims.chunk_size, ctx->dims.max_cache_len,
+              ctx->dims.num_heads, ctx->dims.head_dim);
+        return (t2w_dit_handle_t) ctx;
+    }
+}
+
+// ----------------------------------------------------------------------------
+// dims / sizes
+// ----------------------------------------------------------------------------
+
+int t2w_dit_get_dims(t2w_dit_handle_t h, t2w_dit_dims_t * out) {
+    if (!h || !out) return -1;
+    t2w_dit_ctx_t * ctx = (t2w_dit_ctx_t *) h;
+    *out = ctx->dims;
+    return 0;
+}
+
+int t2w_dit_predict_buffer_sizes(t2w_dit_handle_t h,
+                                  size_t * nelem_x_mu_cond_feat,
+                                  size_t * nelem_t,
+                                  size_t * nelem_spks,
+                                  size_t * nelem_cnn_cache,
+                                  size_t * nelem_att_cache,
+                                  size_t * nelem_attn_mask) {
+    if (!h) return -1;
+    t2w_dit_ctx_t * ctx = (t2w_dit_ctx_t *) h;
+    const t2w_dit_dims_t * d = &ctx->dims;
+    if (nelem_x_mu_cond_feat) *nelem_x_mu_cond_feat = (size_t) d->batch * d->mel_channels * d->chunk_size;
+    if (nelem_t)              *nelem_t              = (size_t) d->batch;
+    if (nelem_spks)           *nelem_spks           = (size_t) d->batch * d->spk_dim;
+    if (nelem_cnn_cache)      *nelem_cnn_cache      = (size_t) d->depth * d->batch * d->cnn_cache_channels * d->cnn_cache_t;
+    if (nelem_att_cache)      *nelem_att_cache      = (size_t) d->depth * d->batch * d->num_heads * d->max_cache_len * (2 * d->head_dim);
+    if (nelem_attn_mask)      *nelem_attn_mask      = (size_t) d->batch * d->chunk_size * (d->chunk_size + d->max_cache_len);
+    return 0;
+}
+
+// ----------------------------------------------------------------------------
+// 内部工具：用 dataPointer 包一个 fp32 MLMultiArray（零拷贝输入）
+// ----------------------------------------------------------------------------
+
+static MLMultiArray * make_array_fp32(const float * data, NSArray<NSNumber *> * shape, NSError ** err) {
+    // 构造 row-major strides
+    NSMutableArray<NSNumber *> * strides = [NSMutableArray arrayWithCapacity:shape.count];
+    NSInteger stride = 1;
+    for (NSInteger i = (NSInteger) shape.count - 1; i >= 0; --i) {
+        [strides insertObject:@(stride) atIndex:0];
+        stride *= [shape[i] integerValue];
+    }
+    // 注意：CoreML 不会写这块内存，但 dataPointer 接受的是 void*（非 const）。
+    void * mutable_ptr = (void *) data;
+    return [[MLMultiArray alloc] initWithDataPointer:mutable_ptr
+                                               shape:shape
+                                            dataType:MLMultiArrayDataTypeFloat32
+                                             strides:strides
+                                         deallocator:nil
+                                               error:err];
+}
+
+// 检查 MLMultiArray 是否是 row-major contiguous（常规情况是；保底再 verify）。
+static bool array_is_contiguous(MLMultiArray * arr) {
+    NSArray<NSNumber *> * shape = arr.shape;
+    NSArray<NSNumber *> * strides = arr.strides;
+    if (shape.count != strides.count) return false;
+    NSInteger expect = 1;
+    for (NSInteger i = (NSInteger) shape.count - 1; i >= 0; --i) {
+        if ([strides[i] integerValue] != expect) return false;
+        expect *= [shape[i] integerValue];
+    }
+    return true;
+}
+
+// 把 ANE/CoreML 输出 MLMultiArray 拷贝到 row-major contiguous 的外部 fp32 buffer。
+//
+// CoreML 的输出张量经常带 padding（ANE 把 inner dim pad 到 16/32/64 边界以提速），
+// 例如 shape=[2,80,56] strides=[5120,64,1] —— 第 2 维 pad 到 64。这种情况下直接
+// memcpy 会把 padding 当真实数据读，导致数值完全错乱。
+//
+// 实现：尾维 stride=1 时把它当 contiguous "行" 一段一段 memcpy；外层用 N-D
+// 计数器迭代。最大 rank 8（远超我们的 4D）。
+static void copy_array_to_fp32(MLMultiArray * arr, float * dst) {
+    if (!arr || !dst) return;
+    const NSInteger n_elem = arr.count;
+
+    if (arr.dataType != MLMultiArrayDataTypeFloat32 &&
+        arr.dataType != MLMultiArrayDataTypeFloat16) {
+        NSLog(@"[t2w_dit] warn: unexpected output dtype %ld", (long) arr.dataType);
+        return;
+    }
+    const bool is_fp16 = (arr.dataType == MLMultiArrayDataTypeFloat16);
+    const size_t elem_size = is_fp16 ? sizeof(__fp16) : sizeof(float);
+    const void * raw = arr.dataPointer;
+
+    if (array_is_contiguous(arr) && !is_fp16) {
+        memcpy(dst, raw, (size_t) n_elem * sizeof(float));
+        return;
+    }
+
+    NSArray<NSNumber *> * shape   = arr.shape;
+    NSArray<NSNumber *> * strides = arr.strides;
+    const NSInteger ndim = (NSInteger) shape.count;
+    if (ndim == 0 || ndim > 8) {
+        NSLog(@"[t2w_dit] warn: unsupported rank %ld", (long) ndim);
+        return;
+    }
+
+    int64_t sh[8] = {0}, st[8] = {0};
+    for (NSInteger i = 0; i < ndim; ++i) {
+        sh[i] = [shape[i]   longLongValue];
+        st[i] = [strides[i] longLongValue];
+    }
+    const int64_t inner_dim    = sh[ndim - 1];
+    const int64_t inner_stride = st[ndim - 1];
+    const bool inner_contig    = (inner_stride == 1);
+
+    // 外层迭代器：对前 ndim-1 维做 N-D 计数（row-major 输出顺序）。
+    // 每步从源读 inner_dim 个元素到 dst[out_off..out_off+inner_dim]。
+    int64_t idx[8] = {0};
+    int64_t out_off = 0;
+    while (true) {
+        int64_t src_byte_off = 0;
+        for (NSInteger i = 0; i < ndim - 1; ++i) {
+            src_byte_off += (int64_t) idx[i] * st[i] * (int64_t) elem_size;
+        }
+        const char * src = (const char *) raw + src_byte_off;
+
+        if (is_fp16) {
+            // 逐元素转 fp32
+            for (int64_t k = 0; k < inner_dim; ++k) {
+                const __fp16 * p = (const __fp16 *) (src + k * inner_stride * (int64_t) elem_size);
+                dst[out_off + k] = (float) (*p);
+            }
+        } else if (inner_contig) {
+            memcpy(dst + out_off, src, (size_t) inner_dim * sizeof(float));
+        } else {
+            // inner stride != 1：极少见，逐元素拷
+            for (int64_t k = 0; k < inner_dim; ++k) {
+                const float * p = (const float *) (src + k * inner_stride * (int64_t) sizeof(float));
+                dst[out_off + k] = *p;
+            }
+        }
+        out_off += inner_dim;
+
+        // 递增最后一个非内层维（ndim-2 → 0）
+        if (ndim == 1) break;
+        NSInteger d = ndim - 2;
+        idx[d]++;
+        while (idx[d] >= sh[d]) {
+            if (d == 0) goto done;
+            idx[d] = 0;
+            d--;
+            idx[d]++;
+        }
+    }
+    done:
+    (void) 0;
+}
+
+// ----------------------------------------------------------------------------
+// predict
+// ----------------------------------------------------------------------------
+
+int t2w_dit_predict(t2w_dit_handle_t h,
+                    const float * x,
+                    const float * mu,
+                    const float * t,
+                    const float * spks,
+                    const float * cond,
+                    const float * cnn_cache_in,
+                    const float * att_cache_in,
+                    const float * attn_mask,
+                    float * feat_out,
+                    float * cnn_cache_out,
+                    float * att_cache_out) {
+    if (!h || !x || !mu || !t || !spks || !cond || !cnn_cache_in || !att_cache_in || !attn_mask) {
+        NSLog(@"[t2w_dit] predict: null input");
+        return -1;
+    }
+    if (!feat_out || !cnn_cache_out || !att_cache_out) {
+        NSLog(@"[t2w_dit] predict: null output");
+        return -1;
+    }
+
+    @autoreleasepool {
+        t2w_dit_ctx_t * ctx = (t2w_dit_ctx_t *) h;
+        const t2w_dit_dims_t * d = &ctx->dims;
+
+        const auto t0 = std::chrono::high_resolution_clock::now();
+
+        NSError * err = nil;
+        NSArray * sh_x        = @[ @(d->batch), @(d->mel_channels), @(d->chunk_size) ];
+        NSArray * sh_t        = @[ @(d->batch) ];
+        NSArray * sh_spks     = @[ @(d->batch), @(d->spk_dim) ];
+        NSArray * sh_cnn      = @[ @(d->depth * d->batch), @(d->cnn_cache_channels), @(d->cnn_cache_t) ];
+        NSArray * sh_att      = @[ @(d->depth * d->batch), @(d->num_heads), @(d->max_cache_len), @(2 * d->head_dim) ];
+        NSArray * sh_mask     = @[ @(d->batch), @(d->chunk_size), @(d->chunk_size + d->max_cache_len) ];
+
+        MLMultiArray * a_x        = make_array_fp32(x,            sh_x,    &err);
+        MLMultiArray * a_mu       = err ? nil : make_array_fp32(mu,           sh_x,    &err);
+        MLMultiArray * a_t        = err ? nil : make_array_fp32(t,            sh_t,    &err);
+        MLMultiArray * a_spks     = err ? nil : make_array_fp32(spks,         sh_spks, &err);
+        MLMultiArray * a_cond     = err ? nil : make_array_fp32(cond,         sh_x,    &err);
+        MLMultiArray * a_cnn_in   = err ? nil : make_array_fp32(cnn_cache_in, sh_cnn,  &err);
+        MLMultiArray * a_att_in   = err ? nil : make_array_fp32(att_cache_in, sh_att,  &err);
+        MLMultiArray * a_mask     = err ? nil : make_array_fp32(attn_mask,    sh_mask, &err);
+        if (err || !a_x || !a_mu || !a_t || !a_spks || !a_cond || !a_cnn_in || !a_att_in || !a_mask) {
+            NSLog(@"[t2w_dit] predict: input array build failed: %@", err.localizedDescription);
+            return -5;
+        }
+
+        NSDictionary * features = @{
+            @"x":            [MLFeatureValue featureValueWithMultiArray:a_x],
+            @"mu":           [MLFeatureValue featureValueWithMultiArray:a_mu],
+            @"t":            [MLFeatureValue featureValueWithMultiArray:a_t],
+            @"spks":         [MLFeatureValue featureValueWithMultiArray:a_spks],
+            @"cond":         [MLFeatureValue featureValueWithMultiArray:a_cond],
+            @"cnn_cache_in": [MLFeatureValue featureValueWithMultiArray:a_cnn_in],
+            @"att_cache_in": [MLFeatureValue featureValueWithMultiArray:a_att_in],
+            @"attn_mask":    [MLFeatureValue featureValueWithMultiArray:a_mask],
+        };
+        MLDictionaryFeatureProvider * provider = [[MLDictionaryFeatureProvider alloc]
+                                                    initWithDictionary:features error:&err];
+        if (err || !provider) {
+            NSLog(@"[t2w_dit] predict: provider build failed: %@", err.localizedDescription);
+            return -2;
+        }
+
+        const auto t_pre = std::chrono::high_resolution_clock::now();
+
+        id<MLFeatureProvider> result = [ctx->model predictionFromFeatures:provider error:&err];
+        if (err || !result) {
+            NSLog(@"[t2w_dit] predict: model predict failed: %@", err.localizedDescription);
+            return -3;
+        }
+
+        const auto t_pred = std::chrono::high_resolution_clock::now();
+
+        // 一次性 debug 输出实际拿到的 output names + shapes（仅当 prof 开启时）
+        if (ctx->prof_enabled && ctx->n_calls == 0) {
+            for (NSString * name in result.featureNames) {
+                MLMultiArray * a = [result featureValueForName:name].multiArrayValue;
+                if (a) {
+                    NSMutableString * sh = [NSMutableString stringWithString:@"["];
+                    for (NSInteger i = 0; i < (NSInteger) a.shape.count; ++i) {
+                        if (i > 0) [sh appendString:@","];
+                        [sh appendFormat:@"%@", a.shape[i]];
+                    }
+                    [sh appendString:@"]"];
+                    NSMutableString * st = [NSMutableString stringWithString:@"["];
+                    for (NSInteger i = 0; i < (NSInteger) a.strides.count; ++i) {
+                        if (i > 0) [st appendString:@","];
+                        [st appendFormat:@"%@", a.strides[i]];
+                    }
+                    [st appendString:@"]"];
+                    fprintf(stderr, "[t2w_dit] output[%s]: count=%ld shape=%s strides=%s\n",
+                            [name UTF8String], (long) a.count,
+                            [sh UTF8String], [st UTF8String]);
+                }
+            }
+        }
+
+        MLMultiArray * o_feat = [result featureValueForName:@"feat"].multiArrayValue;
+        MLMultiArray * o_cnn  = [result featureValueForName:@"cnn_cache_out"].multiArrayValue;
+        MLMultiArray * o_att  = [result featureValueForName:@"att_cache_out"].multiArrayValue;
+        if (!o_feat || !o_cnn || !o_att) {
+            NSLog(@"[t2w_dit] predict: missing output (feat=%p cnn=%p att=%p)",
+                  o_feat, o_cnn, o_att);
+            return -4;
+        }
+
+        copy_array_to_fp32(o_feat, feat_out);
+        copy_array_to_fp32(o_cnn,  cnn_cache_out);
+        copy_array_to_fp32(o_att,  att_cache_out);
+
+        const auto t1 = std::chrono::high_resolution_clock::now();
+
+        const double ms_predict = std::chrono::duration<double, std::milli>(t_pred - t_pre).count();
+        const double ms_total   = std::chrono::duration<double, std::milli>(t1     - t0  ).count();
+        ctx->n_calls++;
+        ctx->ms_predict += ms_predict;
+        ctx->ms_total   += ms_total;
+
+        if (ctx->prof_enabled) {
+            const double ms_wrap = std::chrono::duration<double, std::milli>(t_pre - t0).count();
+            const double ms_post = std::chrono::duration<double, std::milli>(t1 - t_pred).count();
+            fprintf(stderr,
+                    "[prof] t2w_dit call=%lld total=%.2fms (wrap=%.2f predict=%.2f post=%.2f)\n",
+                    (long long) ctx->n_calls, ms_total, ms_wrap, ms_predict, ms_post);
+        }
+        return 0;
+    }
+}
+
+// ----------------------------------------------------------------------------
+// free
+// ----------------------------------------------------------------------------
+
+void t2w_dit_free(t2w_dit_handle_t h) {
+    if (!h) return;
+    t2w_dit_ctx_t * ctx = (t2w_dit_ctx_t *) h;
+    if (ctx->n_calls > 0) {
+        fprintf(stderr,
+                "[t2w_dit] summary: n_calls=%lld total=%.2fms (avg=%.2fms) predict=%.2fms (avg=%.2fms)\n",
+                (long long) ctx->n_calls, ctx->ms_total, ctx->ms_total / (double) ctx->n_calls,
+                ctx->ms_predict, ctx->ms_predict / (double) ctx->n_calls);
+    }
+    ctx->model = nil;  // ARC release
+    free(ctx);
+}
+
+#if __cplusplus
+}  // extern "C"
+#endif

--- a/tools/omni/coreml/coreml_t2w_dit.mm
+++ b/tools/omni/coreml/coreml_t2w_dit.mm
@@ -1,10 +1,9 @@
 // coreml_t2w_dit.mm
 //
-// Token2Mel DiT estimator → ANE 桥接实现。
+// Token2Mel DiT estimator → CoreML 桥接实现。
 //
 // 不依赖 Xcode 自动生成的 typed wrapper class（model 输入太多、有 stateful
-// streaming 形状），用通用 MLModel + MLDictionaryFeatureProvider，从 mlpackage
-// metadata 直接读 schema 并构造 IO。
+// streaming 形状），用通用 MLModel + MLDictionaryFeatureProvider。
 
 #import <CoreML/CoreML.h>
 #import <Accelerate/Accelerate.h>
@@ -30,7 +29,7 @@ typedef struct t2w_dit_ctx {
     double                     ms_predict;
 } t2w_dit_ctx_t;
 
-// 默认 dims（与 ane_export_dit.py 写死的常量一致；mlpackage metadata 也存了一份，
+// 默认 dims（与 ane_export_dit.py 写死的常量一致；model metadata 也存了一份，
 // 后面 t2w_dit_load 会从 metadata 覆盖以校验一致性）。
 static void fill_default_dims(t2w_dit_dims_t * d) {
     d->depth              = 16;
@@ -57,13 +56,13 @@ static int parse_int_md(NSDictionary * md, NSString * key, int fallback) {
 // load
 // ----------------------------------------------------------------------------
 
-t2w_dit_handle_t t2w_dit_load(const char * mlpackage_path) {
+t2w_dit_handle_t t2w_dit_load(const char * model_path) {
     @autoreleasepool {
-        if (!mlpackage_path) {
-            NSLog(@"[t2w_dit] error: mlpackage_path is null");
+        if (!model_path) {
+            NSLog(@"[t2w_dit] error: model_path is null");
             return nullptr;
         }
-        NSString * pathStr = [NSString stringWithUTF8String:mlpackage_path];
+        NSString * pathStr = [NSString stringWithUTF8String:model_path];
         NSFileManager * fm = [NSFileManager defaultManager];
         if (![fm fileExistsAtPath:pathStr]) {
             NSLog(@"[t2w_dit] error: file not found: %@", pathStr);
@@ -85,7 +84,7 @@ t2w_dit_handle_t t2w_dit_load(const char * mlpackage_path) {
 
             // 没有 cache 才重编译（编译要 5-30s，是大头）
             if (![fm fileExistsAtPath:cachedPath]) {
-                NSLog(@"[t2w_dit] compiling mlpackage -> %@ ...", cachedPath);
+                NSLog(@"[t2w_dit] compiling CoreML model -> %@ ...", cachedPath);
                 NSURL * tmpURL = [MLModel compileModelAtURL:url error:&err];
                 if (err || !tmpURL) {
                     NSLog(@"[t2w_dit] error: compileModelAtURL failed: %@",
@@ -144,7 +143,7 @@ t2w_dit_handle_t t2w_dit_load(const char * mlpackage_path) {
         ctx->model = model;
         fill_default_dims(&ctx->dims);
 
-        // 用 mlpackage 自定义 metadata 校验/覆盖 dims。
+        // 用 CoreML 模型自定义 metadata 校验/覆盖 dims。
         NSDictionary * userMD = model.modelDescription.metadata[MLModelCreatorDefinedKey];
         if ([userMD isKindOfClass:[NSDictionary class]]) {
             ctx->dims.depth         = parse_int_md(userMD, @"depth",         ctx->dims.depth);
@@ -162,7 +161,7 @@ t2w_dit_handle_t t2w_dit_load(const char * mlpackage_path) {
         ctx->ms_total  = 0.0;
         ctx->ms_predict = 0.0;
 
-        NSLog(@"[t2w_dit] loaded mlpackage: %@", pathStr);
+        NSLog(@"[t2w_dit] loaded CoreML model: %@", pathStr);
         NSLog(@"[t2w_dit]   compute_units = %@", cu_str);
         NSLog(@"[t2w_dit]   depth=%d batch=%d chunk=%d cache=%d heads=%d head_dim=%d",
               ctx->dims.depth, ctx->dims.batch, ctx->dims.chunk_size, ctx->dims.max_cache_len,
@@ -236,9 +235,9 @@ static bool array_is_contiguous(MLMultiArray * arr) {
     return true;
 }
 
-// 把 ANE/CoreML 输出 MLMultiArray 拷贝到 row-major contiguous 的外部 fp32 buffer。
+// 把 CoreML 输出 MLMultiArray 拷贝到 row-major contiguous 的外部 fp32 buffer。
 //
-// CoreML 的输出张量经常带 padding（ANE 把 inner dim pad 到 16/32/64 边界以提速），
+// CoreML 的输出张量经常带 padding（CoreML 把 inner dim pad 到 16/32/64 边界以提速），
 // 例如 shape=[2,80,56] strides=[5120,64,1] —— 第 2 维 pad 到 64。这种情况下直接
 // memcpy 会把 padding 当真实数据读，导致数值完全错乱。
 //

--- a/tools/omni/omni-cli.cpp
+++ b/tools/omni/omni-cli.cpp
@@ -65,6 +65,8 @@ static void show_usage(const char * prog_name) {
         "  --omni              Enable omni mode (audio + vision, media_type=2)\n"
         "  --vision-backend <mode>  Vision compute backend: 'metal' (default) or 'coreml' (ANE)\n"
         "  --vision-coreml <path>   Path to CoreML model (.mlmodelc), required when backend=coreml\n"
+        "  --t2w-coreml <path>  Enable token2wav CoreML backend (DiT on CoreML, encoder on GPU)\n"
+        "                        Use 'auto' to auto-discover CoreML model in model dir\n"
         "  --test <prefix> <n> Run test case with data prefix and count\n"
         "  -h, --help          Show this help message\n\n"
         "Example:\n"
@@ -206,6 +208,7 @@ int main(int argc, char ** argv) {
     std::string projector_path_override;
     std::string vision_backend = "metal";  // vision backend: "metal" (default) or "coreml"
     std::string vision_coreml_model_path;  // CoreML model path (required when vision_backend=coreml)
+    std::string token2wav_coreml_model_path; // CoreML model path for token2wav DiT (empty = GPU only)
     std::string ref_audio_path = "tools/omni/assets/default_ref_audio/default_ref_audio.wav";
     int n_ctx = 4096;
     int n_gpu_layers = 99;  // GPU 层数，默认 99
@@ -262,6 +265,9 @@ int main(int argc, char ** argv) {
         }
         else if (arg == "--vision-coreml" && i + 1 < argc) {
             vision_coreml_model_path = argv[++i];
+        }
+        else if (arg == "--t2w-coreml" && i + 1 < argc) {
+            token2wav_coreml_model_path = argv[++i];
         }
         else if (arg == "--test" && i + 2 < argc) {
             run_test = true;
@@ -321,6 +327,7 @@ int main(int argc, char ** argv) {
         }
         params.vision_coreml_model_path = vision_coreml_model_path;
     }
+    params.token2wav_coreml_model_path = token2wav_coreml_model_path;
     params.n_ctx = n_ctx;
     params.n_gpu_layers = n_gpu_layers;
     
@@ -345,6 +352,9 @@ int main(int argc, char ** argv) {
     }
     printf("  TTS bin dir: %s\n", tts_bin_dir.c_str());
     printf("  Ref audio: %s\n", ref_audio_path.c_str());
+    if (!params.token2wav_coreml_model_path.empty()) {
+        printf("  T2W CoreML: %s\n", params.token2wav_coreml_model_path.c_str());
+    }
     
     // 🔧 Token2Wav 使用 GPU（Metal），已用 ggml_add+ggml_repeat 替代不支持的 ggml_add1
     auto ctx_omni = omni_init(&params, media_type, use_tts, tts_bin_dir, -1, "gpu:0");

--- a/tools/omni/omni.cpp
+++ b/tools/omni/omni.cpp
@@ -4143,27 +4143,40 @@ struct omni_context * omni_init(struct common_params * params, int media_type, b
             // 优先级: prompt_cache.gguf > prompt_bundle (实时计算 fallback)
             print_with_timestamp("Token2Wav: using prompt_cache from %s\n", prompt_cache_gguf.c_str());
 
-            // ANE 后端选择：环境变量 OMNI_T2W_ANE_MLPACKAGE 指向 ane_t2w_dit_*.mlpackage 时启用。
-            // 默认会去 <gguf_dir>/../ane_t2w/ane_t2w_dit_f16_chunk56_cache600.mlpackage 找
-            // （即把 mlpackage 放在 model bundle 旁边）。两条路径都不存在则走纯 GGUF。
-            std::string ane_mlpackage_path;
-            if (const char * v = ::getenv("OMNI_T2W_ANE_MLPACKAGE"); v && *v) {
-                ane_mlpackage_path = v;
-            } else {
-                std::string default_ane_dir = ctx_omni->token2wav_model_dir + "/../ane_t2w";
-                std::string default_ane_pkg = default_ane_dir + "/ane_t2w_dit_f16_chunk56_cache600.mlpackage";
-                std::ifstream probe(default_ane_pkg + "/Manifest.json");
-                if (probe.good()) {
-                    ane_mlpackage_path = default_ane_pkg;
+            // CoreML 后端选择：通过 params->token2wav_coreml_model_path 控制。
+            // - 空字符串（默认）：纯 GPU/GGUF 路径，不启用 CoreML。
+            // - "auto"：自动在 token2wav-gguf 目录查找 CoreML 模型。
+            // - 具体路径：使用指定 CoreML 模型。
+            std::string coreml_model_path;
+            if (!ctx_omni->params->token2wav_coreml_model_path.empty()) {
+                if (ctx_omni->params->token2wav_coreml_model_path == "auto") {
+                    // 与 GGUF 文件同级目录下查找
+                    std::string auto_pkg = ctx_omni->token2wav_model_dir + "/coreml_minicpmo45_t2w_dit.mlpackage";
+                    std::ifstream probe(auto_pkg + "/Manifest.json");
+                    if (probe.good()) {
+                        coreml_model_path = auto_pkg;
+                    } else {
+                        // fallback: 尝试带完整文件名
+                        auto_pkg = ctx_omni->token2wav_model_dir + "/coreml_minicpmo45_t2w_dit_f16_chunk56_cache600.mlpackage";
+                        std::ifstream probe2(auto_pkg + "/Manifest.json");
+                        if (probe2.good()) {
+                            coreml_model_path = auto_pkg;
+                        } else {
+                            print_with_timestamp("Token2Wav: CoreML auto mode, but no CoreML model found in %s\n",
+                                                 ctx_omni->token2wav_model_dir.c_str());
+                        }
+                    }
+                } else {
+                    coreml_model_path = ctx_omni->params->token2wav_coreml_model_path;
                 }
             }
-            if (!ane_mlpackage_path.empty()) {
-                print_with_timestamp("Token2Wav: ANE mlpackage = %s\n", ane_mlpackage_path.c_str());
+            if (!coreml_model_path.empty()) {
+                print_with_timestamp("Token2Wav: CoreML model = %s\n", coreml_model_path.c_str());
             }
 
             init_ok = ctx_omni->token2wav_session->init_from_prompt_cache_gguf(
                     encoder_gguf, flow_matching_gguf, flow_extra_gguf, prompt_cache_gguf,
-                    vocoder_gguf, device_token2mel, device_vocoder, 5, 1.0f, ane_mlpackage_path);
+                    vocoder_gguf, device_token2mel, device_vocoder, 5, 1.0f, coreml_model_path);
             if (!init_ok && use_prompt_bundle) {
                 print_with_timestamp("Token2Wav: prompt_cache failed, fallback to prompt_bundle from %s\n", prompt_bundle_dir.c_str());
                 init_ok = ctx_omni->token2wav_session->init_from_prompt_bundle(

--- a/tools/omni/omni.cpp
+++ b/tools/omni/omni.cpp
@@ -4142,9 +4142,28 @@ struct omni_context * omni_init(struct common_params * params, int media_type, b
             bool init_ok = false;
             // 优先级: prompt_cache.gguf > prompt_bundle (实时计算 fallback)
             print_with_timestamp("Token2Wav: using prompt_cache from %s\n", prompt_cache_gguf.c_str());
+
+            // ANE 后端选择：环境变量 OMNI_T2W_ANE_MLPACKAGE 指向 ane_t2w_dit_*.mlpackage 时启用。
+            // 默认会去 <gguf_dir>/../ane_t2w/ane_t2w_dit_f16_chunk56_cache600.mlpackage 找
+            // （即把 mlpackage 放在 model bundle 旁边）。两条路径都不存在则走纯 GGUF。
+            std::string ane_mlpackage_path;
+            if (const char * v = ::getenv("OMNI_T2W_ANE_MLPACKAGE"); v && *v) {
+                ane_mlpackage_path = v;
+            } else {
+                std::string default_ane_dir = ctx_omni->token2wav_model_dir + "/../ane_t2w";
+                std::string default_ane_pkg = default_ane_dir + "/ane_t2w_dit_f16_chunk56_cache600.mlpackage";
+                std::ifstream probe(default_ane_pkg + "/Manifest.json");
+                if (probe.good()) {
+                    ane_mlpackage_path = default_ane_pkg;
+                }
+            }
+            if (!ane_mlpackage_path.empty()) {
+                print_with_timestamp("Token2Wav: ANE mlpackage = %s\n", ane_mlpackage_path.c_str());
+            }
+
             init_ok = ctx_omni->token2wav_session->init_from_prompt_cache_gguf(
                     encoder_gguf, flow_matching_gguf, flow_extra_gguf, prompt_cache_gguf,
-                    vocoder_gguf, device_token2mel, device_vocoder, 5, 1.0f);
+                    vocoder_gguf, device_token2mel, device_vocoder, 5, 1.0f, ane_mlpackage_path);
             if (!init_ok && use_prompt_bundle) {
                 print_with_timestamp("Token2Wav: prompt_cache failed, fallback to prompt_bundle from %s\n", prompt_bundle_dir.c_str());
                 init_ok = ctx_omni->token2wav_session->init_from_prompt_bundle(

--- a/tools/omni/test/test_t2w_ane_end2end.cpp
+++ b/tools/omni/test/test_t2w_ane_end2end.cpp
@@ -1,0 +1,403 @@
+// test_t2w_ane_end2end.cpp
+//
+// 完整端到端 ANE 路径在 C++ 端的真实运行 + mel 落盘：
+//
+//   - PyTorch 已离线在 /tmp/ane_t2w_work/runtime_state 准备：
+//       * spk_proj.bin                  (1, 80) speaker 投影
+//       * init_cnn_cache_step{0..4}.bin (32, 1024, 2)        每 timestep 各一份初始 CNN cache
+//       * init_att_cache_step{0..4}.bin (32, 8, 600, 128)    每 timestep 各一份 padded att cache
+//       * chunk_<i>_mu.bin              (1, 80, 56)           encoder 算好的 mu
+//       * chunk_<i>_z.bin               (1, 80, 56)           初始噪声
+//       * chunk_<i>_cond.bin            (1, 80, 56)           cond
+//       * meta.txt                                             n_chunks / valid_cache_len_init / inference_cfg_rate
+//
+//   - C++ 端：
+//       1. 加载 ANE mlpackage（coreml_t2w_dit）
+//       2. 对每个 chunk：cosine schedule + CFG batch=2 + Euler ODE × n_timesteps
+//          每 step 调一次 t2w_dit_predict
+//       3. 把每 chunk 的 mel 拼接，落盘 /tmp/ane_t2w_work/runtime_state/mel_cpp_ane.bin
+//
+//   - 后续 Python 端拿 mel_cpp_ane.bin 跑 vocoder 出 wav，做三方对比。
+//
+// 这个 test 验证 C++ ANE 完整 pipeline 在真实 prompt + 真实 mu 输入下的:
+//   * 数值准确性（vs PyTorch 端 ANE 路径，应数值一致）
+//   * 真实运行时延（包含 5 timesteps × N chunks 的 ANE 调用，扫除 dummy 输入测试中可能的 outlier）
+
+#include "coreml/coreml_t2w_dit.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <chrono>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// IO helpers
+// ---------------------------------------------------------------------------
+
+static bool read_fp32(const std::string & path, std::vector<float> & out, size_t expect = 0) {
+    std::ifstream f(path, std::ios::binary);
+    if (!f) {
+        fprintf(stderr, "[end2end] open failed: %s\n", path.c_str());
+        return false;
+    }
+    f.seekg(0, std::ios::end);
+    size_t bytes = (size_t) f.tellg();
+    f.seekg(0, std::ios::beg);
+    if (bytes % sizeof(float) != 0) {
+        fprintf(stderr, "[end2end] %s: %zu not 4-aligned\n", path.c_str(), bytes);
+        return false;
+    }
+    size_t n = bytes / sizeof(float);
+    if (expect > 0 && n != expect) {
+        fprintf(stderr, "[end2end] %s: nelem=%zu expect=%zu\n", path.c_str(), n, expect);
+        return false;
+    }
+    out.resize(n);
+    f.read(reinterpret_cast<char *>(out.data()), bytes);
+    return (bool) f;
+}
+
+static bool write_fp32(const std::string & path, const std::vector<float> & v) {
+    std::ofstream f(path, std::ios::binary);
+    if (!f) return false;
+    f.write(reinterpret_cast<const char *>(v.data()), v.size() * sizeof(float));
+    return (bool) f;
+}
+
+static bool read_meta(const std::string & path, std::vector<std::string> & lines) {
+    std::ifstream f(path);
+    if (!f) return false;
+    std::string l;
+    while (std::getline(f, l)) lines.push_back(l);
+    return true;
+}
+
+static int meta_int(const std::vector<std::string> & lines, const std::string & key, int fallback) {
+    for (const auto & l : lines) {
+        std::istringstream iss(l);
+        std::string k; iss >> k;
+        if (k == key) {
+            int v; iss >> v;
+            return v;
+        }
+    }
+    return fallback;
+}
+
+static double meta_double(const std::vector<std::string> & lines, const std::string & key, double fallback) {
+    for (const auto & l : lines) {
+        std::istringstream iss(l);
+        std::string k; iss >> k;
+        if (k == key) {
+            double v; iss >> v;
+            return v;
+        }
+    }
+    return fallback;
+}
+
+// ---------------------------------------------------------------------------
+// Solver helpers
+// ---------------------------------------------------------------------------
+
+// cosine schedule: t_span[i] = 1 - cos(pi/2 * i/n)
+static std::vector<float> cosine_t_span(int n_timesteps) {
+    std::vector<float> ts((size_t) n_timesteps + 1);
+    for (int i = 0; i <= n_timesteps; ++i) {
+        const double u = (double) i / (double) n_timesteps;
+        ts[(size_t) i] = (float) (1.0 - std::cos(u * 0.5 * M_PI));
+    }
+    return ts;
+}
+
+// 构造 K 维布局 = [chunk(T) | cache(Tc)] 的 additive mask:
+//   前 T 全 0；接下来 valid_cache_len 个 0；其余 -1e4
+static void build_attn_mask(int B, int T, int Tc, int valid_cache_len, std::vector<float> & out) {
+    valid_cache_len = std::max(0, std::min(valid_cache_len, Tc));
+    out.assign((size_t) B * (size_t) T * (size_t) (T + Tc), -1e4f);
+    for (int b = 0; b < B; ++b) {
+        for (int t = 0; t < T; ++t) {
+            float * row = out.data() + ((size_t) b * T + t) * (size_t) (T + Tc);
+            for (int k = 0; k < T + valid_cache_len; ++k) {
+                row[k] = 0.0f;  // valid
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 主流程
+// ---------------------------------------------------------------------------
+
+int main(int argc, char ** argv) {
+    std::string state_dir = "/tmp/ane_t2w_work/runtime_state";
+    std::string mlpkg = "/Users/tianchi/code/project/ane/ane/ane_o45_tts/"
+                        "ane_t2w_dit_f16_chunk56_cache600.mlpackage";
+    std::string out_mel = "/tmp/ane_t2w_work/runtime_state/mel_cpp_ane.bin";
+    std::string dump_io_dir;  // 若非空，把 chunk 0 step 1 的所有 IO 落盘，方便 cross-check
+
+    for (int i = 1; i < argc; ++i) {
+        std::string a = argv[i];
+        if (a == "--state" && i + 1 < argc) state_dir = argv[++i];
+        else if (a == "--mlpkg" && i + 1 < argc) mlpkg = argv[++i];
+        else if (a == "--out-mel" && i + 1 < argc) out_mel = argv[++i];
+        else if (a == "--dump-io-dir" && i + 1 < argc) dump_io_dir = argv[++i];
+        else if (a == "-h" || a == "--help") {
+            printf("Usage: %s [--state <dir>] [--mlpkg <pkg>] [--out-mel <file>] "
+                   "[--dump-io-dir <dir>]\n", argv[0]);
+            return 0;
+        }
+    }
+
+    // 1. read meta
+    std::vector<std::string> meta;
+    if (!read_meta(state_dir + "/meta.txt", meta)) {
+        fprintf(stderr, "[end2end] no meta.txt at %s\n", state_dir.c_str());
+        return 1;
+    }
+    const int n_chunks       = meta_int(meta, "n_chunks", 0);
+    const int n_timesteps    = meta_int(meta, "n_timesteps", 5);
+    const int chunk_size     = meta_int(meta, "chunk_size", 56);
+    const int max_cache_len  = meta_int(meta, "max_cache_len", 600);
+    const int valid_cache_init = meta_int(meta, "valid_cache_len_init", 302);
+    const int depth          = meta_int(meta, "depth", 16);
+    const int B              = meta_int(meta, "batch", 2);
+    const int num_heads      = meta_int(meta, "num_heads", 8);
+    const int head_dim       = meta_int(meta, "head_dim", 64);
+    const int mel_channels   = meta_int(meta, "mel_channels", 80);
+    const float cfg_rate     = (float) meta_double(meta, "inference_cfg_rate", 0.7);
+
+    printf("=== test_t2w_ane_end2end ===\n");
+    printf("  state_dir:   %s\n", state_dir.c_str());
+    printf("  mlpkg:       %s\n", mlpkg.c_str());
+    printf("  n_chunks:    %d\n", n_chunks);
+    printf("  n_timesteps: %d\n", n_timesteps);
+    printf("  chunk_size:  %d  max_cache_len: %d  valid_init: %d\n",
+           chunk_size, max_cache_len, valid_cache_init);
+    printf("  cfg_rate:    %.3f\n", cfg_rate);
+
+    // 2. load ANE
+    printf("\n[1/4] load ANE mlpackage ...\n");
+    auto t0 = std::chrono::high_resolution_clock::now();
+    t2w_dit_handle_t h = t2w_dit_load(mlpkg.c_str());
+    if (!h) { fprintf(stderr, "load failed\n"); return 2; }
+    double ms_load = std::chrono::duration<double, std::milli>(
+        std::chrono::high_resolution_clock::now() - t0).count();
+    printf("  loaded in %.1f ms\n", ms_load);
+
+    t2w_dit_dims_t dims;
+    t2w_dit_get_dims(h, &dims);
+    if (dims.depth != depth || dims.batch != B || dims.chunk_size != chunk_size
+        || dims.max_cache_len != max_cache_len || dims.num_heads != num_heads
+        || dims.head_dim != head_dim || dims.mel_channels != mel_channels) {
+        fprintf(stderr, "[end2end] meta vs mlpackage dims mismatch\n");
+        t2w_dit_free(h);
+        return 3;
+    }
+
+    // 3. load static state: spk_proj + per-timestep init caches
+    printf("\n[2/4] load static state ...\n");
+    const size_t n_xmcf      = (size_t) B * mel_channels * chunk_size;
+    const size_t n_spks      = (size_t) B * mel_channels;
+    const size_t n_cnn       = (size_t) depth * B * 1024 * 2;
+    const size_t n_att       = (size_t) depth * B * num_heads * max_cache_len * (2 * head_dim);
+    const size_t n_mask      = (size_t) B * chunk_size * (chunk_size + max_cache_len);
+
+    std::vector<float> spk_proj_b1;  // (1, 80)
+    if (!read_fp32(state_dir + "/spk_proj.bin", spk_proj_b1, (size_t) mel_channels)) {
+        t2w_dit_free(h);
+        return 4;
+    }
+
+    // CFG batch=2: spks_b2 = [spk_proj; 0]
+    std::vector<float> spks_b2(n_spks, 0.0f);
+    std::memcpy(spks_b2.data(), spk_proj_b1.data(), n_spks / 2 * sizeof(float));
+
+    // 每 timestep 各自一份 cnn / att cache
+    std::vector<std::vector<float>> cnn_caches(n_timesteps), att_caches(n_timesteps);
+    for (int s = 0; s < n_timesteps; ++s) {
+        char buf[64];
+        snprintf(buf, sizeof(buf), "/init_cnn_cache_step%d.bin", s);
+        if (!read_fp32(state_dir + buf, cnn_caches[s], n_cnn)) { t2w_dit_free(h); return 5; }
+        snprintf(buf, sizeof(buf), "/init_att_cache_step%d.bin", s);
+        if (!read_fp32(state_dir + buf, att_caches[s], n_att)) { t2w_dit_free(h); return 5; }
+    }
+    printf("  per-timestep cache loaded (%d × cnn=%zu MB + att=%zu MB)\n",
+           n_timesteps, n_cnn * 4 / (1<<20), n_att * 4 / (1<<20));
+
+    // ---- 4. 主循环 ----
+    printf("\n[3/4] inference %d chunks × %d timesteps ...\n", n_chunks, n_timesteps);
+    const std::vector<float> t_span_v = cosine_t_span(n_timesteps);
+
+    std::vector<float> mel_total;  // 拼接所有 chunk 的 mel：(80, T_total)，row-major
+
+    int valid_cache_len = valid_cache_init;
+    double total_ane_ms = 0.0;
+    double total_chunk_ms = 0.0;
+
+    // 预分配 working buffers
+    std::vector<float> x_b1(n_xmcf / 2);
+    std::vector<float> mu_b1(n_xmcf / 2);
+    std::vector<float> cond_b1(n_xmcf / 2);
+    std::vector<float> z_b1(n_xmcf / 2);
+
+    std::vector<float> x_b2(n_xmcf);
+    std::vector<float> mu_b2(n_xmcf);
+    std::vector<float> cond_b2(n_xmcf);
+    std::vector<float> t_b2((size_t) B);
+    std::vector<float> mask_b2(n_mask);
+
+    std::vector<float> feat_b2(n_xmcf);
+    std::vector<float> cnn_out(n_cnn);
+    std::vector<float> att_out(n_att);
+
+    for (int ci = 0; ci < n_chunks; ++ci) {
+        char buf[64];
+        snprintf(buf, sizeof(buf), "/chunk_%03d_mu.bin", ci);
+        if (!read_fp32(state_dir + buf, mu_b1, n_xmcf / 2)) { t2w_dit_free(h); return 6; }
+        snprintf(buf, sizeof(buf), "/chunk_%03d_z.bin", ci);
+        if (!read_fp32(state_dir + buf, z_b1, n_xmcf / 2)) { t2w_dit_free(h); return 6; }
+        snprintf(buf, sizeof(buf), "/chunk_%03d_cond.bin", ci);
+        if (!read_fp32(state_dir + buf, cond_b1, n_xmcf / 2)) { t2w_dit_free(h); return 6; }
+
+        // 把 b=1 上的 mu/cond 复制成 b=2: [orig; 0] (uncond branch 用 0 替代)
+        std::memset(mu_b2.data(),   0, mu_b2.size()   * sizeof(float));
+        std::memset(cond_b2.data(), 0, cond_b2.size() * sizeof(float));
+        std::memcpy(mu_b2.data(),   mu_b1.data(),   mu_b1.size()   * sizeof(float));
+        std::memcpy(cond_b2.data(), cond_b1.data(), cond_b1.size() * sizeof(float));
+
+        // x init = z
+        std::copy(z_b1.begin(), z_b1.end(), x_b1.begin());
+
+        // build attn_mask once（每个 step 共用，valid 长度在本 chunk 内不变）
+        build_attn_mask(B, chunk_size, max_cache_len, valid_cache_len, mask_b2);
+
+        const auto t_chunk0 = std::chrono::high_resolution_clock::now();
+        float t_scalar = t_span_v[0];
+        float dt = t_span_v[1] - t_span_v[0];
+
+        for (int step = 1; step <= n_timesteps; ++step) {
+            // x_b2 = [x; x]
+            std::memcpy(x_b2.data(),                       x_b1.data(), x_b1.size() * sizeof(float));
+            std::memcpy(x_b2.data() + x_b1.size(),         x_b1.data(), x_b1.size() * sizeof(float));
+            // t_b2 = [t; t]
+            t_b2[0] = t_scalar; t_b2[1] = t_scalar;
+
+            // 可选：dump chunk 0 第 1 个 step 的所有 IO（用于 cross-check 数值）
+            if (!dump_io_dir.empty() && ci == 0 && step == 1) {
+                auto dump = [&](const std::string & name, const std::vector<float> & v) {
+                    std::ofstream f(dump_io_dir + "/" + name, std::ios::binary);
+                    f.write(reinterpret_cast<const char *>(v.data()), v.size() * sizeof(float));
+                };
+                dump("io_x.bin",            x_b2);
+                dump("io_mu.bin",           mu_b2);
+                dump("io_t.bin",            t_b2);
+                dump("io_spks.bin",         spks_b2);
+                dump("io_cond.bin",         cond_b2);
+                dump("io_cnn_cache_in.bin", cnn_caches[step - 1]);
+                dump("io_att_cache_in.bin", att_caches[step - 1]);
+                dump("io_attn_mask.bin",    mask_b2);
+                fprintf(stderr, "[dump] chunk0 step1 inputs saved to %s\n", dump_io_dir.c_str());
+            }
+
+            const auto t_pred0 = std::chrono::high_resolution_clock::now();
+            int rc = t2w_dit_predict(h,
+                x_b2.data(), mu_b2.data(), t_b2.data(), spks_b2.data(), cond_b2.data(),
+                cnn_caches[step - 1].data(), att_caches[step - 1].data(), mask_b2.data(),
+                feat_b2.data(), cnn_out.data(), att_out.data());
+            if (rc != 0) {
+                fprintf(stderr, "predict failed rc=%d at chunk %d step %d\n", rc, ci, step);
+                t2w_dit_free(h);
+                return 7;
+            }
+            const double ms_pred = std::chrono::duration<double, std::milli>(
+                std::chrono::high_resolution_clock::now() - t_pred0).count();
+            total_ane_ms += ms_pred;
+
+            if (!dump_io_dir.empty() && ci == 0 && step == 1) {
+                auto dump = [&](const std::string & name, const std::vector<float> & v) {
+                    std::ofstream f(dump_io_dir + "/" + name, std::ios::binary);
+                    f.write(reinterpret_cast<const char *>(v.data()), v.size() * sizeof(float));
+                };
+                dump("io_feat.bin",          feat_b2);
+                dump("io_cnn_cache_out.bin", cnn_out);
+                dump("io_att_cache_out.bin", att_out);
+                fprintf(stderr, "[dump] chunk0 step1 outputs saved\n");
+            }
+
+            // CFG: dphi = (1+cfg) * cond_branch - cfg * uncond_branch
+            // feat layout: [B0=cond_branch; B1=uncond_branch]，B0 占前一半
+            const size_t half = n_xmcf / 2;
+            const float k1 = 1.0f + cfg_rate;
+            const float k2 = cfg_rate;
+            for (size_t i = 0; i < half; ++i) {
+                const float dphi = k1 * feat_b2[i] - k2 * feat_b2[half + i];
+                x_b1[i] = x_b1[i] + dt * dphi;
+            }
+
+            t_scalar += dt;
+            if (step < n_timesteps) {
+                dt = t_span_v[(size_t) step + 1] - t_scalar;
+            }
+
+            // 更新该 timestep 的 cache（流转到下一个 chunk）
+            std::swap(cnn_caches[step - 1], cnn_out);
+            std::swap(att_caches[step - 1], att_out);
+            // 注意 swap 后 cnn_out / att_out 持有上一帧的 buffer，下一次 predict
+            // 会被覆盖；但 size 不变所以 OK
+        }
+        const double ms_chunk = std::chrono::duration<double, std::milli>(
+            std::chrono::high_resolution_clock::now() - t_chunk0).count();
+        total_chunk_ms += ms_chunk;
+
+        // x_b1 即本 chunk 输出 mel，shape (1, 80, 56)。
+        // 拼接到 mel_total（按 (80, T_total) 行优先），保持每行（channel）连续。
+        // 输入 row-major (1, 80, 56)：c 慢、t 快。要拼成 (80, T_total)，每行 c 紧密放，按 t 拼接。
+        const size_t T_old = mel_total.empty() ? 0 : mel_total.size() / mel_channels;
+        const size_t T_new = T_old + chunk_size;
+        std::vector<float> next(mel_channels * T_new);
+        for (int c = 0; c < mel_channels; ++c) {
+            // 拷贝旧的 c 行
+            if (T_old > 0) {
+                std::memcpy(next.data() + (size_t) c * T_new,
+                            mel_total.data() + (size_t) c * T_old,
+                            T_old * sizeof(float));
+            }
+            // 追加本 chunk 的 c 行（在 x_b1 中位置 = c*56）
+            std::memcpy(next.data() + (size_t) c * T_new + T_old,
+                        x_b1.data() + (size_t) c * chunk_size,
+                        (size_t) chunk_size * sizeof(float));
+        }
+        mel_total.swap(next);
+
+        printf("  chunk %d  valid_cache=%3d  chunk=%.1fms  ane_avg/step=%.2fms\n",
+               ci, valid_cache_len, ms_chunk, ms_chunk / n_timesteps);
+
+        valid_cache_len = std::min(valid_cache_len + chunk_size, max_cache_len);
+    }
+
+    printf("\n[4/4] save mel ...\n");
+    if (!write_fp32(out_mel, mel_total)) {
+        fprintf(stderr, "write failed: %s\n", out_mel.c_str());
+        t2w_dit_free(h);
+        return 8;
+    }
+    printf("  saved: %s   shape=(80, %zu)  bytes=%zu\n",
+           out_mel.c_str(), mel_total.size() / mel_channels, mel_total.size() * 4);
+
+    printf("\n=== Summary ===\n");
+    printf("  total chunk wall: %.1fms (avg %.1fms / chunk)\n",
+           total_chunk_ms, total_chunk_ms / n_chunks);
+    printf("  total ANE predict: %.1fms (avg %.2fms / call, %d calls)\n",
+           total_ane_ms, total_ane_ms / (double) (n_chunks * n_timesteps),
+           n_chunks * n_timesteps);
+
+    t2w_dit_free(h);
+    return 0;
+}

--- a/tools/omni/test/test_t2w_ane_end2end.cpp
+++ b/tools/omni/test/test_t2w_ane_end2end.cpp
@@ -12,7 +12,7 @@
 //       * meta.txt                                             n_chunks / valid_cache_len_init / inference_cfg_rate
 //
 //   - C++ 端：
-//       1. 加载 ANE mlpackage（coreml_t2w_dit）
+//       1. 加载 CoreML 模型（coreml_t2w_dit）
 //       2. 对每个 chunk：cosine schedule + CFG batch=2 + Euler ODE × n_timesteps
 //          每 step 调一次 t2w_dit_predict
 //       3. 把每 chunk 的 mel 拼接，落盘 /tmp/ane_t2w_work/runtime_state/mel_cpp_ane.bin
@@ -136,10 +136,9 @@ static void build_attn_mask(int B, int T, int Tc, int valid_cache_len, std::vect
 // ---------------------------------------------------------------------------
 
 int main(int argc, char ** argv) {
-    std::string state_dir = "/tmp/ane_t2w_work/runtime_state";
-    std::string mlpkg = "/Users/tianchi/code/project/ane/ane/ane_o45_tts/"
-                        "ane_t2w_dit_f16_chunk56_cache600.mlpackage";
-    std::string out_mel = "/tmp/ane_t2w_work/runtime_state/mel_cpp_ane.bin";
+    std::string state_dir;
+    std::string mlpkg;
+    std::string out_mel;
     std::string dump_io_dir;  // 若非空，把 chunk 0 step 1 的所有 IO 落盘，方便 cross-check
 
     for (int i = 1; i < argc; ++i) {
@@ -153,6 +152,15 @@ int main(int argc, char ** argv) {
                    "[--dump-io-dir <dir>]\n", argv[0]);
             return 0;
         }
+    }
+
+    if (mlpkg.empty() || state_dir.empty()) {
+        fprintf(stderr, "Error: --mlpkg <path> and --state <dir> are required\n");
+        fprintf(stderr, "Usage: %s --mlpkg <path> --state <dir> [--out-mel <file>] [--dump-io-dir <dir>]\n", argv[0]);
+        return 1;
+    }
+    if (out_mel.empty()) {
+        out_mel = state_dir + "/mel_cpp_ane.bin";
     }
 
     // 1. read meta
@@ -183,7 +191,7 @@ int main(int argc, char ** argv) {
     printf("  cfg_rate:    %.3f\n", cfg_rate);
 
     // 2. load ANE
-    printf("\n[1/4] load ANE mlpackage ...\n");
+    printf("\n[1/4] load CoreML model ...\n");
     auto t0 = std::chrono::high_resolution_clock::now();
     t2w_dit_handle_t h = t2w_dit_load(mlpkg.c_str());
     if (!h) { fprintf(stderr, "load failed\n"); return 2; }
@@ -196,7 +204,7 @@ int main(int argc, char ** argv) {
     if (dims.depth != depth || dims.batch != B || dims.chunk_size != chunk_size
         || dims.max_cache_len != max_cache_len || dims.num_heads != num_heads
         || dims.head_dim != head_dim || dims.mel_channels != mel_channels) {
-        fprintf(stderr, "[end2end] meta vs mlpackage dims mismatch\n");
+        fprintf(stderr, "[end2end] meta vs CoreML model dims mismatch\n");
         t2w_dit_free(h);
         return 3;
     }

--- a/tools/omni/test/test_t2w_dit_ane.cpp
+++ b/tools/omni/test/test_t2w_dit_ane.cpp
@@ -13,8 +13,8 @@
 //
 // 用法:
 //   ./build/bin/llama-omni-test-t2w-dit-ane \
-//       --mlpkg /Users/tianchi/code/project/ane/ane/ane_o45_tts/ane_t2w_dit_f16_chunk56_cache600.mlpackage \
-//       --vec-dir /tmp/ane_t2w_work/test_vectors
+//       --mlpkg <path/to/coreml_minicpmo45_t2w_dit.mlpackage> \
+//       --vec-dir <path/to/test_vectors>
 
 #include "coreml/coreml_t2w_dit.h"
 
@@ -83,14 +83,9 @@ static DiffStats compute_diff(const std::vector<float> & a, const std::vector<fl
 }
 
 int main(int argc, char ** argv) {
-    std::string mlpkg = "/Users/tianchi/code/project/ane/ane/ane_o45_tts/"
-                        "ane_t2w_dit_f16_chunk56_cache600.mlpackage";
-    std::string vec_dir = "/tmp/ane_t2w_work/test_vectors";
+    std::string mlpkg;
+    std::string vec_dir;
     int repeat = 5;
-    // 默认容差：ref 是 CPU_ONLY 跑出来的（fp32 路径）。
-    //   - CPU_ONLY: bit-exact，1e-4 即可
-    //   - ANE / ALL / CPU_GPU: fp16 内部累加，会有 ~0.1-0.5 量级偏差
-    // 可通过 --tol 显式覆盖。
     double tol_max = -1.0;  // -1 表示自动按 compute_units 选
 
     for (int i = 1; i < argc; ++i) {
@@ -117,13 +112,19 @@ int main(int argc, char ** argv) {
         }
     }
 
+    if (mlpkg.empty() || vec_dir.empty()) {
+        fprintf(stderr, "Error: --mlpkg <path> and --vec-dir <dir> are required\n");
+        fprintf(stderr, "Usage: %s --mlpkg <path> --vec-dir <dir> [--repeat <n>] [--tol <max|Δ|>]\n", argv[0]);
+        return 1;
+    }
+
     printf("=== test_t2w_dit_ane ===\n");
     printf("  mlpkg:    %s\n", mlpkg.c_str());
     printf("  vec_dir:  %s\n", vec_dir.c_str());
     printf("  repeat:   %d\n\n", repeat);
 
     // 1. load model
-    printf("[1/4] load mlpackage ...\n");
+    printf("[1/4] load CoreML model ...\n");
     auto t0 = std::chrono::high_resolution_clock::now();
     t2w_dit_handle_t h = t2w_dit_load(mlpkg.c_str());
     if (!h) {

--- a/tools/omni/test/test_t2w_dit_ane.cpp
+++ b/tools/omni/test/test_t2w_dit_ane.cpp
@@ -1,0 +1,269 @@
+// test_t2w_dit_ane.cpp
+//
+// 独立单元测试：验证 coreml_t2w_dit C ABI 工作正常，
+// 且 C++ 端 predict 输出与 Python 端 predict 输出 bit/数值一致。
+//
+// 工作流程：
+//   1. 离线在 Python 侧生成一组确定性 dummy 输入（fix-seed），喂给 ANE 模型，
+//      把 inputs/outputs 全部落盘到 raw fp32 .bin 文件。
+//      （由 tools/convert/o45_tts/dump_test_vectors.py 生成）
+//   2. 本测试读这些 .bin，调 t2w_dit_predict()，比对输出与 Python 端落盘的输出。
+//
+// 退出码: 0 成功 / 非 0 失败。
+//
+// 用法:
+//   ./build/bin/llama-omni-test-t2w-dit-ane \
+//       --mlpkg /Users/tianchi/code/project/ane/ane/ane_o45_tts/ane_t2w_dit_f16_chunk56_cache600.mlpackage \
+//       --vec-dir /tmp/ane_t2w_work/test_vectors
+
+#include "coreml/coreml_t2w_dit.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <chrono>
+#include <fstream>
+#include <string>
+#include <vector>
+
+static bool read_fp32(const std::string & path, std::vector<float> & out, size_t expected_n = 0) {
+    std::ifstream f(path, std::ios::binary);
+    if (!f) {
+        fprintf(stderr, "[test] failed to open: %s\n", path.c_str());
+        return false;
+    }
+    f.seekg(0, std::ios::end);
+    size_t bytes = (size_t) f.tellg();
+    f.seekg(0, std::ios::beg);
+    if (bytes % sizeof(float) != 0) {
+        fprintf(stderr, "[test] %s: size %zu not multiple of 4\n", path.c_str(), bytes);
+        return false;
+    }
+    size_t n = bytes / sizeof(float);
+    if (expected_n > 0 && n != expected_n) {
+        fprintf(stderr, "[test] %s: nelem=%zu expected %zu\n", path.c_str(), n, expected_n);
+        return false;
+    }
+    out.resize(n);
+    f.read(reinterpret_cast<char *>(out.data()), bytes);
+    if (!f) {
+        fprintf(stderr, "[test] read failed: %s\n", path.c_str());
+        return false;
+    }
+    return true;
+}
+
+struct DiffStats {
+    double max_d  = 0.0;
+    double mean_d = 0.0;
+    double rms    = 0.0;
+    double rel    = 0.0;
+};
+
+static DiffStats compute_diff(const std::vector<float> & a, const std::vector<float> & b) {
+    DiffStats st;
+    if (a.size() != b.size() || a.empty()) return st;
+    double max_d = 0.0, sum_abs = 0.0, sum_sq = 0.0;
+    float a_max = a[0], a_min = a[0];
+    for (size_t i = 0; i < a.size(); ++i) {
+        const double d = std::fabs((double) a[i] - (double) b[i]);
+        if (d > max_d) max_d = d;
+        sum_abs += d;
+        sum_sq += d * d;
+        if (a[i] > a_max) a_max = a[i];
+        if (a[i] < a_min) a_min = a[i];
+    }
+    st.max_d  = max_d;
+    st.mean_d = sum_abs / (double) a.size();
+    st.rms    = std::sqrt(sum_sq / (double) a.size());
+    const double range = (double) a_max - (double) a_min;
+    st.rel    = max_d / (range + 1e-9);
+    return st;
+}
+
+int main(int argc, char ** argv) {
+    std::string mlpkg = "/Users/tianchi/code/project/ane/ane/ane_o45_tts/"
+                        "ane_t2w_dit_f16_chunk56_cache600.mlpackage";
+    std::string vec_dir = "/tmp/ane_t2w_work/test_vectors";
+    int repeat = 5;
+    // 默认容差：ref 是 CPU_ONLY 跑出来的（fp32 路径）。
+    //   - CPU_ONLY: bit-exact，1e-4 即可
+    //   - ANE / ALL / CPU_GPU: fp16 内部累加，会有 ~0.1-0.5 量级偏差
+    // 可通过 --tol 显式覆盖。
+    double tol_max = -1.0;  // -1 表示自动按 compute_units 选
+
+    for (int i = 1; i < argc; ++i) {
+        std::string a = argv[i];
+        if (a == "--mlpkg" && i + 1 < argc) {
+            mlpkg = argv[++i];
+        } else if (a == "--vec-dir" && i + 1 < argc) {
+            vec_dir = argv[++i];
+        } else if (a == "--repeat" && i + 1 < argc) {
+            repeat = std::atoi(argv[++i]);
+        } else if (a == "--tol" && i + 1 < argc) {
+            tol_max = std::atof(argv[++i]);
+        } else if (a == "-h" || a == "--help") {
+            printf("Usage: %s [--mlpkg <path>] [--vec-dir <dir>] [--repeat <n>] [--tol <max|Δ|>]\n", argv[0]);
+            return 0;
+        }
+    }
+    if (tol_max < 0) {
+        const char * cu = getenv("OMNI_T2W_DIT_COMPUTE_UNITS");
+        if (cu && std::string(cu) == "cpu") {
+            tol_max = 1e-4;     // CPU 路径 bit-exact
+        } else {
+            tol_max = 0.5;      // ANE / GPU 路径 fp16 量化预期损失
+        }
+    }
+
+    printf("=== test_t2w_dit_ane ===\n");
+    printf("  mlpkg:    %s\n", mlpkg.c_str());
+    printf("  vec_dir:  %s\n", vec_dir.c_str());
+    printf("  repeat:   %d\n\n", repeat);
+
+    // 1. load model
+    printf("[1/4] load mlpackage ...\n");
+    auto t0 = std::chrono::high_resolution_clock::now();
+    t2w_dit_handle_t h = t2w_dit_load(mlpkg.c_str());
+    if (!h) {
+        fprintf(stderr, "load failed\n");
+        return 1;
+    }
+    auto t_load = std::chrono::duration<double, std::milli>(
+        std::chrono::high_resolution_clock::now() - t0).count();
+    printf("  loaded in %.1f ms\n", t_load);
+
+    // 2. dims & buffer sizes
+    t2w_dit_dims_t d;
+    if (t2w_dit_get_dims(h, &d) != 0) {
+        fprintf(stderr, "get_dims failed\n");
+        t2w_dit_free(h);
+        return 1;
+    }
+    printf("  dims: depth=%d batch=%d chunk=%d cache=%d heads=%d head_dim=%d "
+           "mel=%d spk=%d cnn(c=%d t=%d)\n",
+           d.depth, d.batch, d.chunk_size, d.max_cache_len, d.num_heads, d.head_dim,
+           d.mel_channels, d.spk_dim, d.cnn_cache_channels, d.cnn_cache_t);
+
+    size_t n_xmcf, n_t, n_spks, n_cnn, n_att, n_mask;
+    t2w_dit_predict_buffer_sizes(h, &n_xmcf, &n_t, &n_spks, &n_cnn, &n_att, &n_mask);
+    printf("  buffer sizes (fp32 elems):\n");
+    printf("    x/mu/cond/feat: %zu\n", n_xmcf);
+    printf("    t:              %zu\n", n_t);
+    printf("    spks:           %zu\n", n_spks);
+    printf("    cnn_cache:      %zu\n", n_cnn);
+    printf("    att_cache:      %zu\n", n_att);
+    printf("    attn_mask:      %zu\n", n_mask);
+
+    // 3. load test vectors (from Python dumper)
+    printf("\n[2/4] load test vectors from %s ...\n", vec_dir.c_str());
+    std::vector<float> in_x, in_mu, in_t, in_spks, in_cond,
+                       in_cnn, in_att, in_mask,
+                       ref_feat, ref_cnn_out, ref_att_out;
+    bool ok = true;
+    ok &= read_fp32(vec_dir + "/in_x.bin",            in_x,        n_xmcf);
+    ok &= read_fp32(vec_dir + "/in_mu.bin",           in_mu,       n_xmcf);
+    ok &= read_fp32(vec_dir + "/in_t.bin",            in_t,        n_t);
+    ok &= read_fp32(vec_dir + "/in_spks.bin",         in_spks,     n_spks);
+    ok &= read_fp32(vec_dir + "/in_cond.bin",         in_cond,     n_xmcf);
+    ok &= read_fp32(vec_dir + "/in_cnn_cache.bin",    in_cnn,      n_cnn);
+    ok &= read_fp32(vec_dir + "/in_att_cache.bin",    in_att,      n_att);
+    ok &= read_fp32(vec_dir + "/in_attn_mask.bin",    in_mask,     n_mask);
+    ok &= read_fp32(vec_dir + "/ref_feat.bin",        ref_feat,    n_xmcf);
+    ok &= read_fp32(vec_dir + "/ref_cnn_cache.bin",   ref_cnn_out, n_cnn);
+    ok &= read_fp32(vec_dir + "/ref_att_cache.bin",   ref_att_out, n_att);
+    if (!ok) {
+        fprintf(stderr, "test vectors missing/wrong size; run dump_test_vectors.py first\n");
+        t2w_dit_free(h);
+        return 2;
+    }
+    printf("  all 11 vectors loaded\n");
+
+    // 打印每个输入张量的 stat，跟 Python dump 端的 stat 对照（看字节是否一致）
+    auto stat = [](const std::vector<float> & v) {
+        if (v.empty()) return std::make_tuple(0.0, 0.0, 0.0, 0.0);
+        double mn = v[0], mx = v[0], s = 0.0, ss = 0.0;
+        for (float x : v) {
+            if (x < mn) mn = x;
+            if (x > mx) mx = x;
+            s += x;
+            ss += (double) x * x;
+        }
+        return std::make_tuple(mn, mx, s / (double) v.size(),
+                               std::sqrt(ss / (double) v.size()));
+    };
+    auto pr = [&](const char * n, const std::vector<float> & v) {
+        auto [mn, mx, mean, rms] = stat(v);
+        printf("    %-22s n=%-9zu min=%-+10.4e max=%-+10.4e mean=%-+10.4e rms=%-10.4e\n",
+               n, v.size(), mn, mx, mean, rms);
+    };
+    printf("  input stats (C++):\n");
+    pr("in_x",         in_x);
+    pr("in_mu",        in_mu);
+    pr("in_t",         in_t);
+    pr("in_spks",      in_spks);
+    pr("in_cond",      in_cond);
+    pr("in_cnn_cache", in_cnn);
+    pr("in_att_cache", in_att);
+    pr("in_attn_mask", in_mask);
+    printf("  expected ref stats (loaded from .bin):\n");
+    pr("ref_feat",     ref_feat);
+    pr("ref_cnn_cache", ref_cnn_out);
+    pr("ref_att_cache", ref_att_out);
+
+    // 4. predict + verify
+    printf("\n[3/4] predict (n=%d) ...\n", repeat);
+    std::vector<float> out_feat(n_xmcf), out_cnn(n_cnn), out_att(n_att);
+    double ms_first = 0.0, ms_steady_sum = 0.0;
+    for (int i = 0; i < repeat; ++i) {
+        auto ti = std::chrono::high_resolution_clock::now();
+        int rc = t2w_dit_predict(h,
+            in_x.data(), in_mu.data(), in_t.data(), in_spks.data(), in_cond.data(),
+            in_cnn.data(), in_att.data(), in_mask.data(),
+            out_feat.data(), out_cnn.data(), out_att.data());
+        auto te = std::chrono::high_resolution_clock::now();
+        double ms = std::chrono::duration<double, std::milli>(te - ti).count();
+        if (rc != 0) {
+            fprintf(stderr, "predict failed rc=%d at iter %d\n", rc, i);
+            t2w_dit_free(h);
+            return 3;
+        }
+        if (i == 0) ms_first = ms;
+        else        ms_steady_sum += ms;
+        printf("  iter %d  %.2f ms\n", i, ms);
+    }
+    if (repeat >= 2) {
+        printf("  first call:    %.2f ms\n", ms_first);
+        printf("  steady avg:    %.2f ms (n=%d)\n",
+               ms_steady_sum / (double) (repeat - 1), repeat - 1);
+    }
+
+    // 5. compare to reference
+    printf("\n[4/4] verify against reference ...\n");
+    printf("  output stats (C++):\n");
+    pr("out_feat",      out_feat);
+    pr("out_cnn_cache", out_cnn);
+    pr("out_att_cache", out_att);
+    DiffStats df = compute_diff(ref_feat,    out_feat);
+    DiffStats dc = compute_diff(ref_cnn_out, out_cnn);
+    DiffStats da = compute_diff(ref_att_out, out_att);
+    printf("  feat:           max|Δ|=%.4e  mean|Δ|=%.4e  rms=%.4e  rel=%.4f%%\n",
+           df.max_d, df.mean_d, df.rms, df.rel * 100);
+    printf("  cnn_cache_out:  max|Δ|=%.4e  mean|Δ|=%.4e  rms=%.4e  rel=%.4f%%\n",
+           dc.max_d, dc.mean_d, dc.rms, dc.rel * 100);
+    printf("  att_cache_out:  max|Δ|=%.4e  mean|Δ|=%.4e  rms=%.4e  rel=%.4f%%\n",
+           da.max_d, da.mean_d, da.rms, da.rel * 100);
+
+    // 阈值：CPU_ONLY 时 bit-exact (~1e-4)；ANE 模式预期 fp16 量化损失 ~0.1-0.5。
+    bool pass = (df.max_d <= tol_max) && (dc.max_d <= tol_max) && (da.max_d <= tol_max);
+    if (!pass) {
+        printf("\n  >>> FAIL: 数值差距超过容差 %.4f\n", tol_max);
+        t2w_dit_free(h);
+        return 4;
+    }
+    printf("\n  >>> PASS (容差 max|Δ| ≤ %.4f)\n", tol_max);
+
+    t2w_dit_free(h);
+    return 0;
+}

--- a/tools/omni/token2wav/token2wav-example.cpp
+++ b/tools/omni/token2wav/token2wav-example.cpp
@@ -165,10 +165,11 @@ int main() {
     omni::flow::Token2WavSession sess;
     // 初始化：加载 encoder/flow/vocoder 模型，导入 prompt_cache用于初始化
     const auto t_init0 = clock::now();
-    std::string ane_mlpackage = env_or("OMNI_T2W_ANE_MLPACKAGE", "");
+    // CoreML backend: pass the path to init_from_prompt_cache_gguf. Leave empty for GPU-only.
+    std::string coreml_model;
     if (!sess.init_from_prompt_cache_gguf(encoder_gguf, flow_matching_gguf, flow_extra_gguf, prompt_cache_gguf,
                                           vocoder_gguf, device_token2mel, device_vocoder, n_timesteps, temperature,
-                                          ane_mlpackage)) {
+                                          coreml_model)) {
         std::fprintf(stderr, "init_from_prompt_cache_gguf failed\n");
         return 3;
     }

--- a/tools/omni/token2wav/token2wav-example.cpp
+++ b/tools/omni/token2wav/token2wav-example.cpp
@@ -165,8 +165,10 @@ int main() {
     omni::flow::Token2WavSession sess;
     // 初始化：加载 encoder/flow/vocoder 模型，导入 prompt_cache用于初始化
     const auto t_init0 = clock::now();
+    std::string ane_mlpackage = env_or("OMNI_T2W_ANE_MLPACKAGE", "");
     if (!sess.init_from_prompt_cache_gguf(encoder_gguf, flow_matching_gguf, flow_extra_gguf, prompt_cache_gguf,
-                                          vocoder_gguf, device_token2mel, device_vocoder, n_timesteps, temperature)) {
+                                          vocoder_gguf, device_token2mel, device_vocoder, n_timesteps, temperature,
+                                          ane_mlpackage)) {
         std::fprintf(stderr, "init_from_prompt_cache_gguf failed\n");
         return 3;
     }

--- a/tools/omni/token2wav/token2wav-impl.cpp
+++ b/tools/omni/token2wav/token2wav-impl.cpp
@@ -17,7 +17,12 @@ typedef void (*ggml_backend_cuda_set_disable_graph_t)(ggml_backend_t backend, bo
 #include "gguf.h"
 #include <chrono>
 #include <fstream>
+#include <random>
 #include <unordered_map>
+
+#if defined(ENABLE_COREML) && defined(__APPLE__)
+#include "coreml/coreml_t2w_dit.h"
+#endif
 #include <vector>
 #include "ggml-cpu.h"
 #ifdef GGML_USE_CUDA
@@ -231,6 +236,33 @@ flowSetupCacheOut flowCausalMaskedDiffWithXvec::build_setup_cache_graph(
     out.conformer_cnn_cache = enc_out.new_cnn_cache_ctb;
     out.conformer_att_cache = enc_out.new_att_cache;
     out.estimator_cache     = cache_out_ptr;
+    return out;
+}
+flowEncoderOnlyOut flowCausalMaskedDiffWithXvec::build_inference_chunk_encoder_only_graph(
+    ggml_context * ctx,
+    ggml_tensor *  token_ids_tb_i32,
+    ggml_tensor *  spk_cb_f32,
+    bool           last_chunk,
+    ggml_tensor *  conformer_cnn_cache_in,
+    ggml_tensor *  conformer_att_cache_in) const {
+    flowEncoderOnlyOut out{};
+    if (ctx == nullptr || token_ids_tb_i32 == nullptr || spk_cb_f32 == nullptr) {
+        return out;
+    }
+    if (!encoder_) {
+        return out;
+    }
+    // ANE 路径：仅 encoder + projector + spk affine，跳过 decoder/CFG/ODE。
+    // 与 build_inference_chunk_graph 前 4 步语义完全一致。
+    ggml_tensor * xs_ctb       = flow_build_token_embedding_ctb(ctx, token_embedding_weight_, token_ids_tb_i32, input_size_);
+    ggml_tensor * spk_norm_cb  = flow_build_l2_normalize_cb(ctx, spk_cb_f32, 1e-12f);
+    ggml_tensor * spk_proj_cb  = flow_build_linear_cb(ctx, spk_norm_cb, spk_affine_weight_, spk_affine_bias_);
+    auto enc_out               = encoder_->forward_chunk(ctx, xs_ctb, last_chunk, conformer_cnn_cache_in, conformer_att_cache_in);
+    ggml_tensor * mu_ctb       = flow_build_linear_ctb(ctx, enc_out.ys_ctb, encoder_proj_weight_, encoder_proj_bias_);
+    out.mu_ctb              = ggml_cont(ctx, mu_ctb);
+    out.spk_proj_cb         = ggml_cont(ctx, spk_proj_cb);
+    out.conformer_cnn_cache = enc_out.new_cnn_cache_ctb;
+    out.conformer_att_cache = enc_out.new_att_cache;
     return out;
 }
 flowInferenceChunkOut flowCausalMaskedDiffWithXvec::build_inference_chunk_graph(
@@ -7495,6 +7527,28 @@ ggml_tensor * runner_slice_time_dim1_4d(ggml_context * ctx, ggml_tensor * x, int
 }
 }  // namespace
 // 用于上下文/计算图与流式缓存张量
+// 提前定义 streamSessionEncOnly，让 reset()/reset_stream() 能引用其 clear()。
+// 实现细节（build graph / 字段语义）在 inference_chunk_encoder_only 处一并说明。
+struct flowGGUFModelRunner::streamSessionEncOnly {
+    ggml_context *  ctx     = nullptr;
+    ggml_gallocr_t  galloc  = nullptr;
+    int64_t         B               = 0;
+    int64_t         T_chunk_token   = 0;
+    ggml_tensor *   spk_cb              = nullptr;
+    ggml_tensor *   chunk_token_ids_tb  = nullptr;
+    ggml_tensor *   conf_cnn_cache      = nullptr;
+    ggml_tensor *   conf_att_cache      = nullptr;
+    ggml_tensor *   out_mu_ctb_nonlast  = nullptr;
+    ggml_tensor *   out_mu_ctb_last     = nullptr;
+    ggml_tensor *   out_spk_proj_cb     = nullptr;
+    ggml_cgraph *   gf_nonlast = nullptr;
+    ggml_cgraph *   gf_last    = nullptr;
+    void clear() {
+        if (galloc) { ggml_gallocr_free(galloc); galloc = nullptr; }
+        if (ctx)    { ggml_free(ctx);    ctx    = nullptr; }
+        *this = streamSessionEncOnly();
+    }
+};
 struct flowGGUFModelRunner::streamSession {
     ggml_context *        ctx = nullptr;
     ggml_gallocr_t        galloc = nullptr;
@@ -7541,6 +7595,10 @@ void flowGGUFModelRunner::reset() {
         sess_->clear();
         sess_.reset();
     }
+    if (sess_enc_only_) {
+        sess_enc_only_->clear();
+        sess_enc_only_.reset();
+    }
     loader_.~flowGGUFModelLoader();
     new (&loader_) flowGGUFModelLoader();
     num_threads_           = 1;
@@ -7568,6 +7626,10 @@ void flowGGUFModelRunner::reset_stream() {
     if (sess_) {
         sess_->clear();
         sess_.reset();
+    }
+    if (sess_enc_only_) {
+        sess_enc_only_->clear();
+        sess_enc_only_.reset();
     }
     if (std::shared_ptr<flow_matching::fmCausalConditionalCFM> dec = loader_.decoder()) {
         dec->reset_stream_state();
@@ -7947,6 +8009,292 @@ bool flowGGUFModelRunner::inference_chunk(const int32_t *             token_bt,
         runner_read_tensor_bytes(loader_.backend(), sess_->conf_att_cache, cache_out.conformer_att_cache);
         runner_read_tensor_bytes(loader_.backend(), sess_->est_cnn_cache, cache_out.estimator_cnn_cache);
         runner_read_tensor_bytes(loader_.backend(), sess_->est_att_cache, cache_out.estimator_att_cache);
+    }
+    return true;
+}
+// ============================================================================
+// ANE 路径：encoder-only inference 子图 + cache fold 工具
+// streamSessionEncOnly 已经提前定义在 streamSession 旁边，让 reset()/reset_stream()
+// 能引用其 clear()。这里只放函数实现。
+// ============================================================================
+// 把 (C, B) row-major 转 (B, C) row-major
+static void runner_cb_to_bc(const std::vector<float> & cb, int64_t C, int64_t B, std::vector<float> & bc_out) {
+    bc_out.assign((size_t) C * (size_t) B, 0.0f);
+    for (int64_t b = 0; b < B; ++b) {
+        for (int64_t c = 0; c < C; ++c) {
+            bc_out[(size_t) b * (size_t) C + (size_t) c] = cb[(size_t) c * (size_t) B + (size_t) b];
+        }
+    }
+}
+bool flowGGUFModelRunner::inference_chunk_encoder_only(const int32_t *             token_bt,
+                                                       int64_t                     B,
+                                                       int64_t                     T_token,
+                                                       const float *               spk_bc,
+                                                       int64_t                     C_spk,
+                                                       bool                        last_chunk,
+                                                       const flowStreamCacheHost & cache_in_conformer,
+                                                       std::vector<float> &        mu_bct_out,
+                                                       std::vector<float> &        spk_proj_b80_out,
+                                                       flowStreamCacheHost &       cache_out_conformer) {
+    mu_bct_out.clear();
+    spk_proj_b80_out.clear();
+    cache_out_conformer.clear();
+    if (!token_bt || !spk_bc || B <= 0 || T_token <= 0) {
+        return false;
+    }
+    if (C_spk != 192) {
+        LOG_ERROR("inference_chunk_encoder_only: expected C_spk=192, got %lld\n", (long long) C_spk);
+        return false;
+    }
+    if (!loader_.backend() || !loader_.model()) {
+        return false;
+    }
+    if (cache_in_conformer.conformer_cnn_ne.size() != 3 || cache_in_conformer.conformer_att_ne.size() != 4) {
+        LOG_ERROR("inference_chunk_encoder_only: bad cache_in conformer ne (need cnn=3D, att=4D)\n");
+        return false;
+    }
+    const int64_t T_chunk_token = T_token;
+    if (!sess_enc_only_) {
+        sess_enc_only_ = std::make_unique<streamSessionEncOnly>();
+    }
+    auto & s = *sess_enc_only_;
+    const bool need_rebuild = s.ctx == nullptr || s.B != B || s.T_chunk_token != T_chunk_token;
+    if (need_rebuild) {
+        s.clear();
+        s.B             = B;
+        s.T_chunk_token = T_chunk_token;
+        ggml_init_params p{};
+        p.mem_size   = 1024ull * 1024ull * 1024ull;
+        p.mem_buffer = nullptr;
+        p.no_alloc   = true;
+        s.ctx        = ggml_init(p);
+        if (!s.ctx) {
+            s.clear();
+            return false;
+        }
+        // 输入张量
+        s.spk_cb = ggml_new_tensor_2d(s.ctx, GGML_TYPE_F32, C_spk, B);
+        ggml_set_input(s.spk_cb);
+        s.chunk_token_ids_tb = ggml_new_tensor_2d(s.ctx, GGML_TYPE_I32, T_chunk_token, B);
+        ggml_set_input(s.chunk_token_ids_tb);
+        // 持久 conformer cache（按 cache_in 的 ne）
+        s.conf_cnn_cache = ggml_new_tensor_3d(s.ctx, GGML_TYPE_F32,
+            cache_in_conformer.conformer_cnn_ne[0],
+            cache_in_conformer.conformer_cnn_ne[1],
+            cache_in_conformer.conformer_cnn_ne[2]);
+        s.conf_att_cache = ggml_new_tensor_4d(s.ctx, GGML_TYPE_F32,
+            cache_in_conformer.conformer_att_ne[0],
+            cache_in_conformer.conformer_att_ne[1],
+            cache_in_conformer.conformer_att_ne[2],
+            cache_in_conformer.conformer_att_ne[3]);
+        if (!s.conf_cnn_cache || !s.conf_att_cache) {
+            s.clear();
+            return false;
+        }
+        ggml_set_output(s.conf_cnn_cache);
+        ggml_set_output(s.conf_att_cache);
+        // build nonlast graph
+        auto out_n = loader_.model()->build_inference_chunk_encoder_only_graph(
+            s.ctx, s.chunk_token_ids_tb, s.spk_cb, /*last_chunk=*/false,
+            s.conf_cnn_cache, s.conf_att_cache);
+        if (!out_n.mu_ctb || !out_n.spk_proj_cb) {
+            s.clear();
+            return false;
+        }
+        s.out_mu_ctb_nonlast = out_n.mu_ctb;
+        s.out_spk_proj_cb    = out_n.spk_proj_cb;
+        // build last graph
+        auto out_l = loader_.model()->build_inference_chunk_encoder_only_graph(
+            s.ctx, s.chunk_token_ids_tb, s.spk_cb, /*last_chunk=*/true,
+            s.conf_cnn_cache, s.conf_att_cache);
+        if (!out_l.mu_ctb) {
+            s.clear();
+            return false;
+        }
+        s.out_mu_ctb_last = out_l.mu_ctb;
+        // 把新 conformer cache 写回持久 cache（last 路径 att 长度可能 > 持久 ne[1]，trim 之）
+        const int64_t L_conf_att = s.conf_att_cache->ne[1];
+        ggml_tensor * out_n_att_trim = out_n.conformer_att_cache;
+        if (out_n.conformer_att_cache->ne[1] > L_conf_att) {
+            const int64_t delta = out_n.conformer_att_cache->ne[1] - L_conf_att;
+            out_n_att_trim = runner_slice_time_dim1_4d(s.ctx, out_n.conformer_att_cache, delta, L_conf_att);
+        }
+        ggml_tensor * out_l_att_trim = out_l.conformer_att_cache;
+        if (out_l.conformer_att_cache->ne[1] > L_conf_att) {
+            const int64_t delta = out_l.conformer_att_cache->ne[1] - L_conf_att;
+            out_l_att_trim = runner_slice_time_dim1_4d(s.ctx, out_l.conformer_att_cache, delta, L_conf_att);
+        }
+        ggml_tensor * cpy_cnn_n = ggml_cpy(s.ctx, out_n.conformer_cnn_cache, s.conf_cnn_cache);
+        ggml_tensor * cpy_att_n = ggml_cpy(s.ctx, out_n_att_trim,            s.conf_att_cache);
+        ggml_tensor * cpy_cnn_l = ggml_cpy(s.ctx, out_l.conformer_cnn_cache, s.conf_cnn_cache);
+        ggml_tensor * cpy_att_l = ggml_cpy(s.ctx, out_l_att_trim,            s.conf_att_cache);
+        // 两个独立 graph
+        s.gf_nonlast = ggml_new_graph_custom(s.ctx, GGML_DEFAULT_GRAPH_SIZE * 256, false);
+        ggml_build_forward_expand(s.gf_nonlast, s.out_mu_ctb_nonlast);
+        ggml_build_forward_expand(s.gf_nonlast, s.out_spk_proj_cb);
+        ggml_build_forward_expand(s.gf_nonlast, cpy_cnn_n);
+        ggml_build_forward_expand(s.gf_nonlast, cpy_att_n);
+        s.gf_last = ggml_new_graph_custom(s.ctx, GGML_DEFAULT_GRAPH_SIZE * 256, false);
+        ggml_build_forward_expand(s.gf_last, s.out_mu_ctb_last);
+        ggml_build_forward_expand(s.gf_last, s.out_spk_proj_cb);
+        ggml_build_forward_expand(s.gf_last, cpy_cnn_l);
+        ggml_build_forward_expand(s.gf_last, cpy_att_l);
+        // 单图 alloc 让 galloc 算出最大内存预算
+        ggml_cgraph * gf_alloc = ggml_new_graph_custom(s.ctx, GGML_DEFAULT_GRAPH_SIZE * 256, false);
+        ggml_build_forward_expand(gf_alloc, s.out_mu_ctb_nonlast);
+        ggml_build_forward_expand(gf_alloc, s.out_spk_proj_cb);
+        ggml_build_forward_expand(gf_alloc, cpy_cnn_n);
+        ggml_build_forward_expand(gf_alloc, cpy_att_n);
+        ggml_build_forward_expand(gf_alloc, s.out_mu_ctb_last);
+        ggml_build_forward_expand(gf_alloc, cpy_cnn_l);
+        ggml_build_forward_expand(gf_alloc, cpy_att_l);
+        ggml_backend_buffer_type_t buft = ggml_backend_get_default_buffer_type(loader_.backend());
+        s.galloc                        = ggml_gallocr_new(buft);
+        if (!s.galloc) {
+            s.clear();
+            return false;
+        }
+        if (!ggml_gallocr_alloc_graph(s.galloc, gf_alloc)) {
+            s.clear();
+            return false;
+        }
+        // 把 cache_in 的 conformer cache 字节写入持久 tensor
+        backend_tensor_set(loader_.backend(), s.conf_cnn_cache,
+                           cache_in_conformer.conformer_cnn_cache.data(),
+                           cache_in_conformer.conformer_cnn_cache.size());
+        backend_tensor_set(loader_.backend(), s.conf_att_cache,
+                           cache_in_conformer.conformer_att_cache.data(),
+                           cache_in_conformer.conformer_att_cache.size());
+    }
+    // 上传输入
+    std::vector<int32_t> token_tb;
+    runner_bt_to_tb(token_bt, B, T_token, token_tb);
+    std::vector<float> spk_cb_v;
+    runner_bc_to_cb(spk_bc, B, C_spk, spk_cb_v);
+    backend_tensor_set(loader_.backend(), s.chunk_token_ids_tb, token_tb.data(),
+                       token_tb.size() * sizeof(int32_t));
+    backend_tensor_set(loader_.backend(), s.spk_cb, spk_cb_v.data(), spk_cb_v.size() * sizeof(float));
+    runner_feed_enc_stream_pos(loader_.backend(), s.ctx, loader_.encoder());
+    // 运行
+    ggml_cgraph *        gf = last_chunk ? s.gf_last : s.gf_nonlast;
+    const ggml_status    st = ggml_backend_graph_compute(loader_.backend(), gf);
+    if (st != GGML_STATUS_SUCCESS) {
+        return false;
+    }
+    if (runner_backend_is_device(loader_.backend())) {
+        ggml_backend_synchronize(loader_.backend());
+    }
+    // 下载 mu (B, 80, T_mel)
+    ggml_tensor * mu_t = last_chunk ? s.out_mu_ctb_last : s.out_mu_ctb_nonlast;
+    {
+        const int64_t      C   = mu_t->ne[0];
+        const int64_t      T   = mu_t->ne[1];
+        const int64_t      Bb  = mu_t->ne[2];
+        std::vector<float> mu_ctb((size_t) C * (size_t) T * (size_t) Bb);
+        ggml_backend_tensor_get(mu_t, mu_ctb.data(), 0, mu_ctb.size() * sizeof(float));
+        runner_ctb_to_bct(mu_ctb, C, T, Bb, mu_bct_out);
+    }
+    // 下载 spk_proj (C=80, B) → (B, C=80)
+    {
+        const int64_t      C  = s.out_spk_proj_cb->ne[0];
+        const int64_t      Bb = s.out_spk_proj_cb->ne[1];
+        std::vector<float> cb_v((size_t) C * (size_t) Bb);
+        ggml_backend_tensor_get(s.out_spk_proj_cb, cb_v.data(), 0, cb_v.size() * sizeof(float));
+        runner_cb_to_bc(cb_v, C, Bb, spk_proj_b80_out);
+    }
+    // export 新 conformer cache
+    if (export_caches_to_host_) {
+        cache_out_conformer.conformer_cnn_ne = { s.conf_cnn_cache->ne[0], s.conf_cnn_cache->ne[1],
+                                                 s.conf_cnn_cache->ne[2] };
+        cache_out_conformer.conformer_att_ne = { s.conf_att_cache->ne[0], s.conf_att_cache->ne[1],
+                                                 s.conf_att_cache->ne[2], s.conf_att_cache->ne[3] };
+        runner_read_tensor_bytes(loader_.backend(), s.conf_cnn_cache, cache_out_conformer.conformer_cnn_cache);
+        runner_read_tensor_bytes(loader_.backend(), s.conf_att_cache, cache_out_conformer.conformer_att_cache);
+    }
+    return true;
+}
+// 把 setup_cache 输出的 5D estimator cache (row-major bytes, 来自
+// flowStreamCacheHost) fold 成 ANE 期望的 4D 格式（按 timestep 拆开）。
+//
+// 5D layout (row-major)：
+//   cnn: estimator_cnn_ne = [t1, t2, t3, n_step, depth]  -- 实际 ne 是 ggml 反向
+//        我们跟随 setup_cache 现有 ne 顺序（dim0=最快变维度，dim4=最慢）：
+//          ne0=2, ne1=1024, ne2=B(=2), ne3=depth(=16), ne4=n_step
+//   att: ne0=128, ne1=T_real, ne2=num_heads(=8), ne3=B(=2), ne4=depth(=16)
+//        actually setup_cache 的 ne 顺序是 (head_dim*2, T, num_heads, B, depth, n_step)?
+//        实际从 build_setup_cache_graph 推导：每层 cache 维度由 fmCFMCache::cnn_cache/att_cache 决定。
+// 这里我们只做 byte-level 切片（按 n_step 切 n 段），剩余维序不变，让 ANE 端按 4D
+// (depth*B, ...) 读取。
+//
+// 结论（与 omni.cpp 跑出来的实测一致）：
+//   estimator_cnn_ne = {2, 1024, B=2*n_step}   ← n_step × depth × B 摊在一起，3D
+//   estimator_att_ne = {128, T, num_heads, B=2*n_step}   ← n_step × depth × B 摊在 dim3
+// 实际 ne 大小由 token2wav-impl 设置；我们按下面的 _bytes_per_step 切片即可。
+bool flowGGUFModelRunner::fold_estimator_cache_5d_to_4d(
+    const flowStreamCacheHost & host,
+    int64_t                      depth,
+    int64_t                      B_internal_2,
+    std::vector<std::vector<float>> & cnn_per_step_4d,
+    std::vector<std::vector<float>> & att_per_step_4d,
+    int64_t &                          out_T_real_att) {
+    cnn_per_step_4d.clear();
+    att_per_step_4d.clear();
+    out_T_real_att = 0;
+    if (host.n_timesteps <= 0) {
+        return false;
+    }
+    if (host.estimator_cnn_ne.size() != 4 || host.estimator_att_ne.size() != 4) {
+        LOG_ERROR("fold_estimator_cache: expected 4D estimator ne, got cnn=%zu att=%zu\n",
+                  host.estimator_cnn_ne.size(), host.estimator_att_ne.size());
+        return false;
+    }
+    const int64_t n_step      = host.n_timesteps;
+    const int64_t cnn_ne0     = host.estimator_cnn_ne[0]; // 2
+    const int64_t cnn_ne1     = host.estimator_cnn_ne[1]; // 1024
+    const int64_t cnn_ne2     = host.estimator_cnn_ne[2]; // B_internal=2
+    const int64_t cnn_ne3     = host.estimator_cnn_ne[3]; // depth*n_step or n_step*depth
+    const int64_t att_ne0     = host.estimator_att_ne[0]; // head_dim*2 = 128
+    const int64_t att_ne1     = host.estimator_att_ne[1]; // T_real
+    const int64_t att_ne2     = host.estimator_att_ne[2]; // num_heads = 8
+    const int64_t att_ne3     = host.estimator_att_ne[3]; // B_internal*depth*n_step (or 类似)
+    // 期望：ne3 = n_step * depth * B_internal_2
+    const int64_t expect_ne3  = n_step * depth * B_internal_2;
+    if (cnn_ne2 != B_internal_2 || cnn_ne3 != expect_ne3 || att_ne3 != expect_ne3) {
+        LOG_ERROR("fold_estimator_cache: ne mismatch cnn={%lld,%lld,%lld,%lld} "
+                  "att={%lld,%lld,%lld,%lld} depth=%lld B=%lld n_step=%lld expect_ne3=%lld\n",
+                  (long long) cnn_ne0, (long long) cnn_ne1, (long long) cnn_ne2, (long long) cnn_ne3,
+                  (long long) att_ne0, (long long) att_ne1, (long long) att_ne2, (long long) att_ne3,
+                  (long long) depth, (long long) B_internal_2, (long long) n_step,
+                  (long long) expect_ne3);
+        return false;
+    }
+    out_T_real_att = att_ne1;
+    // bytes-per-step
+    const size_t cnn_per_step_elems = (size_t) cnn_ne0 * (size_t) cnn_ne1 * (size_t) cnn_ne2 * (size_t) (depth * B_internal_2);
+    const size_t att_per_step_elems = (size_t) att_ne0 * (size_t) att_ne1 * (size_t) att_ne2 * (size_t) (depth * B_internal_2);
+    const size_t cnn_total_bytes    = cnn_per_step_elems * (size_t) n_step * sizeof(float);
+    const size_t att_total_bytes    = att_per_step_elems * (size_t) n_step * sizeof(float);
+    if (host.estimator_cnn_cache.size() != cnn_total_bytes ||
+        host.estimator_att_cache.size() != att_total_bytes) {
+        LOG_ERROR("fold_estimator_cache: byte size mismatch cnn=%zu vs %zu, att=%zu vs %zu\n",
+                  host.estimator_cnn_cache.size(), cnn_total_bytes,
+                  host.estimator_att_cache.size(), att_total_bytes);
+        return false;
+    }
+    // 切片：按 n_step 拆 host bytes 成 n_step 份。每份的 4D shape 是
+    //   cnn: (depth*B_internal_2, 1024, 2)         — fold 后维度顺序为 (D*B, c1, c2)
+    //   att: (depth*B_internal_2, num_heads, T, hd*2)
+    // 注意原 5D bytes 在 dim3=depth*B 上是 contiguous 的（因为 ggml row-major），
+    // 所以同一 step 的 cnn/att 在 host bytes 中是连续的一段。
+    cnn_per_step_4d.resize(n_step);
+    att_per_step_4d.resize(n_step);
+    const float * cnn_src = reinterpret_cast<const float *>(host.estimator_cnn_cache.data());
+    const float * att_src = reinterpret_cast<const float *>(host.estimator_att_cache.data());
+    for (int64_t s = 0; s < n_step; ++s) {
+        cnn_per_step_4d[s].assign(cnn_src + (size_t) s * cnn_per_step_elems,
+                                  cnn_src + (size_t) (s + 1) * cnn_per_step_elems);
+        att_per_step_4d[s].assign(att_src + (size_t) s * att_per_step_elems,
+                                  att_src + (size_t) (s + 1) * att_per_step_elems);
     }
     return true;
 }
@@ -8350,11 +8698,21 @@ bool t2m_load_prompt_cache_gguf(const std::string &               gguf_path,
 
 }  // namespace
 
+Token2Mel::~Token2Mel() {
+#if defined(ENABLE_COREML) && defined(__APPLE__)
+    if (ane_handle_) {
+        t2w_dit_free((t2w_dit_handle_t) ane_handle_);
+        ane_handle_ = nullptr;
+    }
+#endif
+}
+
 bool Token2Mel::load_model(const std::string & encoder_gguf,
                            const std::string & flow_matching_gguf,
                            const std::string & flow_extra_gguf,
                            const std::string & device,
-                           int                 threads) {
+                           int                 threads,
+                           const std::string & ane_mlpackage_path) {
     // 用于加载三段GGUF并初始化runner(失败时回退到cpu)
     reset_stream();
     runner_.set_num_threads(threads);
@@ -8373,6 +8731,38 @@ bool Token2Mel::load_model(const std::string & encoder_gguf,
     }
 
     runner_.set_export_caches_to_host(false);
+
+    // ANE 后端：加载 mlpackage handle
+    backend_kind_       = Backend::GGUF;
+    ane_handle_         = nullptr;
+    ane_mlpackage_path_.clear();
+    if (!ane_mlpackage_path.empty()) {
+#if defined(ENABLE_COREML) && defined(__APPLE__)
+        std::fprintf(stderr,
+                     "[Token2Mel] ANE backend requested, loading mlpackage: %s\n",
+                     ane_mlpackage_path.c_str());
+        ane_handle_ = (void *) t2w_dit_load(ane_mlpackage_path.c_str());
+        if (!ane_handle_) {
+            LOG_ERROR("Token2Mel.load_model: t2w_dit_load failed for %s; "
+                      "falling back to GGUF DiT\n",
+                      ane_mlpackage_path.c_str());
+        } else {
+            ane_mlpackage_path_ = ane_mlpackage_path;
+            backend_kind_       = Backend::ANE;
+            std::fprintf(stderr, "[Token2Mel] ANE backend ready (DiT on ANE, encoder on %s)\n",
+                         device.c_str());
+            // 启用 cache 导出：encoder-only 路径需要 host conformer cache 流转
+            runner_.set_export_caches_to_host(true);
+            // 设置 export_caches_to_host=true 后，inference_chunk 会比平时多
+            // download conformer + estimator cache，但 ANE 模式下我们不会调
+            // inference_chunk（只调 inference_chunk_encoder_only），所以只影响
+            // setup_cache 阶段的一次性导出。
+        }
+#else
+        LOG_ERROR("Token2Mel.load_model: ANE mlpackage requested but ENABLE_COREML not set; "
+                  "falling back to GGUF DiT\n");
+#endif
+    }
 
     model_loaded_   = true;
     stream_started_ = false;
@@ -8570,14 +8960,51 @@ bool Token2Mel::start_stream_with_prompt_cache_gguf(const std::string & prompt_c
     const int   use_nt   = (n_timesteps > 0) ? n_timesteps : n_ts_file;
     const float use_temp = (temperature > 0.0f) ? temperature : temp_file;
 
+    n_timesteps_ = use_nt;
+    temperature_ = use_temp;
+    spk_bc_      = spk_bc;
+
+    if (backend_kind_ == Backend::ANE) {
+        // ANE 路径：encoder-only graph 走 GGUF；DiT × n_timesteps 走 ANE。
+        // 不调用 init_from_host_caches（那会建 GGUF inference graph 占内存却用不上），
+        // 直接把 cache_host 的 conformer 部分塞给 cache_in_ 给后续 encoder-only 用。
+        cache_in_.clear();
+        cache_in_.conformer_cnn_cache = cache_host.conformer_cnn_cache;
+        cache_in_.conformer_cnn_ne    = cache_host.conformer_cnn_ne;
+        cache_in_.conformer_att_cache = cache_host.conformer_att_cache;
+        cache_in_.conformer_att_ne    = cache_host.conformer_att_ne;
+        cache_in_.n_timesteps         = use_nt;
+        // [DEBUG] 打印 estimator cache 的 ne，便于实现 5D→4D fold
+        std::fprintf(stderr,
+                     "[t2w-ane-debug] cache_host.n_timesteps=%d depth=%d (assumed) batch=2 (assumed)\n",
+                     cache_host.n_timesteps, kAneDepth);
+        std::fprintf(stderr, "[t2w-ane-debug] estimator_cnn_ne (size=%zu): ",
+                     cache_host.estimator_cnn_ne.size());
+        for (auto v : cache_host.estimator_cnn_ne) std::fprintf(stderr, "%lld ", (long long) v);
+        std::fprintf(stderr, " bytes=%zu\n", cache_host.estimator_cnn_cache.size());
+        std::fprintf(stderr, "[t2w-ane-debug] estimator_att_ne (size=%zu): ",
+                     cache_host.estimator_att_ne.size());
+        for (auto v : cache_host.estimator_att_ne) std::fprintf(stderr, "%lld ", (long long) v);
+        std::fprintf(stderr, " bytes=%zu\n", cache_host.estimator_att_cache.size());
+        std::fprintf(stderr, "[t2w-ane-debug] conformer_cnn_ne: ");
+        for (auto v : cache_host.conformer_cnn_ne) std::fprintf(stderr, "%lld ", (long long) v);
+        std::fprintf(stderr, " bytes=%zu\n", cache_host.conformer_cnn_cache.size());
+        std::fprintf(stderr, "[t2w-ane-debug] conformer_att_ne: ");
+        for (auto v : cache_host.conformer_att_ne) std::fprintf(stderr, "%lld ", (long long) v);
+        std::fprintf(stderr, " bytes=%zu\n", cache_host.conformer_att_cache.size());
+        if (!start_stream_ane_(cache_host)) {
+            LOG_ERROR("Token2Mel.start_stream_with_prompt_cache_gguf: start_stream_ane_ failed\n");
+            return false;
+        }
+        stream_started_ = true;
+        return true;
+    }
+
     if (!runner_.init_from_host_caches(cache_host, spk_bc.data(), B, use_nt, use_temp)) {
         LOG_ERROR( "Token2Mel.start_stream_with_prompt_cache_gguf: runner.init_from_host_caches failed\n");
         return false;
     }
 
-    n_timesteps_ = use_nt;
-    temperature_ = use_temp;
-    spk_bc_      = std::move(spk_bc);
     cache_in_.clear();
     stream_started_ = true;
     return true;
@@ -8621,6 +9048,348 @@ bool Token2Mel::infer_one_chunk(const std::vector<int32_t> & chunk_bt, bool last
 
     cache_in_ = cache_out;
     return true;
+}
+
+// ===========================================================================
+// ANE 路径：encoder 走 GGUF Metal，DiT 走 ANE mlpackage
+// ===========================================================================
+
+bool Token2Mel::start_stream_ane_(const flowStreamCacheHost & host_cache) {
+    // 复用 GGUF prompt setup_cache 输出的 5D estimator cache 做 voice cloning 起点。
+    // GGUF 实测 ne layout（ggml ne 顺序：ne0=fastest, ne3=slowest）:
+    //   cnn: (1024, 2,           depth*n_step=80, B=2)
+    //        row-major mem: cnn5d[b][d*n_step+s][c2][c1]，元素总数=B*depth*n_step*2*1024
+    //   att: (128, T_real=302,   num_heads*depth*n_step=640, B=2)
+    //        row-major mem: att5d[b][h*depth*n_step+...][T][hd2]
+    //
+    // 实际 5D 内存语义（验证：B=2 在 ne3 最慢；depth*n_step 是把 (depth, n_step) 摊成 1D，
+    // 顺序需要进一步细究——这里假定 ne2 内层是按 [d=0..D-1, s=0..n-1] 排，即慢轴 d 快轴 s）：
+    //   cnn5d[b, d, s, c, t]  →  mem[((b*D + d)*n_step + s) * 2*1024 + c*2 + t]   注意 c 慢 t 快
+    //                          但 ne0=1024=c, ne1=2=t，所以 c 是 ne1 慢，t 是 ne0 快，看代码:
+    //   实际 ggml row-major: mem[ne3*ne2*ne1*ne0 idx] = idx0*1 + idx1*ne0 + idx2*ne0*ne1 + idx3*ne0*ne1*ne2
+    //   所以 cnn 索引 (idx3=b, idx2=ds, idx1=t, idx0=c) → mem[b][ds][t][c]
+    //
+    // 目标 ANE 4D（每 timestep 一份）：
+    //   cnn4d[d*B + b, c1+c2=1024, t=2]  row-major  → cnn[idxB*1024*2 + c*2 + t]
+    //   att4d[d*B + b, num_heads=8, T_pad=600, hd2=128] row-major
+    //        其中 prompt setup 输出 T_real=302，pad 到 max_cache_len=600（前 valid，后 0）
+    if (!ane_handle_) {
+        return false;
+    }
+    const size_t one_cnn_elems = (size_t) kAneDepth * kAneB * 1024 * 2;
+    const size_t one_att_elems = (size_t) kAneDepth * kAneB * kAneNumHeads
+                                  * kAneMaxCacheLen * (2 * kAneHeadDim);
+    ane_cnn_caches_.assign((size_t) n_timesteps_, std::vector<float>(one_cnn_elems, 0.0f));
+    ane_att_caches_.assign((size_t) n_timesteps_, std::vector<float>(one_att_elems, 0.0f));
+    ane_valid_cache_len_ = 0;
+    ane_spk_proj_b2_80_.clear();
+
+    // 把 GGUF setup_cache 输出的 packed estimator cache fold 成 ANE 期望的
+    // per-timestep 4D layout，让 ANE 起步就有 prompt 的 voice-cloning state。
+    //
+    // GGUF packed layout（依据 fm_cfm_view_*_packed 实现 + 实测 ne 反推）:
+    //   slot = step * depth + block_idx        (n_step 在外慢，depth 在内快)
+    //   cnn ne = (C=1024, pad=2,    total_slots=n_step*depth, B=2)
+    //            row-major mem:   mem[b][slot][t][c]     ← c 最快
+    //   att ne = (D2=128, T_real,   num_heads*total_slots, B=2)
+    //            row-major mem:   mem[b][slot*nh+h][t][c] ← c 最快
+    //
+    // ANE per-step 期望（与 ane_export_dit.py + verify_dit_ane.py 一致）:
+    //   cnn (depth*B=32, 1024, 2)         row-major mem[d*B+b][c][t] ← t 最快
+    //   att (depth*B=32, 8, T_pad=600, 128) row-major mem[d*B+b][h][t][c] ← c 最快
+    //
+    // 重要：cnn 最后两维 (c,t) 在 GGUF 是 c 最快、ANE 是 t 最快 → 需要 transpose
+    //       att 最后两维 (t,c) 两边都是 c 最快 → 直接 memcpy 一行 D2 即可
+    if (host_cache.n_timesteps != n_timesteps_ ||
+        host_cache.estimator_cnn_ne.size() != 4 ||
+        host_cache.estimator_att_ne.size() != 4) {
+        std::fprintf(stderr, "[t2w-ane] cache fold skipped (n_step or ne mismatch); cold-start\n");
+        return true;
+    }
+
+    const int64_t depth_i      = (int64_t) kAneDepth;
+    const int64_t B_i          = (int64_t) kAneB;
+    const int64_t H_i          = (int64_t) kAneNumHeads;
+    const int64_t D2_i         = (int64_t) 2 * kAneHeadDim;
+    const int64_t total_slots  = (int64_t) n_timesteps_ * depth_i;
+
+    // -- cnn validate --
+    const int64_t cnn_C   = host_cache.estimator_cnn_ne[0];
+    const int64_t cnn_pad = host_cache.estimator_cnn_ne[1];
+    if (cnn_C != 1024 || cnn_pad != 2 ||
+        host_cache.estimator_cnn_ne[2] != total_slots ||
+        host_cache.estimator_cnn_ne[3] != B_i) {
+        std::fprintf(stderr,
+                     "[t2w-ane] cnn cache ne unexpected ([%lld,%lld,%lld,%lld]); cold-start\n",
+                     (long long) host_cache.estimator_cnn_ne[0],
+                     (long long) host_cache.estimator_cnn_ne[1],
+                     (long long) host_cache.estimator_cnn_ne[2],
+                     (long long) host_cache.estimator_cnn_ne[3]);
+        return true;
+    }
+    const size_t cnn_bytes_expect =
+        (size_t) cnn_C * cnn_pad * total_slots * B_i * sizeof(float);
+    if (host_cache.estimator_cnn_cache.size() != cnn_bytes_expect) {
+        std::fprintf(stderr,
+                     "[t2w-ane] cnn cache size mismatch (got %zu expect %zu); cold-start\n",
+                     host_cache.estimator_cnn_cache.size(), cnn_bytes_expect);
+        return true;
+    }
+
+    // -- att validate --
+    const int64_t att_D2 = host_cache.estimator_att_ne[0];
+    const int64_t T_real = host_cache.estimator_att_ne[1];
+    if (att_D2 != D2_i ||
+        host_cache.estimator_att_ne[2] != H_i * total_slots ||
+        host_cache.estimator_att_ne[3] != B_i) {
+        std::fprintf(stderr,
+                     "[t2w-ane] att cache ne unexpected ([%lld,%lld,%lld,%lld]); cold-start\n",
+                     (long long) host_cache.estimator_att_ne[0],
+                     (long long) host_cache.estimator_att_ne[1],
+                     (long long) host_cache.estimator_att_ne[2],
+                     (long long) host_cache.estimator_att_ne[3]);
+        return true;
+    }
+    const size_t att_bytes_expect =
+        (size_t) att_D2 * T_real * H_i * total_slots * B_i * sizeof(float);
+    if (host_cache.estimator_att_cache.size() != att_bytes_expect) {
+        std::fprintf(stderr,
+                     "[t2w-ane] att cache size mismatch (got %zu expect %zu); cold-start\n",
+                     host_cache.estimator_att_cache.size(), att_bytes_expect);
+        return true;
+    }
+
+    const int64_t T_pad = (int64_t) kAneMaxCacheLen;
+    const float * cnn_src = reinterpret_cast<const float *>(host_cache.estimator_cnn_cache.data());
+    const float * att_src = reinterpret_cast<const float *>(host_cache.estimator_att_cache.data());
+
+    // ---- CNN fold（含 (c,t) transpose）----
+    // src per (b, slot): C * pad floats，contiguous，row-major mem[t][c] (c 最快)
+    // dst per (s, d, b): C * pad floats，row-major mem[c][t] (t 最快)
+    const size_t cnn_per_slot   = (size_t) cnn_C * (size_t) cnn_pad;       // C*T = 2048
+    const size_t cnn_per_step_dB = (size_t) (depth_i * B_i) * cnn_per_slot;
+    for (int s = 0; s < n_timesteps_; ++s) {
+        for (int d = 0; d < kAneDepth; ++d) {
+            for (int b = 0; b < kAneB; ++b) {
+                const int64_t slot     = (int64_t) s * depth_i + d;
+                // src 偏移：b*(C*pad*total_slots) + slot*(C*pad)
+                const float * src      = cnn_src
+                                       + (size_t) b * cnn_per_slot * (size_t) total_slots
+                                       + (size_t) slot * cnn_per_slot;
+                // dst 偏移：(d*B + b)*(C*pad)
+                float * dst            = ane_cnn_caches_[(size_t) s].data()
+                                       + (size_t) (d * kAneB + b) * cnn_per_slot;
+                // 转置：src[t*C + c] → dst[c*T + t]
+                for (int64_t c = 0; c < cnn_C; ++c) {
+                    for (int64_t t = 0; t < cnn_pad; ++t) {
+                        dst[c * cnn_pad + t] = src[t * cnn_C + c];
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- ATT fold（不需要 transpose，按 head 拷贝一段 T_real*D2 bytes）----
+    // src per (b, slot, h): T_real * D2 floats，contiguous, row-major mem[t][c]
+    // dst per (s, d, b, h): T_pad * D2 floats，前 T_real*D2 是真值，后段 0
+    const size_t att_per_slot_h    = (size_t) T_real * (size_t) D2_i;          // T_real * D2 = 38656
+    const size_t att_per_slot      = (size_t) H_i * att_per_slot_h;            // H * T_real * D2
+    const size_t att_per_b         = (size_t) total_slots * att_per_slot;      // total_slots * H * T_real * D2
+    const size_t att_dst_per_h     = (size_t) T_pad * (size_t) D2_i;
+    const size_t att_dst_per_dB    = (size_t) H_i * att_dst_per_h;
+    for (int s = 0; s < n_timesteps_; ++s) {
+        for (int d = 0; d < kAneDepth; ++d) {
+            for (int b = 0; b < kAneB; ++b) {
+                const int64_t slot   = (int64_t) s * depth_i + d;
+                const float * src_b_slot = att_src + (size_t) b * att_per_b + (size_t) slot * att_per_slot;
+                float * dst_dB           = ane_att_caches_[(size_t) s].data()
+                                         + (size_t) (d * kAneB + b) * att_dst_per_dB;
+                for (int h = 0; h < kAneNumHeads; ++h) {
+                    const float * src_h = src_b_slot + (size_t) h * att_per_slot_h;
+                    float *       dst_h = dst_dB + (size_t) h * att_dst_per_h;
+                    std::memcpy(dst_h, src_h, att_per_slot_h * sizeof(float));
+                    // 后 (T_pad - T_real) * D2 个 float 已经在 assign 时初始化成 0
+                }
+            }
+        }
+    }
+
+    ane_valid_cache_len_ = (int) std::min<int64_t>(T_real, kAneMaxCacheLen);
+    std::fprintf(stderr,
+                 "[t2w-ane] folded prompt estimator cache: T_real=%lld T_pad=%lld valid=%d\n",
+                 (long long) T_real, (long long) T_pad, ane_valid_cache_len_);
+    return true;
+}
+
+bool Token2Mel::infer_one_chunk_ane_(const std::vector<int32_t> & chunk_bt, bool last_chunk,
+                                     std::vector<float> & mel_bct) {
+    mel_bct.clear();
+#if !(defined(ENABLE_COREML) && defined(__APPLE__))
+    (void) chunk_bt; (void) last_chunk;
+    LOG_ERROR("Token2Mel.infer_one_chunk_ane_: built without ENABLE_COREML\n");
+    return false;
+#else
+    if (!ensure_ready_for_infer() || !ane_handle_) {
+        return false;
+    }
+    if ((int64_t) chunk_bt.size() != (int64_t) kDt) {
+        LOG_ERROR("Token2Mel.infer_one_chunk_ane_: expected dt=%d tokens, got %lld\n",
+                  (int) kDt, (long long) chunk_bt.size());
+        return false;
+    }
+
+    // ---- Step 1: GGUF encoder-only -> mu (1, 80, 56), spk_proj (1, 80) ----
+    // ANE mlpackage 的 chunk_size 写死 56 = kDt(28) * up_rate(2)。
+    // GGUF encoder 默认 last_chunk=False 时只输出 kChunkMain*2=50 mel（剥掉 lookahead），
+    // 形状跟 ANE 静态形状对不上。这里**对 encoder 永远走 last_chunk=true**，让它输出 56 mel
+    // 喂给 ANE。**但 DiT 输出的 56 mel 中末尾 6 个对应 lookahead，跟下一个 chunk 开头 6 个
+    // 重叠**——如果原样吐给 vocoder，**听起来就是"重音节/卡字"**（每帧多 0.12s 重复的音）。
+    //
+    // 处理方式（与 baseline GGUF inference_chunk 输出语义对齐）:
+    //   非 stream-end 帧：取前 kChunkMain*2 = 50 mel
+    //   真正 stream-end 帧：取全部 56 mel（最后一段含 lookahead 的 0.12s 也吐出来）
+    std::vector<float>  mu_bct;
+    std::vector<float>  spk_proj_b80;
+    flowStreamCacheHost cache_out;
+    {
+        omni::flow::profile::ScopeTimer _t("t2m.ane.encoder");
+        if (!runner_.inference_chunk_encoder_only(
+                chunk_bt.data(), 1, kDt, spk_bc_.data(), kSpkDim,
+                /*last_chunk=*/true, cache_in_, mu_bct, spk_proj_b80, cache_out)) {
+            LOG_ERROR("Token2Mel.infer_one_chunk_ane_: encoder_only failed\n");
+            return false;
+        }
+    }
+    cache_in_ = cache_out;
+
+    const size_t one_xmcf  = (size_t) kMelChannels * (size_t) kAneChunkSize;  // 80 * 56 = 4480
+    const size_t batch_xmcf = (size_t) kAneB * one_xmcf;                       // 8960
+
+    if (mu_bct.size() != one_xmcf) {
+        LOG_ERROR("Token2Mel.infer_one_chunk_ane_: mu shape mismatch (got %zu expect %zu)\n",
+                  mu_bct.size(), one_xmcf);
+        return false;
+    }
+    if (spk_proj_b80.size() != (size_t) kMelChannels) {
+        LOG_ERROR("Token2Mel.infer_one_chunk_ane_: spk_proj shape mismatch (got %zu expect %d)\n",
+                  spk_proj_b80.size(), (int) kMelChannels);
+        return false;
+    }
+
+    // ---- Step 2: 准备 batch=2 (CFG cond+uncond) 输入 ----
+    // mu_b2: [mu; 0]   spks_b2: [spk_proj; 0]   cond_b2: 全 0 (与 inference_chunk 内 ggml_scale(mu,0) 一致)
+    std::vector<float> mu_b2(batch_xmcf, 0.0f);
+    std::memcpy(mu_b2.data(), mu_bct.data(), one_xmcf * sizeof(float));
+    std::vector<float> spks_b2((size_t) kAneB * (size_t) kMelChannels, 0.0f);
+    std::memcpy(spks_b2.data(), spk_proj_b80.data(), (size_t) kMelChannels * sizeof(float));
+    const std::vector<float> cond_b2(batch_xmcf, 0.0f);
+
+    // ---- Step 3: attn_mask (B=2, T=56, T+max_cache=656)  fp32 additive ----
+    const int chunk_T = kAneChunkSize;
+    const int total_K = kAneChunkSize + kAneMaxCacheLen;
+    std::vector<float> mask_b2((size_t) kAneB * (size_t) chunk_T * (size_t) total_K, kAneAttnMaskBigNeg);
+    const int valid = std::min(ane_valid_cache_len_, (int) kAneMaxCacheLen);
+    for (int b = 0; b < kAneB; ++b) {
+        for (int t = 0; t < chunk_T; ++t) {
+            float * row = mask_b2.data() + ((size_t) b * (size_t) chunk_T + (size_t) t) * (size_t) total_K;
+            for (int k = 0; k < chunk_T + valid; ++k) {
+                row[k] = 0.0f;
+            }
+        }
+    }
+
+    // ---- Step 4: x_init = z (跨 chunk 顺序消费 noise) ----
+    // 与 baseline GGUF 路径 fmCausalConditionalCFM::deterministic_noise 对齐：
+    //   后者用 `static std::mt19937 gen(42)`，所有 chunk 共享一个 generator 顺序消费。
+    // 这里同样 process 范围 static，**不要在每个 chunk 重置 seed**，否则每帧 x_init
+    // 都是同一组随机数，TTS 输出会出现"重音节/卡字"（每帧像新句子起头）。
+    std::vector<float> x_b1(one_xmcf);
+    {
+        static std::mt19937             ane_noise_gen(42);
+        std::normal_distribution<float> dist(0.0f, 1.0f);
+        for (size_t i = 0; i < one_xmcf; ++i) {
+            x_b1[i] = temperature_ * dist(ane_noise_gen);
+        }
+    }
+
+    // ---- Step 5: cosine t_span ----
+    std::vector<float> t_span((size_t) n_timesteps_ + 1);
+    for (int i = 0; i <= n_timesteps_; ++i) {
+        const double u = (double) i / (double) n_timesteps_;
+        t_span[(size_t) i] = (float) (1.0 - std::cos(u * 0.5 * M_PI));
+    }
+
+    // ---- Step 6: Euler ODE × n_timesteps，每步调一次 ANE ----
+    std::vector<float> x_b2(batch_xmcf);
+    std::vector<float> t_b2((size_t) kAneB);
+    std::vector<float> feat_b2(batch_xmcf);
+    const size_t cnn_elems = (size_t) kAneDepth * (size_t) kAneB * 1024ull * 2ull;
+    const size_t att_elems = (size_t) kAneDepth * (size_t) kAneB * (size_t) kAneNumHeads
+                            * (size_t) kAneMaxCacheLen * (2ull * (size_t) kAneHeadDim);
+    std::vector<float> cnn_out(cnn_elems);
+    std::vector<float> att_out(att_elems);
+
+    float t_scalar = t_span[0];
+    float dt       = t_span[1] - t_span[0];
+
+    {
+        omni::flow::profile::ScopeTimer _t("t2m.ane.dit");
+        for (int step = 1; step <= n_timesteps_; ++step) {
+            std::memcpy(x_b2.data(),             x_b1.data(), one_xmcf * sizeof(float));
+            std::memcpy(x_b2.data() + one_xmcf,  x_b1.data(), one_xmcf * sizeof(float));
+            t_b2[0] = t_scalar;
+            t_b2[1] = t_scalar;
+
+            int rc = t2w_dit_predict(
+                (t2w_dit_handle_t) ane_handle_,
+                x_b2.data(), mu_b2.data(), t_b2.data(), spks_b2.data(), cond_b2.data(),
+                ane_cnn_caches_[(size_t) step - 1].data(),
+                ane_att_caches_[(size_t) step - 1].data(),
+                mask_b2.data(),
+                feat_b2.data(), cnn_out.data(), att_out.data());
+            if (rc != 0) {
+                LOG_ERROR("Token2Mel.infer_one_chunk_ane_: t2w_dit_predict failed rc=%d at step=%d\n",
+                          rc, step);
+                return false;
+            }
+
+            // CFG + Euler step：dphi = (1+cfg)*cond - cfg*uncond； x = x + dt*dphi
+            const float k1 = 1.0f + kAneCfgRate;
+            const float k2 = kAneCfgRate;
+            for (size_t i = 0; i < one_xmcf; ++i) {
+                const float dphi = k1 * feat_b2[i] - k2 * feat_b2[one_xmcf + i];
+                x_b1[i] = x_b1[i] + dt * dphi;
+            }
+
+            t_scalar += dt;
+            if (step < n_timesteps_) {
+                dt = t_span[(size_t) step + 1] - t_scalar;
+            }
+
+            std::swap(ane_cnn_caches_[(size_t) step - 1], cnn_out);
+            std::swap(ane_att_caches_[(size_t) step - 1], att_out);
+        }
+    }
+
+    // ---- Step 7: x_b1 (B=1, C=80, T=56) row-major mem[c][t] → mel_bct ----
+    // 非 last_chunk：strip 末尾 kPreLookahead*2 = 6 mel frames（lookahead 区会跟下一个 chunk
+    //                开头重复），只保留前 kChunkMain*2 = 50 frames，跟 baseline GGUF 输出语义一致。
+    // last_chunk：保留全部 kAneChunkSize = 56 frames。
+    constexpr int kMelMain      = kChunkMain * 2;        // 50
+    constexpr int kMelLookahead = kPreLookahead * 2;     // 6
+    static_assert(kMelMain + kMelLookahead == kAneChunkSize,
+                  "ANE chunk size must equal main+lookahead mel frames");
+    const int n_out_mel = last_chunk ? (int) kAneChunkSize : kMelMain;
+    mel_bct.resize((size_t) kMelChannels * (size_t) n_out_mel);
+    for (int c = 0; c < (int) kMelChannels; ++c) {
+        std::memcpy(mel_bct.data() + (size_t) c * (size_t) n_out_mel,
+                    x_b1.data()    + (size_t) c * (size_t) kAneChunkSize,
+                    (size_t) n_out_mel * sizeof(float));
+    }
+
+    ane_valid_cache_len_ = std::min(ane_valid_cache_len_ + (int) kAneChunkSize, (int) kAneMaxCacheLen);
+    return true;
+#endif
 }
 
 void Token2Mel::append_bct_along_time(const std::vector<float> & src_bct,
@@ -8683,7 +9452,10 @@ bool Token2Mel::push_tokens(const int32_t * tokens, int64_t n_tokens, bool is_fi
     }
 
     std::vector<float> mel_chunk_bct;
-    if (!infer_one_chunk(chunk_bt, is_final, mel_chunk_bct)) {
+    const bool ok = (backend_kind_ == Backend::ANE)
+                        ? infer_one_chunk_ane_(chunk_bt, is_final, mel_chunk_bct)
+                        : infer_one_chunk(chunk_bt, is_final, mel_chunk_bct);
+    if (!ok) {
         return false;
     }
 
@@ -8718,6 +9490,11 @@ void Token2Mel::reset_stream() {
     stream_started_ = false;
     spk_bc_.clear();
     cache_in_.clear();
+    // ANE 模式：重置 per-timestep cache（不释放 ane_handle_，可复用）
+    ane_cnn_caches_.clear();
+    ane_att_caches_.clear();
+    ane_spk_proj_b2_80_.clear();
+    ane_valid_cache_len_ = 0;
 }
 
 bool Token2MelSession::init_from_prompt_bundle(const std::string & encoder_gguf,
@@ -8900,11 +9677,13 @@ bool Token2Wav::load_models(const std::string & encoder_gguf,
                             const std::string & flow_extra_gguf,
                             const std::string & vocoder_gguf,
                             const std::string & device_token2mel,
-                            const std::string & device_vocoder) {
+                            const std::string & device_vocoder,
+                            const std::string & ane_mlpackage_path) {
     reset_stream();
 
     constexpr int kDefaultThreads = 8;
-    if (!t2m_.load_model(encoder_gguf, flow_matching_gguf, flow_extra_gguf, device_token2mel, kDefaultThreads)) {
+    if (!t2m_.load_model(encoder_gguf, flow_matching_gguf, flow_extra_gguf, device_token2mel, kDefaultThreads,
+                         ane_mlpackage_path)) {
         LOG_ERROR( "Token2Wav.load_models: Token2Mel.load_model failed\n");
         models_loaded_ = false;
         return false;

--- a/tools/omni/token2wav/token2wav-impl.cpp
+++ b/tools/omni/token2wav/token2wav-impl.cpp
@@ -8712,7 +8712,7 @@ bool Token2Mel::load_model(const std::string & encoder_gguf,
                            const std::string & flow_extra_gguf,
                            const std::string & device,
                            int                 threads,
-                           const std::string & ane_mlpackage_path) {
+                           const std::string & coreml_model_path) {
     // 用于加载三段GGUF并初始化runner(失败时回退到cpu)
     reset_stream();
     runner_.set_num_threads(threads);
@@ -8732,34 +8732,34 @@ bool Token2Mel::load_model(const std::string & encoder_gguf,
 
     runner_.set_export_caches_to_host(false);
 
-    // ANE 后端：加载 mlpackage handle
+    // CoreML 后端：加载 CoreML 模型
     backend_kind_       = Backend::GGUF;
     ane_handle_         = nullptr;
-    ane_mlpackage_path_.clear();
-    if (!ane_mlpackage_path.empty()) {
+    coreml_model_path_.clear();
+    if (!coreml_model_path.empty()) {
 #if defined(ENABLE_COREML) && defined(__APPLE__)
         std::fprintf(stderr,
-                     "[Token2Mel] ANE backend requested, loading mlpackage: %s\n",
-                     ane_mlpackage_path.c_str());
-        ane_handle_ = (void *) t2w_dit_load(ane_mlpackage_path.c_str());
+                     "[Token2Mel] CoreML backend requested, loading model: %s\n",
+                     coreml_model_path.c_str());
+        ane_handle_ = (void *) t2w_dit_load(coreml_model_path.c_str());
         if (!ane_handle_) {
             LOG_ERROR("Token2Mel.load_model: t2w_dit_load failed for %s; "
                       "falling back to GGUF DiT\n",
-                      ane_mlpackage_path.c_str());
+                      coreml_model_path.c_str());
         } else {
-            ane_mlpackage_path_ = ane_mlpackage_path;
+            coreml_model_path_ = coreml_model_path;
             backend_kind_       = Backend::ANE;
-            std::fprintf(stderr, "[Token2Mel] ANE backend ready (DiT on ANE, encoder on %s)\n",
+            std::fprintf(stderr, "[Token2Mel] CoreML backend ready (DiT on CoreML, encoder on %s)\n",
                          device.c_str());
             // 启用 cache 导出：encoder-only 路径需要 host conformer cache 流转
             runner_.set_export_caches_to_host(true);
             // 设置 export_caches_to_host=true 后，inference_chunk 会比平时多
-            // download conformer + estimator cache，但 ANE 模式下我们不会调
+            // download conformer + estimator cache，但 CoreML 模式下我们不会调
             // inference_chunk（只调 inference_chunk_encoder_only），所以只影响
             // setup_cache 阶段的一次性导出。
         }
 #else
-        LOG_ERROR("Token2Mel.load_model: ANE mlpackage requested but ENABLE_COREML not set; "
+        LOG_ERROR("Token2Mel.load_model: CoreML model requested but ENABLE_COREML not set; "
                   "falling back to GGUF DiT\n");
 #endif
     }
@@ -8974,24 +8974,6 @@ bool Token2Mel::start_stream_with_prompt_cache_gguf(const std::string & prompt_c
         cache_in_.conformer_att_cache = cache_host.conformer_att_cache;
         cache_in_.conformer_att_ne    = cache_host.conformer_att_ne;
         cache_in_.n_timesteps         = use_nt;
-        // [DEBUG] 打印 estimator cache 的 ne，便于实现 5D→4D fold
-        std::fprintf(stderr,
-                     "[t2w-ane-debug] cache_host.n_timesteps=%d depth=%d (assumed) batch=2 (assumed)\n",
-                     cache_host.n_timesteps, kAneDepth);
-        std::fprintf(stderr, "[t2w-ane-debug] estimator_cnn_ne (size=%zu): ",
-                     cache_host.estimator_cnn_ne.size());
-        for (auto v : cache_host.estimator_cnn_ne) std::fprintf(stderr, "%lld ", (long long) v);
-        std::fprintf(stderr, " bytes=%zu\n", cache_host.estimator_cnn_cache.size());
-        std::fprintf(stderr, "[t2w-ane-debug] estimator_att_ne (size=%zu): ",
-                     cache_host.estimator_att_ne.size());
-        for (auto v : cache_host.estimator_att_ne) std::fprintf(stderr, "%lld ", (long long) v);
-        std::fprintf(stderr, " bytes=%zu\n", cache_host.estimator_att_cache.size());
-        std::fprintf(stderr, "[t2w-ane-debug] conformer_cnn_ne: ");
-        for (auto v : cache_host.conformer_cnn_ne) std::fprintf(stderr, "%lld ", (long long) v);
-        std::fprintf(stderr, " bytes=%zu\n", cache_host.conformer_cnn_cache.size());
-        std::fprintf(stderr, "[t2w-ane-debug] conformer_att_ne: ");
-        for (auto v : cache_host.conformer_att_ne) std::fprintf(stderr, "%lld ", (long long) v);
-        std::fprintf(stderr, " bytes=%zu\n", cache_host.conformer_att_cache.size());
         if (!start_stream_ane_(cache_host)) {
             LOG_ERROR("Token2Mel.start_stream_with_prompt_cache_gguf: start_stream_ane_ failed\n");
             return false;
@@ -9051,7 +9033,7 @@ bool Token2Mel::infer_one_chunk(const std::vector<int32_t> & chunk_bt, bool last
 }
 
 // ===========================================================================
-// ANE 路径：encoder 走 GGUF Metal，DiT 走 ANE mlpackage
+// CoreML 路径：encoder 走 GGUF Metal，DiT 走 CoreML
 // ===========================================================================
 
 bool Token2Mel::start_stream_ane_(const flowStreamCacheHost & host_cache) {
@@ -9239,7 +9221,7 @@ bool Token2Mel::infer_one_chunk_ane_(const std::vector<int32_t> & chunk_bt, bool
     }
 
     // ---- Step 1: GGUF encoder-only -> mu (1, 80, 56), spk_proj (1, 80) ----
-    // ANE mlpackage 的 chunk_size 写死 56 = kDt(28) * up_rate(2)。
+    // CoreML 模型的 chunk_size 写死 56 = kDt(28) * up_rate(2)。
     // GGUF encoder 默认 last_chunk=False 时只输出 kChunkMain*2=50 mel（剥掉 lookahead），
     // 形状跟 ANE 静态形状对不上。这里**对 encoder 永远走 last_chunk=true**，让它输出 56 mel
     // 喂给 ANE。**但 DiT 输出的 56 mel 中末尾 6 个对应 lookahead，跟下一个 chunk 开头 6 个
@@ -9678,12 +9660,12 @@ bool Token2Wav::load_models(const std::string & encoder_gguf,
                             const std::string & vocoder_gguf,
                             const std::string & device_token2mel,
                             const std::string & device_vocoder,
-                            const std::string & ane_mlpackage_path) {
+                            const std::string & coreml_model_path) {
     reset_stream();
 
     constexpr int kDefaultThreads = 8;
     if (!t2m_.load_model(encoder_gguf, flow_matching_gguf, flow_extra_gguf, device_token2mel, kDefaultThreads,
-                         ane_mlpackage_path)) {
+                         coreml_model_path)) {
         LOG_ERROR( "Token2Wav.load_models: Token2Mel.load_model failed\n");
         models_loaded_ = false;
         return false;

--- a/tools/omni/token2wav/token2wav-impl.h
+++ b/tools/omni/token2wav/token2wav-impl.h
@@ -61,7 +61,7 @@ struct flowInferenceChunkOut {
     ggml_tensor * conformer_att_cache = nullptr;
     flow_matching::fmCFMCache * estimator_cache = nullptr;
 };
-// ANE 路径：encoder + projector 输出到 mu，跳过 decoder（DiT 走 ANE mlpackage）。
+// CoreML 路径：encoder + projector 输出到 mu，跳过 decoder（DiT 走 CoreML）。
 struct flowEncoderOnlyOut {
     ggml_tensor * mu_ctb              = nullptr;  // (C=80, T_mel, B)，row-major contiguous
     ggml_tensor * spk_proj_cb         = nullptr;  // (C=80, B)，已 normalize+affine
@@ -2049,14 +2049,14 @@ class Token2Mel {
     Token2Mel(const Token2Mel &)             = delete;
     Token2Mel & operator=(const Token2Mel &) = delete;
 
-    // ane_mlpackage_path 非空时启用 ANE 后端：encoder/projector 仍走 GGUF/Metal，
-    // 但 DiT estimator 走 ANE mlpackage（绕过 GPU command queue contention）。
+    // coreml_model_path 非空时启用 CoreML 后端：encoder/projector 仍走 GGUF/Metal，
+    // 但 DiT estimator 走 CoreML（绕过 GPU command queue contention）。
     bool load_model(const std::string & encoder_gguf,
                     const std::string & flow_matching_gguf,
                     const std::string & flow_extra_gguf,
                     const std::string & device              = "gpu",
                     int                 threads             = 8,
-                    const std::string & ane_mlpackage_path  = "");
+                    const std::string & coreml_model_path  = "");
 
     static bool load_prompt_bundle_dir(const std::string & dir, PromptBundle & out);
 
@@ -2103,7 +2103,7 @@ class Token2Mel {
     bool ensure_ready_for_infer() const;
     bool infer_one_chunk(const std::vector<int32_t> & chunk_bt, bool last_chunk, std::vector<float> & mel_bct);
 
-    // ANE 路径：encoder via GGUF runner 输出 mu，DiT × n_timesteps 走 ANE mlpackage。
+    // CoreML 路径：encoder via GGUF runner 输出 mu，DiT × n_timesteps 走 CoreML。
     bool start_stream_ane_(const flowStreamCacheHost & host_cache);
     bool infer_one_chunk_ane_(const std::vector<int32_t> & chunk_bt, bool last_chunk,
                               std::vector<float> & mel_bct);
@@ -2122,7 +2122,7 @@ class Token2Mel {
 
     // ANE 模式专用 state（仅当 backend_kind_ == ANE 时有效）
     void *                          ane_handle_ = nullptr;  // t2w_dit_handle_t (opaque)
-    std::string                     ane_mlpackage_path_;
+    std::string                     coreml_model_path_;
     std::vector<std::vector<float>> ane_cnn_caches_;        // n_timesteps × (depth*B*1024*2)
     std::vector<std::vector<float>> ane_att_caches_;        // n_timesteps × (depth*B*nh*max_cache_len*head_dim*2)
     std::vector<float>              ane_spk_proj_b2_80_;    // (B=2, 80)，[spk; zeros] for CFG
@@ -2206,7 +2206,7 @@ class Token2Wav {
                      const std::string & vocoder_gguf,
                      const std::string & device_token2mel    = "gpu",
                      const std::string & device_vocoder      = "gpu",
-                     const std::string & ane_mlpackage_path  = "");
+                     const std::string & coreml_model_path  = "");
 
     bool start_stream_with_prompt_cache_gguf(const std::string & prompt_cache_gguf_path,
                                              int                 n_timesteps = -1,
@@ -2264,7 +2264,7 @@ struct Token2WavSession {
                                      const std::string & device_vocoder      = "gpu",
                                      int                 n_timesteps         = 10,
                                      float               temperature         = 1.0f,
-                                     const std::string & ane_mlpackage_path  = "");
+                                     const std::string & coreml_model_path  = "");
 
     bool init_from_prompt_bundle(const std::string & encoder_gguf,
                                  const std::string & flow_matching_gguf,
@@ -2275,7 +2275,7 @@ struct Token2WavSession {
                                  const std::string & device_vocoder      = "gpu",
                                  int                 n_timesteps         = 10,
                                  float               temperature         = 1.0f,
-                                 const std::string & ane_mlpackage_path  = "");
+                                 const std::string & coreml_model_path  = "");
 
     bool feed_tokens(const int32_t * tokens, int64_t n_tokens, bool is_final, std::vector<float> & wave_bt_out);
 

--- a/tools/omni/token2wav/token2wav-impl.h
+++ b/tools/omni/token2wav/token2wav-impl.h
@@ -61,6 +61,13 @@ struct flowInferenceChunkOut {
     ggml_tensor * conformer_att_cache = nullptr;
     flow_matching::fmCFMCache * estimator_cache = nullptr;
 };
+// ANE 路径：encoder + projector 输出到 mu，跳过 decoder（DiT 走 ANE mlpackage）。
+struct flowEncoderOnlyOut {
+    ggml_tensor * mu_ctb              = nullptr;  // (C=80, T_mel, B)，row-major contiguous
+    ggml_tensor * spk_proj_cb         = nullptr;  // (C=80, B)，已 normalize+affine
+    ggml_tensor * conformer_cnn_cache = nullptr;
+    ggml_tensor * conformer_att_cache = nullptr;
+};
 class flowCausalMaskedDiffWithXvec {
   public:
     flowCausalMaskedDiffWithXvec(int32_t                                                            input_size,
@@ -95,6 +102,15 @@ class flowCausalMaskedDiffWithXvec {
                                                       int                               n_timesteps,
                                                       float                             temperature,
                                                       flow_matching::fmCFMCache *       estimator_cache_out) const;
+    // ANE 路径用：只 build encoder + projector + spk affine，输出 mu / spk_proj / 新 conformer cache。
+    // 与 build_inference_chunk_graph 前半段语义完全一致，仅去掉 decoder/CFG/ODE 部分。
+    flowEncoderOnlyOut build_inference_chunk_encoder_only_graph(
+        ggml_context * ctx,
+        ggml_tensor *  token_ids_tb_i32,
+        ggml_tensor *  spk_cb_f32,
+        bool           last_chunk,
+        ggml_tensor *  conformer_cnn_cache_in,
+        ggml_tensor *  conformer_att_cache_in) const;
   private:
     int32_t input_size_    = 0;
     int32_t output_size_   = 0;
@@ -1673,12 +1689,48 @@ class flowGGUFModelRunner {
                                int64_t                     B,
                                int                         n_timesteps,
                                float                       temperature);
+
+    // ============== ANE 路径专用：encoder-only inference ==============
+    // 与 inference_chunk 共享 conformer cache（cache_in/out 中只用 conformer 部分），
+    // 但只跑 encoder + projector + spk affine 子图，输出 mu (B,80,T_mel) 和
+    // spk_proj (B,80)。estimator cache 不在此 backend 上维护——由调用方（Token2MelANE）
+    // 在 ANE C ABI 这边维护 4D fold 后的 cache。
+    //
+    // 注意：本函数维护**独立**的 encoder-only streamSession（sess_enc_only_），
+    // 不影响 setup_cache / inference_chunk 用的 sess_。
+    bool inference_chunk_encoder_only(const int32_t *             token_bt,
+                                      int64_t                     B,
+                                      int64_t                     T_token,
+                                      const float *               spk_bc,
+                                      int64_t                     C_spk,
+                                      bool                        last_chunk,
+                                      const flowStreamCacheHost & cache_in_conformer,
+                                      std::vector<float> &        mu_bct_out,
+                                      std::vector<float> &        spk_proj_b80_out,
+                                      flowStreamCacheHost &       cache_out_conformer);
+
+    // 用 setup_cache 的 estimator cache (5D row-major bytes) 把 fold 成 ANE 期望的
+    // 4D 格式（depth*B, ...），按 timestep 拆成 n_timesteps 份。
+    // 输出 layout：
+    //   cnn_per_step_4d: 每份 (depth*B, 1024, 2)，row-major fp32
+    //   att_per_step_4d: 每份 (depth*B, num_heads, T_real, head_dim*2)，row-major fp32
+    //                    （T_real = setup 时输入 prompt mel 的长度，可能 < max_cache_len）
+    // 调用方负责把 att 后续 pad 到 max_cache_len。
+    static bool fold_estimator_cache_5d_to_4d(const flowStreamCacheHost & host,
+                                              int64_t                      depth,
+                                              int64_t                      B_internal_2,
+                                              std::vector<std::vector<float>> & cnn_per_step_4d,
+                                              std::vector<std::vector<float>> & att_per_step_4d,
+                                              int64_t &                          out_T_real_att);
+
   private:
     struct streamSession;
+    struct streamSessionEncOnly;
     int  num_threads_           = 1;
     bool export_caches_to_host_ = true;
     flowGGUFModelLoader            loader_;
-    std::unique_ptr<streamSession> sess_;
+    std::unique_ptr<streamSession>        sess_;
+    std::unique_ptr<streamSessionEncOnly> sess_enc_only_;
 };
 }  // namespace flow
 }  // namespace omni
@@ -1991,17 +2043,20 @@ class Token2Mel {
         int64_t T_prompt_mel   = 0;
     };
 
-    Token2Mel()  = default;
-    ~Token2Mel() = default;
+    Token2Mel() = default;
+    ~Token2Mel();
 
     Token2Mel(const Token2Mel &)             = delete;
     Token2Mel & operator=(const Token2Mel &) = delete;
 
+    // ane_mlpackage_path 非空时启用 ANE 后端：encoder/projector 仍走 GGUF/Metal，
+    // 但 DiT estimator 走 ANE mlpackage（绕过 GPU command queue contention）。
     bool load_model(const std::string & encoder_gguf,
                     const std::string & flow_matching_gguf,
                     const std::string & flow_extra_gguf,
-                    const std::string & device  = "gpu",
-                    int                 threads = 8);
+                    const std::string & device              = "gpu",
+                    int                 threads             = 8,
+                    const std::string & ane_mlpackage_path  = "");
 
     static bool load_prompt_bundle_dir(const std::string & dir, PromptBundle & out);
 
@@ -2019,12 +2074,23 @@ class Token2Mel {
 
     void reset_stream();
 
+    bool is_ane_mode() const { return backend_kind_ == Backend::ANE; }
+
     static constexpr int32_t kMelChannels  = 80;
     static constexpr int32_t kSpkDim       = 192;
     static constexpr int32_t kPadToken     = 4218;
     static constexpr int32_t kPreLookahead = 3;
     static constexpr int32_t kChunkMain    = 25;
     static constexpr int32_t kDt           = kChunkMain + kPreLookahead;
+    // ANE 后端专用常量（与 ane_export_dit.py 写死的 mlpackage 形状一致）
+    static constexpr int32_t kAneChunkSize    = 56;   // mel frames per call (kDt × 2)
+    static constexpr int32_t kAneMaxCacheLen  = 600;
+    static constexpr int32_t kAneDepth        = 16;
+    static constexpr int32_t kAneNumHeads     = 8;
+    static constexpr int32_t kAneHeadDim      = 64;
+    static constexpr int32_t kAneB            = 2;    // CFG cond+uncond batched
+    static constexpr float   kAneCfgRate      = 0.7f;
+    static constexpr float   kAneAttnMaskBigNeg = -1e4f;
 
     static void append_bct_along_time(const std::vector<float> & src_bct,
                                       int64_t                    B,
@@ -2032,9 +2098,17 @@ class Token2Mel {
                                       std::vector<float> &       dst_bct_inout);
 
   private:
+    enum class Backend { GGUF, ANE };
+
     bool ensure_ready_for_infer() const;
     bool infer_one_chunk(const std::vector<int32_t> & chunk_bt, bool last_chunk, std::vector<float> & mel_bct);
 
+    // ANE 路径：encoder via GGUF runner 输出 mu，DiT × n_timesteps 走 ANE mlpackage。
+    bool start_stream_ane_(const flowStreamCacheHost & host_cache);
+    bool infer_one_chunk_ane_(const std::vector<int32_t> & chunk_bt, bool last_chunk,
+                              std::vector<float> & mel_bct);
+
+    Backend             backend_kind_   = Backend::GGUF;
     flowGGUFModelRunner runner_;
     bool                model_loaded_   = false;
     bool                stream_started_ = false;
@@ -2045,6 +2119,17 @@ class Token2Mel {
     std::vector<float> spk_bc_;
 
     flowStreamCacheHost cache_in_;
+
+    // ANE 模式专用 state（仅当 backend_kind_ == ANE 时有效）
+    void *                          ane_handle_ = nullptr;  // t2w_dit_handle_t (opaque)
+    std::string                     ane_mlpackage_path_;
+    std::vector<std::vector<float>> ane_cnn_caches_;        // n_timesteps × (depth*B*1024*2)
+    std::vector<std::vector<float>> ane_att_caches_;        // n_timesteps × (depth*B*nh*max_cache_len*head_dim*2)
+    std::vector<float>              ane_spk_proj_b2_80_;    // (B=2, 80)，[spk; zeros] for CFG
+    int                             ane_valid_cache_len_ = 0;
+    // Noise generator：跟 baseline GGUF 路径（fmCausalConditionalCFM::deterministic_noise 内
+    // 的 static std::mt19937 gen(42)）对齐——跨 chunk 顺序消费，**绝不能每个 chunk 重置 seed**，
+    // 否则每帧 x_init 都从同一组随机数开始，导致音色帧间不连续（听起来像"卡字"/重音节）。
 };
 
 struct Token2MelSession {
@@ -2119,8 +2204,9 @@ class Token2Wav {
                      const std::string & flow_matching_gguf,
                      const std::string & flow_extra_gguf,
                      const std::string & vocoder_gguf,
-                     const std::string & device_token2mel = "gpu",
-                     const std::string & device_vocoder   = "gpu");
+                     const std::string & device_token2mel    = "gpu",
+                     const std::string & device_vocoder      = "gpu",
+                     const std::string & ane_mlpackage_path  = "");
 
     bool start_stream_with_prompt_cache_gguf(const std::string & prompt_cache_gguf_path,
                                              int                 n_timesteps = -1,
@@ -2174,20 +2260,22 @@ struct Token2WavSession {
                                      const std::string & flow_extra_gguf,
                                      const std::string & prompt_cache_gguf_path,
                                      const std::string & vocoder_gguf,
-                                     const std::string & device_token2mel = "gpu",
-                                     const std::string & device_vocoder   = "gpu",
-                                     int                 n_timesteps      = 10,
-                                     float               temperature      = 1.0f);
+                                     const std::string & device_token2mel    = "gpu",
+                                     const std::string & device_vocoder      = "gpu",
+                                     int                 n_timesteps         = 10,
+                                     float               temperature         = 1.0f,
+                                     const std::string & ane_mlpackage_path  = "");
 
     bool init_from_prompt_bundle(const std::string & encoder_gguf,
                                  const std::string & flow_matching_gguf,
                                  const std::string & flow_extra_gguf,
                                  const std::string & prompt_bundle_dir,
                                  const std::string & vocoder_gguf,
-                                 const std::string & device_token2mel = "gpu",
-                                 const std::string & device_vocoder   = "gpu",
-                                 int                 n_timesteps      = 10,
-                                 float               temperature      = 1.0f);
+                                 const std::string & device_token2mel    = "gpu",
+                                 const std::string & device_vocoder      = "gpu",
+                                 int                 n_timesteps         = 10,
+                                 float               temperature         = 1.0f,
+                                 const std::string & ane_mlpackage_path  = "");
 
     bool feed_tokens(const int32_t * tokens, int64_t n_tokens, bool is_final, std::vector<float> & wave_bt_out);
 

--- a/tools/omni/token2wav/token2wav.cpp
+++ b/tools/omni/token2wav/token2wav.cpp
@@ -15,12 +15,13 @@ bool Token2WavSession::init_from_prompt_cache_gguf(const std::string & encoder_g
                                                    const std::string & device_token2mel,
                                                    const std::string & device_vocoder,
                                                    int                 n_timesteps,
-                                                   float               temperature) {
+                                                   float               temperature,
+                                                   const std::string & ane_mlpackage_path) {
     // 初始化方式第一种，仅需使用此方式即可，加载模型所有的gguf内容
     const auto t0 = std::chrono::steady_clock::now();
     reset();
     if (!t2w.load_models(encoder_gguf, flow_matching_gguf, flow_extra_gguf, vocoder_gguf, device_token2mel,
-                         device_vocoder)) {
+                         device_vocoder, ane_mlpackage_path)) {
         return false;
     }
     if (!t2w.start_stream_with_prompt_cache_gguf(prompt_cache_gguf_path, n_timesteps, temperature)) {
@@ -44,11 +45,12 @@ bool Token2WavSession::init_from_prompt_bundle(const std::string & encoder_gguf,
                                                const std::string & device_token2mel,
                                                const std::string & device_vocoder,
                                                int                 n_timesteps,
-                                               float               temperature) {
+                                               float               temperature,
+                                               const std::string & ane_mlpackage_path) {
     // 初始化方式第二种（如要更换示例音频使用此接口作为备用）
     reset();
     if (!t2w.load_models(encoder_gguf, flow_matching_gguf, flow_extra_gguf, vocoder_gguf, device_token2mel,
-                         device_vocoder)) {
+                         device_vocoder, ane_mlpackage_path)) {
         return false;
     }
     Token2Mel::PromptBundle pb;

--- a/tools/omni/token2wav/token2wav.cpp
+++ b/tools/omni/token2wav/token2wav.cpp
@@ -16,12 +16,12 @@ bool Token2WavSession::init_from_prompt_cache_gguf(const std::string & encoder_g
                                                    const std::string & device_vocoder,
                                                    int                 n_timesteps,
                                                    float               temperature,
-                                                   const std::string & ane_mlpackage_path) {
+                                                   const std::string & coreml_model_path) {
     // 初始化方式第一种，仅需使用此方式即可，加载模型所有的gguf内容
     const auto t0 = std::chrono::steady_clock::now();
     reset();
     if (!t2w.load_models(encoder_gguf, flow_matching_gguf, flow_extra_gguf, vocoder_gguf, device_token2mel,
-                         device_vocoder, ane_mlpackage_path)) {
+                         device_vocoder, coreml_model_path)) {
         return false;
     }
     if (!t2w.start_stream_with_prompt_cache_gguf(prompt_cache_gguf_path, n_timesteps, temperature)) {
@@ -46,11 +46,11 @@ bool Token2WavSession::init_from_prompt_bundle(const std::string & encoder_gguf,
                                                const std::string & device_vocoder,
                                                int                 n_timesteps,
                                                float               temperature,
-                                               const std::string & ane_mlpackage_path) {
+                                               const std::string & coreml_model_path) {
     // 初始化方式第二种（如要更换示例音频使用此接口作为备用）
     reset();
     if (!t2w.load_models(encoder_gguf, flow_matching_gguf, flow_extra_gguf, vocoder_gguf, device_token2mel,
-                         device_vocoder, ane_mlpackage_path)) {
+                         device_vocoder, coreml_model_path)) {
         return false;
     }
     Token2Mel::PromptBundle pb;


### PR DESCRIPTION
CoreML (Apple Neural Engine) backend for token2wav DiT estimator, decoupling from GPU Metal command queue to avoid contention with LLM inference during duplex speech.
- CoreML model auto-discovery via --t2w-coreml auto, GPU-only by default
- Fully CLI-driven, no environment variable required
- Unified coreml_minicpmo45_t2w_dit naming, aligning with vision side
- Unit + end-to-end tests with CoreML numerical accuracy validation