### PR TITLE
feat(server): support C++ (llama.cpp-omni) backend via the backend protocol

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3281,6 +3281,19 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             params.port = value;
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_PORT"));
+    // One flag to point at the MiniCPM-o GGUF root; derives the vision/audio/TTS
+    // sub-model paths so the backend-protocol server can be launched with just -m + this.
+    add_opt(common_arg(
+        {"--omni-model-dir"}, "DIR",
+        "MiniCPM-o GGUF root directory; fills vision/audio/TTS model paths for the backend protocol server",
+        [](common_params & params, const std::string & value) {
+            params.omni_model_dir = value;
+            params.vpm_model = value + "/vision/MiniCPM-o-4_5-vision-F16.gguf";
+            params.apm_model = value + "/audio/MiniCPM-o-4_5-audio-F16.gguf";
+            params.tts_model = value + "/tts/MiniCPM-o-4_5-tts-F16.gguf";
+            params.tts_bin_dir = value + "/tts";
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}));
     add_opt(common_arg(
         {"--path"}, "PATH",
         string_format("path to serve static files from (default: %s)", params.public_path.c_str()),

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3281,19 +3281,6 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             params.port = value;
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_PORT"));
-    // One flag to point at the MiniCPM-o GGUF root; derives the vision/audio/TTS
-    // sub-model paths so the backend-protocol server can be launched with just -m + this.
-    add_opt(common_arg(
-        {"--omni-model-dir"}, "DIR",
-        "MiniCPM-o GGUF root directory; fills vision/audio/TTS model paths for the backend protocol server",
-        [](common_params & params, const std::string & value) {
-            params.omni_model_dir = value;
-            params.vpm_model = value + "/vision/MiniCPM-o-4_5-vision-F16.gguf";
-            params.apm_model = value + "/audio/MiniCPM-o-4_5-audio-F16.gguf";
-            params.tts_model = value + "/tts/MiniCPM-o-4_5-tts-F16.gguf";
-            params.tts_bin_dir = value + "/tts";
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}));
     add_opt(common_arg(
         {"--path"}, "PATH",
         string_format("path to serve static files from (default: %s)", params.public_path.c_str()),

--- a/common/common.h
+++ b/common/common.h
@@ -411,6 +411,8 @@ struct common_params {
     std::string tts_model            = ""; // model path
     std::string apm_model            = ""; // model path
     std::string vpm_model            = ""; // model path
+    std::string omni_model_dir       = ""; // MiniCPM-o GGUF root directory
+    std::string tts_bin_dir          = ""; // directory containing TTS projector/token2wav assets
 
     // Apple Neural Engine (CoreML) support
     std::string vision_coreml_model_path = ""; // path to CoreML .mlmodelc for vision ANE

--- a/common/common.h
+++ b/common/common.h
@@ -411,7 +411,6 @@ struct common_params {
     std::string tts_model            = ""; // model path
     std::string apm_model            = ""; // model path
     std::string vpm_model            = ""; // model path
-    std::string omni_model_dir       = ""; // MiniCPM-o GGUF root directory
     std::string tts_bin_dir          = ""; // directory containing TTS projector/token2wav assets
 
     // Apple Neural Engine (CoreML) support

--- a/tools/omni/omni.cpp
+++ b/tools/omni/omni.cpp
@@ -134,6 +134,57 @@ static bool set_python_t2w_ref_audio(struct omni_context * ctx_omni, const std::
 static bool process_python_t2w_tokens(struct omni_context * ctx_omni, const std::vector<int32_t>& tokens, bool last_chunk, const std::string& output_path, double& inference_time_ms, double& audio_duration);
 static bool reset_python_t2w_cache(struct omni_context * ctx_omni);
 
+static bool read_wav_pcm16_data(const std::string & wav_path, std::vector<int16_t> & pcm) {
+    FILE * f = fopen(wav_path.c_str(), "rb");
+    if (!f) {
+        return false;
+    }
+
+    auto read_u32_le = [](FILE * fp, uint32_t & out) {
+        unsigned char b[4];
+        if (fread(b, 1, 4, fp) != 4) {
+            return false;
+        }
+        out = (uint32_t)b[0] | ((uint32_t)b[1] << 8) |
+              ((uint32_t)b[2] << 16) | ((uint32_t)b[3] << 24);
+        return true;
+    };
+
+    char riff[4];
+    char wave[4];
+    uint32_t riff_size = 0;
+    if (fread(riff, 1, 4, f) != 4 || !read_u32_le(f, riff_size) ||
+        fread(wave, 1, 4, f) != 4 || memcmp(riff, "RIFF", 4) != 0 ||
+        memcmp(wave, "WAVE", 4) != 0) {
+        fclose(f);
+        return false;
+    }
+    (void) riff_size;
+
+    while (true) {
+        char chunk_id[4];
+        uint32_t chunk_size = 0;
+        if (fread(chunk_id, 1, 4, f) != 4 || !read_u32_le(f, chunk_size)) {
+            break;
+        }
+        if (memcmp(chunk_id, "data", 4) == 0) {
+            const size_t n_samples = chunk_size / sizeof(int16_t);
+            pcm.assign(n_samples, 0);
+            size_t n_read = fread(pcm.data(), sizeof(int16_t), n_samples, f);
+            pcm.resize(n_read);
+            fclose(f);
+            return !pcm.empty();
+        }
+        long skip = (long)chunk_size + (chunk_size & 1u);
+        if (fseek(f, skip, SEEK_CUR) != 0) {
+            break;
+        }
+    }
+
+    fclose(f);
+    return false;
+}
+
 
 //
 // Forward declarations
@@ -8484,24 +8535,15 @@ void t2w_thread_func_python(struct omni_context * ctx_omni, common_params *param
             if (process_python_t2w_tokens(ctx_omni, window, is_last_window, wav_path, inference_time_ms, audio_duration)) {
                 // Audio output callback (for WS protocol) — read the WAV and pass float32 samples
                 if (ctx_omni->audio_output_cb && audio_duration > 0) {
-                    // Read the WAV file back to get float32 samples
-                    FILE * fw = fopen(wav_path.c_str(), "rb");
-                    if (fw) {
-                        // Skip WAV header (44 bytes for standard PCM WAV)
-                        fseek(fw, 44, SEEK_SET);
-                        // Read int16 PCM data
-                        int n_samples = static_cast<int>(audio_duration * 24000); // Python T2W uses 24kHz
-                        std::vector<int16_t> pcm(n_samples);
-                        size_t n_read = fread(pcm.data(), sizeof(int16_t), n_samples, fw);
-                        fclose(fw);
-                        if (n_read > 0) {
-                            // Convert int16 → float32
-                            std::vector<float> float_samples(n_read);
-                            for (size_t i = 0; i < n_read; ++i) {
-                                float_samples[i] = static_cast<float>(pcm[i]) / 32768.0f;
-                            }
-                            ctx_omni->audio_output_cb(float_samples.data(), static_cast<int>(n_read), 24000, is_last_window);
+                    std::vector<int16_t> pcm;
+                    if (read_wav_pcm16_data(wav_path, pcm)) {
+                        std::vector<float> float_samples(pcm.size());
+                        for (size_t i = 0; i < pcm.size(); ++i) {
+                            float_samples[i] = static_cast<float>(pcm[i]) / 32768.0f;
                         }
+                        ctx_omni->audio_output_cb(float_samples.data(), static_cast<int>(float_samples.size()), 24000, is_last_window);
+                    } else {
+                        LOG_ERR("Python T2W: failed to read WAV data chunk from %s\n", wav_path.c_str());
                     }
                 }
 

--- a/tools/omni/omni.cpp
+++ b/tools/omni/omni.cpp
@@ -4407,6 +4407,68 @@ void omni_stop_threads(struct omni_context * ctx_omni) {
     print_with_timestamp("omni_stop_threads: stop signals sent\n");
 }
 
+// Reset a context between backend-protocol sessions: end any duplex session,
+// stop+join the LLM/TTS/token2wav worker threads and drain their queues, while
+// keeping the loaded model alive so the next session can reuse this context.
+void omni_prepare_for_reuse(struct omni_context * ctx_omni) {
+    if (ctx_omni == nullptr) {
+        return;
+    }
+
+    if (ctx_omni->duplex_session) {
+        omni_duplex_session_end(ctx_omni);
+    }
+    duplex_stop_threads(ctx_omni);
+
+    llm_thread_running = false;
+    if (ctx_omni->llm_thread_info) {
+        ctx_omni->llm_thread_info->cv.notify_all();
+    }
+    if (ctx_omni->llm_thread.joinable()) {
+        ctx_omni->llm_thread.join();
+    }
+
+    tts_thread_running = false;
+    if (ctx_omni->tts_thread_info) {
+        ctx_omni->tts_thread_info->cv.notify_all();
+    }
+    if (ctx_omni->tts_thread.joinable()) {
+        ctx_omni->tts_thread.join();
+    }
+
+    t2w_thread_running = false;
+    if (ctx_omni->t2w_thread_info) {
+        ctx_omni->t2w_thread_info->cv.notify_all();
+    }
+    if (ctx_omni->t2w_thread.joinable()) {
+        ctx_omni->t2w_thread.join();
+    }
+
+    if (ctx_omni->llm_thread_info) {
+        std::lock_guard<std::mutex> lock(ctx_omni->llm_thread_info->mtx);
+        while (!ctx_omni->llm_thread_info->queue.empty()) {
+            delete ctx_omni->llm_thread_info->queue.front();
+            ctx_omni->llm_thread_info->queue.pop();
+        }
+    }
+    if (ctx_omni->tts_thread_info) {
+        std::lock_guard<std::mutex> lock(ctx_omni->tts_thread_info->mtx);
+        while (!ctx_omni->tts_thread_info->queue.empty()) {
+            delete ctx_omni->tts_thread_info->queue.front();
+            ctx_omni->tts_thread_info->queue.pop();
+        }
+    }
+    if (ctx_omni->t2w_thread_info) {
+        std::lock_guard<std::mutex> lock(ctx_omni->t2w_thread_info->mtx);
+        while (!ctx_omni->t2w_thread_info->queue.empty()) {
+            delete ctx_omni->t2w_thread_info->queue.front();
+            ctx_omni->t2w_thread_info->queue.pop();
+        }
+    }
+
+    print_with_timestamp("omni_prepare_for_reuse: inference threads stopped and queues cleared\n");
+}
+
 void omni_free(struct omni_context * ctx_omni) {
 
     // 高层 duplex session 必须在底层 duplex pipeline 之前结束：
@@ -4527,8 +4589,8 @@ void omni_free(struct omni_context * ctx_omni) {
         }
     }
 
-    llama_backend_free();
-
+    // NOTE: do NOT call llama_backend_free() here — the backend/model is shared
+    // and owned by the server; freeing it would break the still-running process.
     delete ctx_omni;
 }
 
@@ -10083,34 +10145,44 @@ bool stream_prefill(struct omni_context * ctx_omni, std::string aud_fname, std::
             // Step 3: 评估 suffix (assistant_prompt，包含 <|audio_end|><|im_end|>)
             eval_string(ctx_omni, ctx_omni->params, assistant_prompt.c_str(), ctx_omni->params->n_batch, &ctx_omni->n_past, false);
         } else {
-            // 🔧 [与 Python 对齐] 非双工模式也需要在 system prompt 中插入 ref_audio embedding
-            // Python: sys_msgs = {"role": "system", "content": [vc_prompt_prefix, ref_audio, vc_prompt_suffix]}
-            // 格式: <|im_start|>system\n{vc_prompt_prefix}\n<|audio_start|>[ref_audio_embed]<|audio_end|>{vc_prompt_suffix}<|im_end|>\n
-            
-            // 确定 ref_audio 路径：优先使用调用方传入的 aud_fname，其次配置路径，最后默认路径
-            std::string system_ref_audio = !aud_fname.empty()
-                ? aud_fname
-                : (!ctx_omni->ref_audio_path.empty()
-                    ? ctx_omni->ref_audio_path
-                    : "tools/omni/assets/default_ref_audio/default_ref_audio.wav");
-            print_with_timestamp("system prompt ref_audio: %s\n", system_ref_audio.c_str());
-            
-            // Step 1: 评估 prefix (voice_clone_prompt，包含 <|audio_start|>)
-            eval_string(ctx_omni, ctx_omni->params, voice_clone_prompt.c_str(), ctx_omni->params->n_batch, &ctx_omni->n_past, false);
-            
-            // Step 2: 获取并 prefill 参考音频的 APM embedding
-            auto * ref_audio_embeds = omni_audio_embed_make_with_filename(ctx_omni->ctx_audio, ctx_omni->params->cpuparams.n_threads, system_ref_audio);
-            if (ref_audio_embeds != nullptr && ref_audio_embeds->n_pos > 0) {
-                print_with_timestamp("system prompt ref_audio embedding: n_pos=%d\n", ref_audio_embeds->n_pos);
-                prefill_with_emb(ctx_omni, ctx_omni->params, ref_audio_embeds->embed, ref_audio_embeds->n_pos, 
-                                ctx_omni->params->n_batch, &ctx_omni->n_past);
-                omni_embed_free(ref_audio_embeds);
+            const bool has_ref_audio_slot =
+                voice_clone_prompt.find("<|audio_start|>") != std::string::npos &&
+                assistant_prompt.find("<|audio_end|>") != std::string::npos;
+
+            if (!has_ref_audio_slot) {
+                // Python no-TTS chat template has a plain system message, with
+                // no ref-audio embedding in the prompt.
+                eval_string(ctx_omni, ctx_omni->params, voice_clone_prompt.c_str(),
+                            ctx_omni->params->n_batch, &ctx_omni->n_past, false);
+                eval_string(ctx_omni, ctx_omni->params, assistant_prompt.c_str(),
+                            ctx_omni->params->n_batch, &ctx_omni->n_past, false);
             } else {
-                print_with_timestamp("WARNING: failed to load system prompt ref_audio: %s\n", system_ref_audio.c_str());
+                // 🔧 [与 Python 对齐] 非双工 TTS/voice-clone system prompt:
+                // <|im_start|>system\nprefix\n<|audio_start|>[ref_audio]<|audio_end|>suffix<|im_end|>\n
+                std::string system_ref_audio = !aud_fname.empty()
+                    ? aud_fname
+                    : (!ctx_omni->ref_audio_path.empty()
+                        ? ctx_omni->ref_audio_path
+                        : "tools/omni/assets/default_ref_audio/default_ref_audio.wav");
+                print_with_timestamp("system prompt ref_audio: %s\n", system_ref_audio.c_str());
+
+                eval_string(ctx_omni, ctx_omni->params, voice_clone_prompt.c_str(),
+                            ctx_omni->params->n_batch, &ctx_omni->n_past, false);
+
+                auto * ref_audio_embeds = omni_audio_embed_make_with_filename(
+                    ctx_omni->ctx_audio, ctx_omni->params->cpuparams.n_threads, system_ref_audio);
+                if (ref_audio_embeds != nullptr && ref_audio_embeds->n_pos > 0) {
+                    print_with_timestamp("system prompt ref_audio embedding: n_pos=%d\n", ref_audio_embeds->n_pos);
+                    prefill_with_emb(ctx_omni, ctx_omni->params, ref_audio_embeds->embed, ref_audio_embeds->n_pos,
+                                    ctx_omni->params->n_batch, &ctx_omni->n_past);
+                    omni_embed_free(ref_audio_embeds);
+                } else {
+                    print_with_timestamp("WARNING: failed to load system prompt ref_audio: %s\n", system_ref_audio.c_str());
+                }
+
+                eval_string(ctx_omni, ctx_omni->params, assistant_prompt.c_str(),
+                            ctx_omni->params->n_batch, &ctx_omni->n_past, false);
             }
-            
-            // Step 3: 评估 suffix (assistant_prompt，包含 <|audio_end|><|im_end|>)
-            eval_string(ctx_omni, ctx_omni->params, assistant_prompt.c_str(), ctx_omni->params->n_batch, &ctx_omni->n_past, false);
         }
         
         // 标记系统 prompt 已初始化
@@ -10489,9 +10561,10 @@ bool stream_decode(struct omni_context * ctx_omni, std::string debug_dir, int ro
         }
         print_with_timestamp("📍 [单工TTS] assistant prompt 完成, n_past=%d\n", ctx_omni->n_past);
     } else {
-        // 🔧 [非双工纯 LLM 模式] 只使用标准的 assistant prompt（无 TTS 标记，无 think 标记）
-        // 格式: <|im_end|>\n<|im_start|>assistant\n
-        std::string prompt = "<|im_end|>\n<|im_start|>assistant\n";
+        // 🔧 [非双工纯 LLM 模式] 使用空 thinking block，避免 Qwen3/MiniCPM-o
+        // 在面向用户的回答里直接生成 <think>...</think>。
+        // 格式: <|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n
+        std::string prompt = "<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n";
         {
             eval_string(ctx_omni, ctx_omni->params, prompt.c_str(), ctx_omni->params->n_batch, &ctx_omni->n_past, false);
         }
@@ -10779,11 +10852,18 @@ bool stream_decode(struct omni_context * ctx_omni, std::string debug_dir, int ro
                 }
             }
             
-            // 🔧 [特殊处理] <|speak|> 是开始标记，直接移除它（不截断后面内容）
-            size_t speak_pos = response.find("<|speak|>");
-            while (speak_pos != std::string::npos) {
-                response.erase(speak_pos, std::string("<|speak|>").length());
-                speak_pos = response.find("<|speak|>");
+            // 🔧 [特殊处理] 开始/控制标记直接移除（不截断后面内容）
+            static const std::vector<std::string> inline_token_strings = {
+                "<|speak|>",
+                "<think>",
+                "</think>",
+            };
+            for (const auto & token : inline_token_strings) {
+                size_t pos = response.find(token);
+                while (pos != std::string::npos) {
+                    response.erase(pos, token.length());
+                    pos = response.find(token);
+                }
             }
         }
         fflush(stdout);

--- a/tools/omni/omni.h
+++ b/tools/omni/omni.h
@@ -490,6 +490,9 @@ struct omni_context * omni_init(struct common_params * params, int media_type, b
                                 const std::string & base_output_dir = "./tools/omni/output");
 
 void omni_free(struct omni_context * ctx_omni);
+// Stop/join inference threads and clear queues so the same context can serve a
+// new session, without tearing down the loaded model (unlike omni_free).
+void omni_prepare_for_reuse(struct omni_context * ctx_omni);
 
 // ANE/CoreML warmup — call once after omni_init to pre-load models into NPU
 void omni_warmup_ane(struct omni_context * ctx_omni);

--- a/tools/omni/omni.h
+++ b/tools/omni/omni.h
@@ -352,7 +352,8 @@ struct omni_context {
     // 语言设置 (用于 prompt 生成)
     std::string language = "zh";
 
-    // text streaming queue for server
+    // text_mtx protects only the text streaming state consumed by HTTP/WS
+    // readers; broader omni_context lifecycle/prefill changes use server octx_mutex.
     std::mutex text_mtx;
     std::condition_variable text_cv;
     std::deque<std::string> text_queue;

--- a/tools/server/protocol.cpp
+++ b/tools/server/protocol.cpp
@@ -1,6 +1,7 @@
 #include "protocol.h"
 #include "common/base64.hpp"
 
+#include <algorithm>
 #include <chrono>
 
 // ============================================================================
@@ -22,8 +23,29 @@ json ProtocolMetrics::to_json() const {
     if (wall_clock_ms > 0.0) {
         m["wall_clock_ms"] = wall_clock_ms;
     }
+    if (cost_llm_ms > 0.0) {
+        m["cost_llm_ms"] = cost_llm_ms;
+    }
+    if (cost_tts_prep_ms > 0.0) {
+        m["cost_tts_prep_ms"] = cost_tts_prep_ms;
+    }
+    if (cost_tts_ms > 0.0) {
+        m["cost_tts_ms"] = cost_tts_ms;
+    }
+    if (cost_token2wav_ms > 0.0) {
+        m["cost_token2wav_ms"] = cost_token2wav_ms;
+    }
     if (n_tokens > 0) {
         m["n_tokens"] = n_tokens;
+    }
+    if (n_tts_tokens > 0) {
+        m["n_tts_tokens"] = n_tts_tokens;
+    }
+    if (vision_slices > 0) {
+        m["vision_slices"] = vision_slices;
+    }
+    if (vision_tokens > 0) {
+        m["vision_tokens"] = vision_tokens;
     }
     return m;
 }
@@ -188,6 +210,50 @@ static float json_float(const json & j, const std::string & key, float default_v
     return default_val;
 }
 
+// Return the first non-empty string among several accepted key aliases.
+static std::string json_str_any(const json & j, std::initializer_list<const char *> keys) {
+    for (const char * key : keys) {
+        if (j.contains(key) && j.at(key).is_string()) {
+            std::string value = j.at(key).get<std::string>();
+            if (!value.empty()) {
+                return value;
+            }
+        }
+    }
+    return "";
+}
+
+// Drop a leading "data:...;base64," prefix if present, returning raw base64.
+static std::string strip_data_url_prefix(const std::string & value) {
+    auto comma = value.find(',');
+    if (comma != std::string::npos && value.substr(0, comma).find("base64") != std::string::npos) {
+        return value.substr(comma + 1);
+    }
+    return value;
+}
+
+// Accept audio/image as either a bare base64 string or an object carrying it
+// under one of several common key names; always return clean base64.
+static std::string extract_audio_b64(const json & value) {
+    if (value.is_string()) {
+        return strip_data_url_prefix(value.get<std::string>());
+    }
+    if (value.is_object()) {
+        return strip_data_url_prefix(json_str_any(value, {"data", "base64", "audio_base64", "audio_data"}));
+    }
+    return "";
+}
+
+static std::string extract_image_b64(const json & value) {
+    if (value.is_string()) {
+        return strip_data_url_prefix(value.get<std::string>());
+    }
+    if (value.is_object()) {
+        return strip_data_url_prefix(json_str_any(value, {"data", "base64", "image_base64"}));
+    }
+    return "";
+}
+
 ParsedSessionInit parse_session_init(const json & msg) {
     ParsedSessionInit out;
 
@@ -215,8 +281,11 @@ ParsedSessionInit parse_session_init(const json & msg) {
     // voice (reference audio)
     if (p.contains("voice") && p.at("voice").is_object()) {
         const json & v = p.at("voice");
-        out.ref_audio_b64 = json_str(v, "ref_audio");
-        out.tts_ref_audio_b64 = json_str(v, "tts_ref_audio");
+        out.ref_audio_b64 = json_str_any(v, {"ref_audio", "ref_audio_base64"});
+        out.tts_ref_audio_b64 = json_str_any(v, {"tts_ref_audio", "tts_ref_audio_base64"});
+        if (out.tts_ref_audio_b64.empty() && !out.ref_audio_b64.empty()) {
+            out.tts_ref_audio_b64 = out.ref_audio_b64;
+        }
     }
 
     // system_prompt
@@ -246,20 +315,61 @@ ParsedInput parse_input_append(const json & msg) {
 
     const json & in = msg.at("input");
 
-    // Full-duplex fields: audio (required), video_frames (optional)
-    if (in.contains("audio") && in.at("audio").is_string()) {
-        out.audio_b64 = in.at("audio").get<std::string>();
+    // Full-duplex audio aliases: audio, audio.data/base64, audio_base64, audio_data.
+    out.audio_b64 = json_str_any(in, {"audio_base64", "audio_data"});
+    if (out.audio_b64.empty() && in.contains("audio")) {
+        out.audio_b64 = extract_audio_b64(in.at("audio"));
     }
+    out.audio_b64 = strip_data_url_prefix(out.audio_b64);
 
-    if (in.contains("video_frames") && in.at("video_frames").is_array()) {
-        for (const auto & f : in.at("video_frames")) {
-            if (f.is_string()) {
-                out.video_frames_b64.push_back(f.get<std::string>());
+    auto append_frames = [&](const json & frames) {
+        if (!frames.is_array()) {
+            return;
+        }
+        for (const auto & f : frames) {
+            std::string frame = extract_image_b64(f);
+            if (!frame.empty()) {
+                out.video_frames_b64.push_back(frame);
             }
         }
+    };
+
+    if (in.contains("video_frames")) {
+        append_frames(in.at("video_frames"));
+    }
+    if (in.contains("frame_base64_list")) {
+        append_frames(in.at("frame_base64_list"));
+    }
+    if (in.contains("frames")) {
+        append_frames(in.at("frames"));
     }
 
-    out.max_slice_nums = json_int(in, "max_slice_nums", -1);
+    // max_slice_nums: int applies to every frame; int[] must match frame count
+    // (schema §4.3). Falls back to hints.max_slice_nums when absent.
+    if (in.contains("max_slice_nums")) {
+        const json & msn = in.at("max_slice_nums");
+        if (msn.is_number_integer()) {
+            out.max_slice_nums = msn.get<int>();
+        } else if (msn.is_array()) {
+            if (!out.video_frames_b64.empty() && msn.size() != out.video_frames_b64.size()) {
+                out.error = "max_slice_nums array length must match video frame count";
+                return out;
+            }
+            if (!msn.empty() && msn.at(0).is_number_integer()) {
+                out.max_slice_nums = msn.at(0).get<int>();
+            }
+        } else if (!msn.is_null()) {
+            out.error = "max_slice_nums must be int or int[]";
+            return out;
+        }
+    } else if (in.contains("hints") && in.at("hints").is_object()) {
+        out.max_slice_nums = json_int(in.at("hints"), "max_slice_nums", -1);
+    }
+
+    out.force_listen = json_bool(in, "force_listen", false);
+    if (in.contains("hints") && in.at("hints").is_object()) {
+        out.force_listen = json_bool(in.at("hints"), "force_listen", out.force_listen);
+    }
 
     // Turn-based fields: messages (required), streaming (required), generation
     if (in.contains("messages") && in.at("messages").is_array()) {
@@ -274,11 +384,21 @@ ParsedInput parse_input_append(const json & msg) {
         out.length_penalty = json_float(gen, "length_penalty", 1.1f);
     }
 
+    if (in.contains("image") && in.at("image").is_object()) {
+        const json & img = in.at("image");
+        out.max_slice_nums = json_int(img, "max_slice_nums", out.max_slice_nums);
+    }
+
     if (in.contains("tts") && in.at("tts").is_object()) {
         const json & tts = in.at("tts");
         out.tts_enabled = json_bool(tts, "enabled", false);
         out.tts_ref_audio_b64 = json_str(tts, "ref_audio_data");
     }
+
+    out.omni_mode = json_bool(in, "omni_mode", false);
+    // TTS is on if either use_tts_template or tts.enabled is set (schema §4.2).
+    out.use_tts_template = json_bool(in, "use_tts_template", false) || out.tts_enabled;
+    out.enable_thinking = json_bool(in, "enable_thinking", false);
 
     out.ok = true;
     return out;
@@ -311,26 +431,37 @@ ParsedMessage parse_one_message(const json & msg) {
                         if (!text_buf.empty()) text_buf += "\n";
                         text_buf += t;
                     }
+                } else if (ptype == "image") {
+                    std::string data = extract_image_b64(part);
+                    if (!data.empty()) {
+                        out.image_b64s.push_back(data);
+                    }
                 } else if (ptype == "image_url") {
                     if (part.contains("image_url") && part.at("image_url").is_object()) {
                         const json & iu = part.at("image_url");
                         std::string url = json_str(iu, "url");
                         if (!url.empty()) {
-                            auto comma = url.find(',');
-                            if (comma != std::string::npos) {
-                                std::string payload = url.substr(comma + 1);
-                                auto raw = b64_decode(payload);
-                                if (!raw.empty()) {
-                                    out.image_b64s.push_back(base64::encode(
-                                        reinterpret_cast<const char*>(raw.data()), raw.size()));
-                                }
+                            std::string payload = strip_data_url_prefix(url);
+                            auto raw = b64_decode(payload);
+                            if (!raw.empty()) {
+                                out.image_b64s.push_back(base64::encode(
+                                    reinterpret_cast<const char*>(raw.data()), raw.size()));
                             }
                         }
                     }
                 } else if (ptype == "audio") {
-                    std::string audio = json_str(part, "audio");
+                    std::string audio = extract_audio_b64(part);
                     if (!audio.empty()) {
                         out.audio_b64s.push_back(audio);
+                    }
+                } else if (ptype == "video") {
+                    // base64 MP4 container (schema §4.4); decoded into frames +
+                    // audio later. stack_frames = frames stacked per sample point.
+                    std::string video = json_str_any(part, {"data", "base64"});
+                    if (!video.empty()) {
+                        out.video_b64s.push_back(strip_data_url_prefix(video));
+                        int stack_frames = json_int(part, "stack_frames", 1);
+                        out.video_stack_frames.push_back(std::max(1, stack_frames));
                     }
                 }
             }
@@ -352,16 +483,26 @@ std::vector<ParsedMessage> parse_messages_array(const json & messages) {
 
 std::string build_prompt_from_messages(const std::vector<ParsedMessage> & msgs) {
     std::string prompt;
+    bool wrote_any = false;
     for (const auto & m : msgs) {
         if (m.role == "system") {
-            prompt += m.text + "\n\n";
+            if (!m.text.empty()) {
+                if (wrote_any) prompt += "\n";
+                prompt += m.text;
+                wrote_any = true;
+            }
         } else if (m.role == "user") {
-            prompt += "<|user|>\n" + m.text + "\n";
+            if (wrote_any) prompt += "<|im_end|>\n";
+            prompt += "<|im_start|>user\n" + m.text;
+            wrote_any = true;
         } else if (m.role == "assistant") {
-            prompt += "<|assistant|>\n" + m.text + "\n";
+            if (wrote_any) prompt += "<|im_end|>\n";
+            prompt += "<|im_start|>assistant\n" + m.text;
+            wrote_any = true;
         }
     }
-    prompt += "<|assistant|>\n";
+    if (wrote_any) prompt += "<|im_end|>\n";
+    prompt += "<|im_start|>assistant\n<think>\n\n</think>\n\n";
     return prompt;
 }
 

--- a/tools/server/protocol.cpp
+++ b/tools/server/protocol.cpp
@@ -197,7 +197,7 @@ static bool json_bool(const json & j, const std::string & key, bool default_val 
 }
 
 static int json_int(const json & j, const std::string & key, int default_val = 0) {
-    if (j.contains(key) && j.at(key).is_number_integer()) {
+    if (j.contains(key) && j.at(key).is_number()) {
         return j.at(key).get<int>();
     }
     return default_val;
@@ -348,14 +348,14 @@ ParsedInput parse_input_append(const json & msg) {
     // (schema §4.3). Falls back to hints.max_slice_nums when absent.
     if (in.contains("max_slice_nums")) {
         const json & msn = in.at("max_slice_nums");
-        if (msn.is_number_integer()) {
+        if (msn.is_number()) {
             out.max_slice_nums = msn.get<int>();
         } else if (msn.is_array()) {
             if (!out.video_frames_b64.empty() && msn.size() != out.video_frames_b64.size()) {
                 out.error = "max_slice_nums array length must match video frame count";
                 return out;
             }
-            if (!msn.empty() && msn.at(0).is_number_integer()) {
+            if (!msn.empty() && msn.at(0).is_number()) {
                 out.max_slice_nums = msn.at(0).get<int>();
             }
         } else if (!msn.is_null()) {
@@ -442,10 +442,8 @@ ParsedMessage parse_one_message(const json & msg) {
                         std::string url = json_str(iu, "url");
                         if (!url.empty()) {
                             std::string payload = strip_data_url_prefix(url);
-                            auto raw = b64_decode(payload);
-                            if (!raw.empty()) {
-                                out.image_b64s.push_back(base64::encode(
-                                    reinterpret_cast<const char*>(raw.data()), raw.size()));
+                            if (!payload.empty()) {
+                                out.image_b64s.push_back(payload);
                             }
                         }
                     }

--- a/tools/server/protocol.h
+++ b/tools/server/protocol.h
@@ -18,7 +18,16 @@ struct ProtocolMetrics {
     double prefill_ms = 0.0;
     double generate_ms = 0.0;
     double wall_clock_ms = 0.0;
+    // Detailed stage timings + token/vision counts (schema §5.4). Only emitted
+    // to JSON when > 0, so leaving any unset simply omits that field.
+    double cost_llm_ms = 0.0;
+    double cost_tts_prep_ms = 0.0;
+    double cost_tts_ms = 0.0;
+    double cost_token2wav_ms = 0.0;
     int n_tokens = 0;
+    int n_tts_tokens = 0;
+    int vision_slices = 0;
+    int vision_tokens = 0;
 
     json to_json() const;
 };
@@ -92,11 +101,15 @@ struct ParsedInput {
     std::string audio_b64;                         // base64 float32 PCM
     std::vector<std::string> video_frames_b64;     // base64 JPEG frames
     int max_slice_nums = -1;
+    bool force_listen = false;            // full_duplex: force this step to LISTEN
 
     // Turn-based fields
     bool streaming = true;
     int max_new_tokens = 512;
     float length_penalty = 1.1f;
+    bool omni_mode = false;               // pass-through hints (§4.2)
+    bool use_tts_template = false;        // emit speech for this turn (use_tts_template OR tts.enabled)
+    bool enable_thinking = false;
     // messages[] — currently passed as raw json for backend to interpret
     json messages;
     std::string tts_ref_audio_b64;
@@ -119,6 +132,8 @@ struct ParsedMessage {
     std::string text;                       // concatenated text content (for easy prompt building)
     std::vector<std::string> image_b64s;    // all images in this message (already decoded)
     std::vector<std::string> audio_b64s;    // all audio in this message (base64 float32 PCM)
+    std::vector<std::string> video_b64s;    // all video containers in this message (base64 MP4)
+    std::vector<int> video_stack_frames;     // stack_frames for each video_b64s entry
 };
 
 // Parse a single message from json

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -2375,6 +2375,13 @@ struct server_context {
     oaicompat_parser_options  oai_parser_opt;
 
     ~server_context() {
+        // Backend-protocol sessions reuse a single server-owned omni_context;
+        // free it here on shutdown instead of per-session.
+        if (octx) {
+            omni_free(octx);
+            octx = nullptr;
+        }
+
         mtmd_free(mctx);
 
         // Clear any sampling context
@@ -6366,7 +6373,8 @@ int main(int argc, char ** argv) {
     // Backend Protocol (WebSocket + HTTP unary)
     //
     svr->WebSocket(params.api_prefix + "/backend", [&](const httplib::Request &, httplib::ws::WebSocket & ws) {
-        handle_ws_backend(ws, ctx_server.session_mgr, params, ctx_server.model, ctx_server.ctx, ctx_server.octx_mutex);
+        handle_ws_backend(ws, ctx_server.session_mgr, params, ctx_server.model, ctx_server.ctx,
+                          ctx_server.octx, ctx_server.octx_mutex);
     });
 
     svr->Post(params.api_prefix + "/sessions/:session_id/close", [&](const httplib::Request & req, httplib::Response & res) {
@@ -6380,18 +6388,24 @@ int main(int argc, char ** argv) {
             return;
         }
 
-        // Signal break to stop any ongoing inference
-        if (session->octx) {
-            session->octx->break_event = true;
-            {
-                std::lock_guard<std::mutex> lk(session->octx->text_mtx);
-                session->octx->text_queue.clear();
-                session->octx->text_done_flag = true;
+        // close is a completion primitive: do not return until inference
+        // threads are stopped and the shared omni_context is safe to reuse.
+        {
+            std::lock_guard<std::mutex> octx_lock(ctx_server.octx_mutex);
+            auto * closing = ctx_server.session_mgr.get(session_id);
+            if (closing && closing->octx) {
+                closing->octx->break_event = true;
+                {
+                    std::lock_guard<std::mutex> lk(closing->octx->text_mtx);
+                    closing->octx->text_queue.clear();
+                    closing->octx->text_done_flag = true;
+                }
+                closing->octx->text_cv.notify_all();
+                omni_prepare_for_reuse(closing->octx);
             }
-            session->octx->text_cv.notify_all();
-        }
 
-        ctx_server.session_mgr.close(session_id);
+            ctx_server.session_mgr.close(session_id);
+        }
 
         json resp;
         resp["ok"] = true;

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -2338,6 +2338,8 @@ struct server_context {
     // multimodal
     mtmd_context * mctx = nullptr;
     omni_context * octx = nullptr;
+    // Protects shared omni_context lifecycle and prefill/decode entry points.
+    // Per-fragment text queues are protected by omni_context::text_mtx.
     std::mutex octx_mutex;
 
     SessionManager session_mgr;
@@ -6387,6 +6389,8 @@ int main(int argc, char ** argv) {
             res.status = 404;
             return;
         }
+
+        ctx_server.session_mgr.request_transport_close(session_id);
 
         // close is a completion primitive: do not return until inference
         // threads are stopped and the shared omni_context is safe to reuse.

--- a/tools/server/session.cpp
+++ b/tools/server/session.cpp
@@ -73,6 +73,30 @@ OmniSession * SessionManager::get(const std::string & session_id) {
     return active_.get();
 }
 
+void SessionManager::set_close_callback(const std::string & session_id, std::function<void()> cb) {
+    std::lock_guard<std::mutex> lock(mtx_);
+
+    if (!active_ || active_->session_id != session_id) {
+        return;
+    }
+    active_->close_ws = std::move(cb);
+}
+
+void SessionManager::request_transport_close(const std::string & session_id) {
+    std::function<void()> close_ws;
+    {
+        std::lock_guard<std::mutex> lock(mtx_);
+        if (!active_ || active_->session_id != session_id) {
+            return;
+        }
+        close_ws = active_->close_ws;
+    }
+
+    if (close_ws) {
+        close_ws();
+    }
+}
+
 void SessionManager::close(const std::string & session_id) {
     std::unique_ptr<OmniSession> to_free;
     {

--- a/tools/server/session.cpp
+++ b/tools/server/session.cpp
@@ -86,29 +86,34 @@ void SessionManager::close(const std::string & session_id) {
             active_->state = SessionState::CLOSED;
         }
 
-        // Release omni_context if owned (model stays alive)
-        if (active_->owns_octx && active_->octx) {
-            omni_free(active_->octx);
-            active_->octx = nullptr;
-        }
-
         to_free = std::move(active_);
     }
-    // to_free destructor runs outside lock
+
+    // Release omni_context outside the manager lock. omni_free stops and joins
+    // inference threads and can touch shared backend state, so holding mtx_ here
+    // can race with WS cleanup or block unrelated lifecycle checks.
+    if (to_free && to_free->owns_octx && to_free->octx) {
+        omni_free(to_free->octx);
+        to_free->octx = nullptr;
+    }
 }
 
 void SessionManager::on_disconnect() {
-    std::lock_guard<std::mutex> lock(mtx_);
+    std::unique_ptr<OmniSession> to_free;
+    {
+        std::lock_guard<std::mutex> lock(mtx_);
 
-    if (!active_ || active_->state == SessionState::CLOSED) {
-        return;
+        if (!active_ || active_->state == SessionState::CLOSED) {
+            return;
+        }
+
+        active_->state = SessionState::CLOSED;
+        to_free = std::move(active_);
     }
 
-    active_->state = SessionState::CLOSED;
-
-    if (active_->owns_octx && active_->octx) {
-        omni_free(active_->octx);
-        active_->octx = nullptr;
+    if (to_free && to_free->owns_octx && to_free->octx) {
+        omni_free(to_free->octx);
+        to_free->octx = nullptr;
     }
 }
 

--- a/tools/server/session.h
+++ b/tools/server/session.h
@@ -26,6 +26,7 @@ struct OmniSession {
     omni_context * octx = nullptr;
     bool owns_octx = false;
     double created_at = 0.0;
+    std::function<void()> close_ws;
 };
 
 // SessionManager — manages the single active backend session.
@@ -43,6 +44,11 @@ public:
 
     // Get a session by id. Returns nullptr if not found.
     OmniSession * get(const std::string & session_id);
+
+    // Register/trigger transport close without holding the manager lock while
+    // invoking the callback.
+    void set_close_callback(const std::string & session_id, std::function<void()> cb);
+    void request_transport_close(const std::string & session_id);
 
     // Close and forget a session. Releases omni_context if owned.
     void close(const std::string & session_id);

--- a/tools/server/ws_handler.cpp
+++ b/tools/server/ws_handler.cpp
@@ -5,6 +5,8 @@
 #include "common.h"
 #include "llama.h"
 #include "log.h"
+#include "audition.h"
+#include "vision.h"
 
 #include <cpp-httplib/httplib.h>
 
@@ -13,8 +15,250 @@
 #include <fstream>
 #include <chrono>
 #include <deque>
+#include <vector>
+#include <algorithm>
+#include <cstdlib>
+#include <cstdio>
 
 namespace fs = std::filesystem;
+
+static double elapsed_ms(std::chrono::steady_clock::time_point start,
+                         std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now()) {
+    return std::chrono::duration<double, std::milli>(end - start).count();
+}
+
+static bool utf8_cont(unsigned char c) {
+    return (c & 0xC0) == 0x80;
+}
+
+// Stream-safe UTF-8: emit only complete code points, hold an incomplete trailing
+// byte sequence in `pending` until the next fragment, and replace invalid bytes
+// with U+FFFD. Prevents broken multi-byte chars when text is chunked over WS.
+static std::string sanitize_utf8_stream(std::string & pending,
+                                        const std::string & fragment,
+                                        bool flush = false) {
+    static const std::string replacement = "\xEF\xBF\xBD";
+    std::string input = pending + fragment;
+    pending.clear();
+
+    std::string out;
+    size_t i = 0;
+    while (i < input.size()) {
+        const unsigned char c = static_cast<unsigned char>(input[i]);
+        if (c < 0x80) {
+            out.push_back(static_cast<char>(c));
+            i++;
+            continue;
+        }
+
+        int need = 0;
+        if (c >= 0xC2 && c <= 0xDF) {
+            need = 1;
+        } else if (c >= 0xE0 && c <= 0xEF) {
+            need = 2;
+        } else if (c >= 0xF0 && c <= 0xF4) {
+            need = 3;
+        } else {
+            out += replacement;
+            i++;
+            continue;
+        }
+
+        if (i + need >= input.size()) {
+            pending = input.substr(i);
+            break;
+        }
+
+        bool ok = true;
+        for (int j = 1; j <= need; ++j) {
+            ok = ok && utf8_cont(static_cast<unsigned char>(input[i + j]));
+        }
+        if (ok && c == 0xE0) {
+            ok = static_cast<unsigned char>(input[i + 1]) >= 0xA0;
+        } else if (ok && c == 0xED) {
+            ok = static_cast<unsigned char>(input[i + 1]) < 0xA0;
+        } else if (ok && c == 0xF0) {
+            ok = static_cast<unsigned char>(input[i + 1]) >= 0x90;
+        } else if (ok && c == 0xF4) {
+            ok = static_cast<unsigned char>(input[i + 1]) < 0x90;
+        }
+
+        if (!ok) {
+            out += replacement;
+            i++;
+            continue;
+        }
+
+        out.append(input, i, need + 1);
+        i += need + 1;
+    }
+
+    if (flush && !pending.empty()) {
+        out += replacement;
+        pending.clear();
+    }
+    return out;
+}
+
+// Build the metrics object attached to downlink events from current runtime
+// state (KV length, TTS token count, vision tokens) plus the timings passed in.
+static ProtocolMetrics make_runtime_metrics(omni_context * octx,
+                                            double prefill_ms = 0.0,
+                                            double generate_ms = 0.0,
+                                            double wall_clock_ms = 0.0,
+                                            int n_tokens = 0,
+                                            int vision_slices = 0) {
+    ProtocolMetrics metrics;
+    metrics.backend = "llama.cpp-omni";
+    if (octx) {
+        metrics.kv_cache_length = std::max(0, octx->n_past);
+        metrics.n_tts_tokens = (int)octx->tts_all_generated_tokens.size();
+        if (vision_slices > 0 && octx->ctx_vision) {
+            metrics.vision_tokens = vision_slices * vision_n_output_tokens(octx->ctx_vision);
+        }
+    }
+    metrics.prefill_ms = prefill_ms;
+    metrics.generate_ms = generate_ms;
+    metrics.wall_clock_ms = wall_clock_ms;
+    metrics.cost_llm_ms = generate_ms;
+    metrics.n_tokens = n_tokens;
+    metrics.vision_slices = vision_slices;
+    return metrics;
+}
+
+static std::string parent_dir(const std::string & path) {
+    const size_t pos = path.find_last_of("/\\");
+    return pos == std::string::npos ? "." : path.substr(0, pos);
+}
+
+// Fill vision/audio/TTS sub-model paths from --omni-model-dir (or, as a
+// fallback, the directory of the main -m model) when they weren't set explicitly.
+static void ensure_omni_model_paths(common_params & params) {
+    std::string root = params.omni_model_dir;
+    if (root.empty() && !params.model.path.empty()) {
+        root = parent_dir(params.model.path);
+        params.omni_model_dir = root;
+    }
+    if (root.empty()) {
+        return;
+    }
+    if (params.vpm_model.empty()) {
+        params.vpm_model = root + "/vision/MiniCPM-o-4_5-vision-F16.gguf";
+    }
+    if (params.apm_model.empty()) {
+        params.apm_model = root + "/audio/MiniCPM-o-4_5-audio-F16.gguf";
+    }
+    if (params.tts_model.empty()) {
+        params.tts_model = root + "/tts/MiniCPM-o-4_5-tts-F16.gguf";
+    }
+    if (params.tts_bin_dir.empty()) {
+        params.tts_bin_dir = root + "/tts";
+    }
+}
+
+static void clear_text_stream_state(omni_context * octx) {
+    std::lock_guard<std::mutex> lk(octx->text_mtx);
+    octx->text_queue.clear();
+    octx->text_done_flag = false;
+    octx->text_streaming = false;
+}
+
+static void stop_reusable_octx_threads(omni_context * octx) {
+    omni_prepare_for_reuse(octx);
+}
+
+// Wipe per-session state on a reused context: stop threads, reset counters/flags,
+// clear LLM/TTS/whisper KV caches, so the next session starts clean on the same
+// loaded model. Used by the shared-octx reuse path in create_session_octx.
+static void reset_octx_for_session(omni_context * octx, const ParsedSessionInit & init,
+                                   const std::string & output_dir) {
+    stop_reusable_octx_threads(octx);
+
+    const bool duplex_mode = (init.mode == "full_duplex");
+    octx->async = true;
+    octx->duplex_mode = duplex_mode;
+    octx->base_output_dir = output_dir;
+
+    octx->break_event.store(false);
+    octx->current_turn_ended = false;
+    octx->llm_generation_done = false;
+    octx->need_speek = false;
+    octx->speek_done = true;
+
+    octx->n_past = 0;
+    octx->n_keep = 0;
+    octx->system_prompt_initialized = false;
+    octx->simplex_round_idx = 0;
+    octx->wav_turn_base = 0;
+    octx->round_start_positions.clear();
+    octx->force_listen_used = 0;
+
+    octx->tts_all_generated_tokens.clear();
+    octx->tts_token_buffer.clear();
+    octx->tts_n_past_accumulated = 0;
+    octx->tts_condition_saved = false;
+    octx->tts_condition_embeddings.clear();
+    octx->tts_condition_length = 0;
+    octx->tts_condition_n_embd = 0;
+
+    clear_text_stream_state(octx);
+
+    if (octx->ctx_llama) {
+        llama_memory_t mem = llama_get_memory(octx->ctx_llama);
+        if (mem) {
+            llama_memory_clear(mem, /*data=*/false);
+        }
+    }
+    if (octx->ctx_tts_llama) {
+        llama_memory_t mem = llama_get_memory(octx->ctx_tts_llama);
+        if (mem) {
+            llama_memory_clear(mem, /*data=*/false);
+        }
+    }
+    if (octx->ctx_audio) {
+        audition_whisper_clear_kv_cache(octx->ctx_audio);
+    }
+    if (octx->ctx_vision) {
+        vision_set_max_slice_nums(octx->ctx_vision, -1);
+    }
+
+    if (!init.system_prompt.empty()) {
+        octx->omni_assistant_prompt = init.system_prompt;
+    }
+}
+
+// Apply the optional opaque init.config (sampling/decoding knobs, §6) onto the
+// context and params. Unknown/missing keys are left at model defaults.
+static void apply_session_config(common_params & params, omni_context * octx, const ParsedSessionInit & init) {
+    if (!init.config.is_object()) {
+        return;
+    }
+    if (init.config.contains("length_penalty") && init.config.at("length_penalty").is_number()) {
+        octx->length_penalty = init.config.at("length_penalty").get<float>();
+    }
+    if (init.config.contains("listen_prob_scale") && init.config.at("listen_prob_scale").is_number()) {
+        octx->listen_prob_scale = init.config.at("listen_prob_scale").get<float>();
+    }
+    if (init.config.contains("force_listen_count") && init.config.at("force_listen_count").is_number_integer()) {
+        octx->force_listen_count = init.config.at("force_listen_count").get<int>();
+        octx->force_listen_used = 0;
+    }
+    if (init.config.contains("max_new_speak_tokens_per_chunk") && init.config.at("max_new_speak_tokens_per_chunk").is_number_integer()) {
+        octx->max_new_speak_tokens_per_chunk = init.config.at("max_new_speak_tokens_per_chunk").get<int>();
+    }
+    if (init.config.contains("tts_temperature") && init.config.at("tts_temperature").is_number()) {
+        octx->tts_temperature = init.config.at("tts_temperature").get<float>();
+    }
+    if (init.config.contains("temperature") && init.config.at("temperature").is_number()) {
+        params.sampling.temp = init.config.at("temperature").get<float>();
+    }
+    if (init.config.contains("top_p") && init.config.at("top_p").is_number()) {
+        params.sampling.top_p = init.config.at("top_p").get<float>();
+    }
+    if (init.config.contains("top_k") && init.config.at("top_k").is_number_integer()) {
+        params.sampling.top_k = init.config.at("top_k").get<int>();
+    }
+}
 
 // ============================================================================
 // TempMediaFiles helpers
@@ -80,21 +324,228 @@ void TempMediaFiles::cleanup() {
     if (!image_path.empty()) { fs::remove(image_path); image_path.clear(); }
 }
 
+static std::string shell_quote(const std::string & value) {
+    std::string out = "'";
+    for (char c : value) {
+        if (c == '\'') {
+            out += "'\\''";
+        } else {
+            out += c;
+        }
+    }
+    out += "'";
+    return out;
+}
+
+static bool file_nonempty(const std::string & path) {
+    std::error_code ec;
+    return fs::exists(path, ec) && fs::file_size(path, ec) > 0;
+}
+
+struct ExtractedVideoMedia {
+    std::string video_path;
+    std::string audio_path;
+    std::vector<std::string> frame_paths;
+};
+
+// Decode a base64 MP4 (turn_based `video` content item) to a temp file and use
+// ffmpeg to split it into a mono 16k PCM WAV + up to `stack_frames` JPEG frames.
+static ExtractedVideoMedia extract_video_mp4_media(const std::string & video_b64,
+                                                   const std::string & temp_dir,
+                                                   int counter,
+                                                   int stack_frames) {
+    ExtractedVideoMedia out;
+    auto raw = b64_decode(video_b64);
+    if (raw.empty()) {
+        return out;
+    }
+
+    const int n_frames = std::max(1, std::min(stack_frames, 8));
+    fs::path dir = fs::path(temp_dir) / ("video_" + std::to_string(counter));
+    fs::create_directories(dir);
+
+    out.video_path = (dir / "input.mp4").string();
+    {
+        std::ofstream f(out.video_path, std::ios::binary);
+        if (!f) {
+            return out;
+        }
+        f.write(reinterpret_cast<const char *>(raw.data()), raw.size());
+    }
+    if (!file_nonempty(out.video_path)) {
+        return out;
+    }
+
+    std::string audio_path = (dir / "audio.wav").string();
+    std::string audio_cmd =
+        "ffmpeg -y -hide_banner -loglevel error -i " + shell_quote(out.video_path) +
+        " -vn -ac 1 -ar 16000 -c:a pcm_f32le " + shell_quote(audio_path);
+    if (std::system(audio_cmd.c_str()) == 0 && file_nonempty(audio_path)) {
+        out.audio_path = audio_path;
+    }
+
+    std::string frame_pattern = (dir / "frame_%03d.jpg").string();
+    std::string frame_cmd =
+        "ffmpeg -y -hide_banner -loglevel error -i " + shell_quote(out.video_path) +
+        " -an -frames:v " + std::to_string(n_frames) +
+        " -q:v 2 " + shell_quote(frame_pattern);
+    if (std::system(frame_cmd.c_str()) == 0) {
+        for (int i = 1; i <= n_frames; ++i) {
+            char name[32];
+            snprintf(name, sizeof(name), "frame_%03d.jpg", i);
+            std::string frame_path = (dir / name).string();
+            if (file_nonempty(frame_path)) {
+                out.frame_paths.push_back(frame_path);
+            }
+        }
+    }
+
+    return out;
+}
+
+static std::string truncate_for_prompt(const std::string & text, size_t max_chars) {
+    if (text.size() <= max_chars) {
+        return text;
+    }
+    return text.substr(0, max_chars) + "...";
+}
+
+static std::string first_system_text(const std::vector<ParsedMessage> & messages) {
+    std::string text;
+    for (const auto & msg : messages) {
+        if (msg.role != "system" || msg.text.empty()) {
+            continue;
+        }
+        if (!text.empty()) {
+            text += "\n";
+        }
+        text += msg.text;
+    }
+    return text;
+}
+
+// Build the ChatML body for a turn: single-turn → just the last user text;
+// multi-turn → the last up-to-8 non-system messages with role tags preserved
+// (matching the Python backend instead of flattening history into one prompt).
+static std::string build_turn_based_chatml_body(const std::vector<ParsedMessage> & messages,
+                                                const ParsedMessage * last_user_msg) {
+    if (!last_user_msg) {
+        return "";
+    }
+    const std::string last_text = last_user_msg->text;
+    if (last_text.empty()) {
+        return "";
+    }
+
+    int non_system_count = 0;
+    for (const auto & msg : messages) {
+        if (msg.role != "system" && !msg.text.empty()) {
+            non_system_count++;
+        }
+    }
+    if (non_system_count <= 1) {
+        return last_text;
+    }
+
+    std::vector<const ParsedMessage *> tail;
+    tail.reserve(8);
+    for (auto it = messages.rbegin(); it != messages.rend() && (int)tail.size() < 8; ++it) {
+        if (it->role == "system" || it->text.empty()) {
+            continue;
+        }
+        tail.push_back(&(*it));
+    }
+    std::reverse(tail.begin(), tail.end());
+
+    std::string prompt;
+    bool first_content = true;
+    for (const ParsedMessage * msg : tail) {
+        const bool is_last = (msg == last_user_msg);
+        const std::string text = truncate_for_prompt(msg->text, 1200);
+
+        if (first_content) {
+            // stream_prefill(index=0) leaves KV at "<|im_start|>user\n".
+            if (msg->role != "user") {
+                prompt += "<|im_end|>\n<|im_start|>" + msg->role + "\n";
+            }
+            first_content = false;
+        } else {
+            prompt += "<|im_start|>" + msg->role + "\n";
+        }
+
+        prompt += text;
+        if (!is_last) {
+            prompt += "<|im_end|>\n";
+        }
+    }
+    return prompt;
+}
+
+// Pick the system/assistant prompt templates for a turn: TTS path uses the
+// voice-clone (ref-audio) system prompt; text-only path uses a plain system
+// message. Mirrors the Python backend's TTS vs no-TTS chat templates.
+static void configure_turn_based_prompt(omni_context * octx,
+                                        bool use_tts_template,
+                                        const std::string & system_text) {
+    if (!octx) {
+        return;
+    }
+
+    if (use_tts_template) {
+        octx->audio_voice_clone_prompt = "<|im_start|>system\n模仿音频样本的音色并生成新的内容。\n<|audio_start|>";
+        octx->audio_assistant_prompt = "<|audio_end|>你的任务是用这种声音模式来当一个助手。请认真、高质量地回复用户的问题。请用高自然度的方式和用户聊天。你是由面壁智能开发的人工智能助手：面壁小钢炮。<|im_end|>\n<|im_start|>user\n";
+        octx->omni_voice_clone_prompt = "<|im_start|>system\n模仿音频样本的音色并生成新的内容。\n<|audio_start|>";
+        octx->omni_assistant_prompt = "<|audio_end|>你的任务是用这种声音模式来当一个助手。请认真、高质量地回复用户的问题。请用高自然度的方式和用户聊天。<|im_end|>\n<|im_start|>user\n";
+        return;
+    }
+
+    const std::string sys = system_text.empty()
+        ? "你是一个有用的助手。请准确、清晰地回答用户问题。"
+        : system_text;
+
+    // Text-only turn-based chat follows the Python no-TTS path: a normal
+    // system message followed by the first user turn. No voice-clone ref audio.
+    octx->omni_voice_clone_prompt = "<|im_start|>system\n" + sys;
+    octx->omni_assistant_prompt = "<|im_end|>\n<|im_start|>user\n";
+    octx->audio_voice_clone_prompt = octx->omni_voice_clone_prompt;
+    octx->audio_assistant_prompt = octx->omni_assistant_prompt;
+}
+
 // ============================================================================
 // Session-level omni init helper
 // ============================================================================
 
 static omni_context * create_session_octx(common_params & params, const ParsedSessionInit & init,
                                           llama_model * model, llama_context * ctx,
+                                          omni_context *& shared_octx,
                                           const std::string & output_dir) {
     int media_type = 2; // omni
     bool duplex_mode = (init.mode == "full_duplex");
+    // Turn-based sessions may request TTS per input.append. Load the TTS-capable
+    // context up front, then toggle octx->use_tts per request.
+    bool use_tts = true;
 
     // Build params for omni_init
     auto & p = params;
     p.n_predict = 2048;
+    ensure_omni_model_paths(p);
 
-    omni_context * octx = omni_init(&p, media_type, /*use_tts*/true, /*tts_bin_dir*/"", /*tts_gpu_layers*/99,
+    // Reuse the server-owned context if it matches this session's mode (avoids
+    // reloading the model); otherwise tear it down and build a fresh one.
+    if (shared_octx && shared_octx->duplex_mode == duplex_mode && shared_octx->use_tts == use_tts) {
+        reset_octx_for_session(shared_octx, init, output_dir);
+        apply_session_config(p, shared_octx, init);
+        LOG_INF("create_session_octx: reused shared octx, duplex=%d, output_dir=%s\n",
+                duplex_mode, output_dir.c_str());
+        return shared_octx;
+    }
+
+    if (shared_octx) {
+        omni_free(shared_octx);
+        shared_octx = nullptr;
+    }
+
+    omni_context * octx = omni_init(&p, media_type, use_tts, p.tts_bin_dir, /*tts_gpu_layers*/99,
                                      /*token2wav_device*/"gpu:0", duplex_mode,
                                      model, ctx, output_dir);
     if (!octx) {
@@ -104,11 +555,13 @@ static omni_context * create_session_octx(common_params & params, const ParsedSe
 
     octx->async = true;
     octx->duplex_mode = duplex_mode;
+    apply_session_config(p, octx, init);
 
     // Voice clone / system prompt
     if (!init.system_prompt.empty()) {
         octx->omni_assistant_prompt = init.system_prompt;
     }
+    shared_octx = octx;
 
     LOG_INF("create_session_octx: session octx created, duplex=%d, output_dir=%s\n",
             duplex_mode, output_dir.c_str());
@@ -124,10 +577,12 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
                         common_params & params_base,
                         llama_model * model,
                         llama_context * ctx,
+                        omni_context *& shared_octx,
                         std::mutex & octx_mutex) {
     const std::string temp_dir = fs::temp_directory_path() / "omni_ws";
     fs::create_directories(temp_dir);
     int msg_counter = 0;
+    std::vector<std::string> retained_media_files;
 
     // Helper: fail-fast — send session.closed and close WS
     auto fail_fast = [&](const std::string & session_id, const std::string & reason) {
@@ -136,6 +591,10 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
             ws.send(ev);
         }
         session_mgr.close(session_id);
+        for (const auto & path : retained_media_files) {
+            fs::remove(path);
+        }
+        retained_media_files.clear();
         ws.close();
     };
 
@@ -184,27 +643,35 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
 
     std::string session_output_dir = (fs::path(temp_dir) / session_id).string();
 
-    omni_context * octx = create_session_octx(params_base, parsed_init, model, ctx, session_output_dir);
+    omni_context * octx = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(octx_mutex);
+        octx = create_session_octx(params_base, parsed_init, model, ctx, shared_octx, session_output_dir);
+    }
     if (!octx) {
         fail_fast(session_id, "omni_init_failed");
         return;
     }
 
-    // Voice prefill if voice audio provided
-    if (!parsed_init.ref_audio_b64.empty()) {
-        std::string voice_wav = TempMediaFiles::write_audio_wav(parsed_init.ref_audio_b64, temp_dir, msg_counter++);
-        if (voice_wav.empty()) {
+    // Full-duplex requires index=0 prefill before the first frame. This
+    // initializes the system prompt and starts the duplex encoder/LLM pipeline.
+    if (parsed_init.mode == "full_duplex" || !parsed_init.ref_audio_b64.empty()) {
+        std::string voice_wav;
+        if (!parsed_init.ref_audio_b64.empty()) {
+            voice_wav = TempMediaFiles::write_audio_wav(parsed_init.ref_audio_b64, temp_dir, msg_counter++);
+        }
+        if (!parsed_init.ref_audio_b64.empty() && voice_wav.empty()) {
             fail_fast(session_id, "voice_audio_decode_failed");
             return;
         }
         std::lock_guard<std::mutex> lock(octx_mutex);
         if (!stream_prefill(octx, voice_wav, /*img*/"", /*index*/0)) {
             LOG_ERR("WS /backend: voice prefill failed\n");
-            fs::remove(voice_wav);
+            if (!voice_wav.empty()) fs::remove(voice_wav);
             fail_fast(session_id, "voice_prefill_failed");
             return;
         }
-        fs::remove(voice_wav);
+        if (!voice_wav.empty()) fs::remove(voice_wav);
         if (octx->llm_thread_info) {
             octx->llm_thread_info->start = std::chrono::steady_clock::now();
         }
@@ -213,18 +680,15 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
     // Activate session
     {
         std::lock_guard<std::mutex> lock(octx_mutex);
-        if (!session_mgr.activate(session_id, octx, /*owns_octx*/true)) {
+        if (!session_mgr.activate(session_id, octx, /*owns_octx*/false)) {
             LOG_ERR("WS /backend: session activate failed for %s\n", session_id.c_str());
-            omni_free(octx);
             fail_fast(session_id, "activate_failed");
             return;
         }
     }
 
     // Send session.created
-    ProtocolMetrics metrics;
-    metrics.backend = "llama.cpp-omni";
-    send_event(make_session_created(session_id, parsed_init.mode, metrics));
+    send_event(make_session_created(session_id, parsed_init.mode, make_runtime_metrics(octx)));
 
     LOG_INF("WS /backend: session %s activated, mode=%s\n", session_id.c_str(), parsed_init.mode.c_str());
 
@@ -235,15 +699,44 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
         std::string session_id;
         std::string response_id; // updated per-turn
         httplib::ws::WebSocket * ws = nullptr;
+        omni_context * octx = nullptr;
+        std::mutex mtx;
+        std::chrono::steady_clock::time_point response_start = std::chrono::steady_clock::now();
+        // Non-streaming turn-based + TTS: accumulate PCM here and emit it as
+        // response.done.audio (full_audio_b64) instead of streaming deltas.
+        bool accumulate = false;
+        std::vector<float> accum;
     };
     auto audio_state = std::make_shared<AudioCbState>();
     audio_state->session_id = session_id;
     audio_state->ws = &ws;
+    audio_state->octx = octx;
 
     octx->audio_output_cb = [audio_state](const float * samples, int n_samples, int /*sample_rate*/, bool /*is_final*/) {
+        {
+            // Non-streaming: buffer the PCM so it can be returned in
+            // response.done.audio rather than emitted as audio deltas.
+            std::lock_guard<std::mutex> lk(audio_state->mtx);
+            if (audio_state->accumulate) {
+                if (samples && n_samples > 0) {
+                    audio_state->accum.insert(audio_state->accum.end(),
+                                              samples, samples + n_samples);
+                }
+                return;
+            }
+        }
         if (audio_state->ws && audio_state->ws->is_open()) {
+            std::string response_id;
+            std::chrono::steady_clock::time_point response_start;
+            {
+                std::lock_guard<std::mutex> lk(audio_state->mtx);
+                response_id = audio_state->response_id;
+                response_start = audio_state->response_start;
+            }
             std::string b64 = float32_pcm_to_b64(samples, n_samples);
-            json ev = make_audio_delta(audio_state->session_id, audio_state->response_id, b64);
+            ProtocolMetrics metrics = make_runtime_metrics(
+                audio_state->octx, 0.0, 0.0, elapsed_ms(response_start));
+            json ev = make_audio_delta(audio_state->session_id, response_id, b64, metrics);
             audio_state->ws->send(ev.dump());
         }
     };
@@ -252,7 +745,6 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
     // Step 3: Read loop — process input.append messages
     // ================================================================
     std::string raw;
-    std::string response_id_counter; // per-session response counter
     int response_seq = 0;
 
     while (true) {
@@ -289,15 +781,27 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
             return;
         }
 
+        const auto t_request_start = std::chrono::steady_clock::now();
         response_seq++;
         std::string response_id = session_id + "_resp_" + std::to_string(response_seq);
-        audio_state->response_id = response_id; // update for audio callback
+        {
+            std::lock_guard<std::mutex> lk(audio_state->mtx);
+            audio_state->response_id = response_id; // update for audio callback
+            audio_state->response_start = t_request_start;
+        }
 
-        // Branch: full_duplex vs turn_based
-        if (parsed_init.mode == "turn_based" && !parsed_input.messages.is_null()) {
+        // Branch: full_duplex vs turn_based. The input shape MUST match the
+        // session mode (schema §7.4 / network §7): turn_based MUST carry
+        // `messages`, full_duplex MUST NOT. A mismatch is a fatal protocol
+        // violation, not a recoverable branch.
+        if (parsed_init.mode == "turn_based") {
             // ================================================================
             // Turn-based input processing
             // ================================================================
+            if (parsed_input.messages.is_null()) {
+                fail_fast(session_id, "mode_mismatch");
+                return;
+            }
             auto parsed_msgs = parse_messages_array(parsed_input.messages);
             if (parsed_msgs.empty()) {
                 fail_fast(session_id, "empty_messages");
@@ -305,6 +809,9 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
             }
 
             TempMediaFiles tmp_files;
+            std::vector<std::string> extra_image_paths;
+            std::vector<std::string> turn_temp_paths;
+            int turn_vision_slices = 0;
 
             // Images: take all images from the last user message
             const ParsedMessage * last_user_msg = nullptr;
@@ -316,8 +823,9 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
             }
 
             if (last_user_msg) {
+                int input_index = ++msg_counter;
                 for (const auto & img_b64 : last_user_msg->image_b64s) {
-                    std::string ipath = TempMediaFiles::write_image_jpeg(img_b64, temp_dir, msg_counter++);
+                    std::string ipath = TempMediaFiles::write_image_jpeg(img_b64, temp_dir, input_index);
                     if (!ipath.empty()) {
                         tmp_files.image_path = ipath; // last image wins
                     }
@@ -325,32 +833,108 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
                 // Audio: use the first audio from the last user message
                 if (!last_user_msg->audio_b64s.empty()) {
                     tmp_files.audio_path = TempMediaFiles::write_audio_wav(
-                        last_user_msg->audio_b64s[0], temp_dir, msg_counter++);
+                        last_user_msg->audio_b64s[0], temp_dir, input_index);
+                }
+                for (size_t i = 0; i < last_user_msg->video_b64s.size(); ++i) {
+                    const int stack_frames = i < last_user_msg->video_stack_frames.size()
+                                           ? last_user_msg->video_stack_frames[i]
+                                           : 1;
+                    ExtractedVideoMedia video = extract_video_mp4_media(
+                        last_user_msg->video_b64s[i], temp_dir, ++msg_counter, stack_frames);
+                    if (!video.video_path.empty()) {
+                        turn_temp_paths.push_back(video.video_path);
+                    }
+                    if (!video.audio_path.empty() && tmp_files.audio_path.empty()) {
+                        tmp_files.audio_path = video.audio_path;
+                    } else if (!video.audio_path.empty()) {
+                        turn_temp_paths.push_back(video.audio_path);
+                    }
+                    for (const auto & frame_path : video.frame_paths) {
+                        if (tmp_files.image_path.empty()) {
+                            tmp_files.image_path = frame_path;
+                        } else {
+                            extra_image_paths.push_back(frame_path);
+                        }
+                    }
+                    if (video.frame_paths.empty()) {
+                        tmp_files.cleanup();
+                        for (const auto & path : turn_temp_paths) fs::remove(path);
+                        fail_fast(session_id, "video_decode_failed");
+                        return;
+                    }
                 }
             }
 
-            // Build prompt
-            std::string prompt = build_prompt_from_messages(parsed_msgs);
+            // The page opens a fresh backend session for every turn. Match the
+            // Python backend by preserving message roles in ChatML instead of
+            // summarizing history into a single natural-language prompt.
+            const std::string system_text = first_system_text(parsed_msgs);
+            std::string prompt = build_turn_based_chatml_body(parsed_msgs, last_user_msg);
 
-            // Prefill with text + audio + image
+            turn_vision_slices = (tmp_files.image_path.empty() ? 0 : 1) + (int)extra_image_paths.size();
+            double prefill_ms = 0.0;
+            double generate_ms = 0.0;
+            int n_past_before_decode = 0;
+
+            // Prefill with text + audio + image/video frames
             {
+                const auto t_prefill_start = std::chrono::steady_clock::now();
                 std::lock_guard<std::mutex> lock(octx_mutex);
+                if (octx->params) {
+                    octx->params->n_predict = parsed_input.max_new_tokens;
+                }
+                octx->length_penalty = parsed_input.length_penalty;
+                const bool prev_use_tts = octx->use_tts;
+                octx->use_tts = parsed_input.use_tts_template;
+                configure_turn_based_prompt(octx, parsed_input.use_tts_template, system_text);
+                if (!octx->system_prompt_initialized) {
+                    if (!stream_prefill(octx, /*aud*/"", /*img*/"", /*index*/0)) {
+                        octx->use_tts = prev_use_tts;
+                        tmp_files.cleanup();
+                        for (const auto & path : extra_image_paths) fs::remove(path);
+                        for (const auto & path : turn_temp_paths) fs::remove(path);
+                        fail_fast(session_id, "system_prefill_failed");
+                        return;
+                    }
+                }
+                int input_index = msg_counter > 0 ? msg_counter : ++msg_counter;
                 if (!stream_prefill(octx, tmp_files.audio_path, tmp_files.image_path,
-                                    msg_counter, parsed_input.max_slice_nums, prompt)) {
+                                    input_index, parsed_input.max_slice_nums, prompt)) {
+                    octx->use_tts = prev_use_tts;
                     tmp_files.cleanup();
+                    for (const auto & path : extra_image_paths) fs::remove(path);
+                    for (const auto & path : turn_temp_paths) fs::remove(path);
                     fail_fast(session_id, "prefill_failed");
                     return;
                 }
+                for (const auto & image_path : extra_image_paths) {
+                    if (!stream_prefill(octx, /*aud*/"", image_path,
+                                        ++msg_counter, parsed_input.max_slice_nums, /*text*/"")) {
+                        octx->use_tts = prev_use_tts;
+                        tmp_files.cleanup();
+                        for (const auto & path : extra_image_paths) fs::remove(path);
+                        for (const auto & path : turn_temp_paths) fs::remove(path);
+                        fail_fast(session_id, "video_frame_prefill_failed");
+                        return;
+                    }
+                }
+                octx->use_tts = prev_use_tts;
+                n_past_before_decode = octx->n_past;
+                prefill_ms = elapsed_ms(t_prefill_start);
             }
 
-            tmp_files.cleanup();
-            msg_counter++;
+            if (!tmp_files.audio_path.empty()) retained_media_files.push_back(tmp_files.audio_path);
+            if (!tmp_files.image_path.empty()) retained_media_files.push_back(tmp_files.image_path);
+            for (const auto & path : extra_image_paths) retained_media_files.push_back(path);
+            for (const auto & path : turn_temp_paths) retained_media_files.push_back(path);
+            tmp_files.audio_path.clear();
+            tmp_files.image_path.clear();
 
             // Decode
             bool streaming = parsed_input.streaming;
             std::string full_text;
+            std::string utf8_pending;
             std::string full_audio_b64;
-            bool had_listen = false;
 
             {
                 std::lock_guard<std::mutex> lk(octx->text_mtx);
@@ -359,6 +943,18 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
                 octx->text_streaming = true;
             }
 
+            const bool prev_use_tts = octx->use_tts;
+            octx->use_tts = parsed_input.use_tts_template;
+
+            // Non-streaming + TTS: collect PCM during decode/drain and return it
+            // in response.done.audio. Streaming keeps emitting audio deltas.
+            {
+                std::lock_guard<std::mutex> lk(audio_state->mtx);
+                audio_state->accumulate = !streaming;
+                audio_state->accum.clear();
+            }
+
+            const auto t_generate_start = std::chrono::steady_clock::now();
             std::thread decode_thread([octx, debug_dir = session_output_dir]() {
                 stream_decode(octx, debug_dir, -1);
             });
@@ -383,17 +979,29 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
 
                 if (!frag.empty()) {
                     if (frag == "__IS_LISTEN__") {
-                        if (streaming) {
-                            send_event(make_listen_delta(session_id, response_id));
-                        }
-                        had_listen = true;
+                        // Express listen via the kind=listen delta channel
+                        // (schema §5.1 / network §6.3) in both streaming and
+                        // non-streaming (non-streaming deltas allowed per
+                        // network §4.2). response.done.reason stays turn_end.
+                        send_event(make_listen_delta(
+                            session_id, response_id,
+                            make_runtime_metrics(octx, prefill_ms,
+                                                 elapsed_ms(t_generate_start),
+                                                 elapsed_ms(t_request_start), 0,
+                                                 turn_vision_slices)));
                         break;
                     } else if (frag == "__END_OF_TURN__") {
                         // handled by response.done
                     } else {
-                        full_text += frag;
-                        if (streaming) {
-                            send_event(make_text_delta(session_id, response_id, frag));
+                        const std::string text = sanitize_utf8_stream(utf8_pending, frag);
+                        full_text += text;
+                        if (streaming && !text.empty()) {
+                            send_event(make_text_delta(
+                                session_id, response_id, text,
+                                make_runtime_metrics(octx, prefill_ms,
+                                                     elapsed_ms(t_generate_start),
+                                                     elapsed_ms(t_request_start), 0,
+                                                     turn_vision_slices)));
                         }
                     }
                 }
@@ -405,41 +1013,111 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
             }
 
             if (decode_thread.joinable()) decode_thread.join();
+            generate_ms = elapsed_ms(t_generate_start);
+            {
+                const std::string text = sanitize_utf8_stream(utf8_pending, "", true);
+                full_text += text;
+                if (streaming && !text.empty()) {
+                    send_event(make_text_delta(
+                        session_id, response_id, text,
+                        make_runtime_metrics(octx, prefill_ms, generate_ms,
+                                             elapsed_ms(t_request_start), 0,
+                                             turn_vision_slices)));
+                }
+            }
+            if (parsed_input.use_tts_template) {
+                if (!omni_duplex_drain_tts_audio(octx, /*max_wait_ms*/120000, /*idle_ms*/3000)) {
+                    LOG_WRN("WS /backend: timed out waiting for TTS audio drain for session %s\n",
+                            session_id.c_str());
+                }
+            }
+            octx->use_tts = prev_use_tts;
+
+            // Non-streaming: hand the buffered PCM to response.done.audio and
+            // stop accumulating so later turns / full-duplex stream normally.
+            {
+                std::lock_guard<std::mutex> lk(audio_state->mtx);
+                if (audio_state->accumulate && !audio_state->accum.empty()) {
+                    full_audio_b64 = float32_pcm_to_b64(
+                        audio_state->accum.data(), audio_state->accum.size());
+                }
+                audio_state->accumulate = false;
+                audio_state->accum.clear();
+            }
 
             // Send response.done (streaming may have sent deltas already, but done is always sent)
+            ProtocolMetrics done_metrics = make_runtime_metrics(
+                octx, prefill_ms, generate_ms, elapsed_ms(t_request_start),
+                std::max(0, octx->n_past - n_past_before_decode), turn_vision_slices);
+            if (parsed_input.use_tts_template) {
+                done_metrics.cost_tts_ms = std::max(
+                    0.0, done_metrics.wall_clock_ms - prefill_ms - generate_ms);
+            }
+            // reason is a turn-completion reason (network §6.6); the listen
+            // decision is conveyed via the kind=listen delta above, not here.
             send_event(make_response_done(session_id, response_id, full_text,
-                                          full_audio_b64, had_listen ? "listen" : "turn_end"));
+                                          full_audio_b64, "turn_end",
+                                          done_metrics));
 
         } else {
             // ================================================================
             // Full-duplex input processing
             // ================================================================
+            // full_duplex MUST NOT carry turn_based `messages` (schema §7.4).
+            if (!parsed_input.messages.is_null()) {
+                fail_fast(session_id, "mode_mismatch");
+                return;
+            }
+            if (parsed_input.audio_b64.empty()) {
+                fail_fast(session_id, "missing_audio");
+                return;
+            }
+
             TempMediaFiles tmp_files;
+            int input_index = ++msg_counter;
+            double prefill_ms = 0.0;
+            int turn_vision_slices = parsed_input.video_frames_b64.empty() ? 0 : 1;
 
             // Write audio to temp WAV
             if (!parsed_input.audio_b64.empty()) {
                 tmp_files.audio_path = TempMediaFiles::write_audio_wav(
-                    parsed_input.audio_b64, temp_dir, msg_counter++);
+                    parsed_input.audio_b64, temp_dir, input_index);
             }
 
             // Write first video frame to temp image
             if (!parsed_input.video_frames_b64.empty()) {
                 tmp_files.image_path = TempMediaFiles::write_image_jpeg(
-                    parsed_input.video_frames_b64[0], temp_dir, msg_counter++);
+                    parsed_input.video_frames_b64[0], temp_dir, input_index);
             }
 
             // Prefill
             {
+                const auto t_prefill_start = std::chrono::steady_clock::now();
                 std::lock_guard<std::mutex> lock(octx_mutex);
                 if (!stream_prefill(octx, tmp_files.audio_path, tmp_files.image_path,
-                                    msg_counter, parsed_input.max_slice_nums)) {
+                                    input_index, parsed_input.max_slice_nums)) {
                     tmp_files.cleanup();
                     fail_fast(session_id, "prefill_failed");
                     return;
                 }
+                prefill_ms = elapsed_ms(t_prefill_start);
             }
 
-            tmp_files.cleanup();
+            if (!tmp_files.audio_path.empty()) retained_media_files.push_back(tmp_files.audio_path);
+            if (!tmp_files.image_path.empty()) retained_media_files.push_back(tmp_files.image_path);
+            tmp_files.audio_path.clear();
+            tmp_files.image_path.clear();
+
+            // force_listen: caller forces this step to LISTEN — skip decoding
+            // and immediately report a listen delta, then wait for next input.
+            if (parsed_input.force_listen) {
+                send_event(make_listen_delta(
+                    session_id, response_id,
+                    make_runtime_metrics(octx, prefill_ms, 0.0,
+                                         elapsed_ms(t_request_start), 0,
+                                         turn_vision_slices)));
+                continue;
+            }
 
             // Decode: start background thread, poll text_queue on this thread
             std::string debug_dir = session_output_dir;
@@ -452,12 +1130,14 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
                 octx->text_streaming = true;
             }
 
+            const auto t_generate_start = std::chrono::steady_clock::now();
             std::thread decode_thread([octx, debug_dir]() {
                 stream_decode(octx, debug_dir, -1);
             });
 
             // Collect full text for response.done
             std::string full_text;
+            std::string utf8_pending;
 
             // Poll text_queue
             while (true) {
@@ -481,14 +1161,27 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
                 if (!frag.empty()) {
                     if (frag == "__IS_LISTEN__") {
                         // Model switched to listen
-                        send_event(make_listen_delta(session_id, response_id));
+                        send_event(make_listen_delta(
+                            session_id, response_id,
+                            make_runtime_metrics(octx, prefill_ms,
+                                                 elapsed_ms(t_generate_start),
+                                                 elapsed_ms(t_request_start), 0,
+                                                 turn_vision_slices)));
                         break; // Done for this input
                     } else if (frag == "__END_OF_TURN__") {
                         // Turn ended — will be handled by response.done
                     } else {
                         // Text delta
-                        full_text += frag;
-                        send_event(make_text_delta(session_id, response_id, frag));
+                        const std::string text = sanitize_utf8_stream(utf8_pending, frag);
+                        full_text += text;
+                        if (!text.empty()) {
+                            send_event(make_text_delta(
+                                session_id, response_id, text,
+                                make_runtime_metrics(octx, prefill_ms,
+                                                     elapsed_ms(t_generate_start),
+                                                     elapsed_ms(t_request_start), 0,
+                                                     turn_vision_slices)));
+                        }
                     }
                 }
 
@@ -506,9 +1199,18 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
             if (decode_thread.joinable()) {
                 decode_thread.join();
             }
-
-            // Send response.done
-            send_event(make_response_done(session_id, response_id, full_text, /*audio*/"", "turn_end"));
+            {
+                const std::string text = sanitize_utf8_stream(utf8_pending, "", true);
+                if (!text.empty()) {
+                    full_text += text;
+                    send_event(make_text_delta(
+                        session_id, response_id, text,
+                        make_runtime_metrics(octx, prefill_ms,
+                                             elapsed_ms(t_generate_start),
+                                             elapsed_ms(t_request_start), 0,
+                                             turn_vision_slices)));
+                }
+            }
         }
     }
 
@@ -523,8 +1225,29 @@ cleanup:
     std::string close_ev = make_session_closed(session_id, "client_disconnected").dump();
     ws.send(close_ev);
 
-    // Close session — frees omni_context
-    session_mgr.close(session_id);
+    // On disconnect, stop inference and recycle the shared context (via
+    // omni_prepare_for_reuse) rather than freeing it — the model stays loaded
+    // for the next session. Then drop the session and clean up temp media.
+    {
+        std::lock_guard<std::mutex> lock(octx_mutex);
+        OmniSession * session = session_mgr.get(session_id);
+        if (session && session->octx) {
+            session->octx->break_event = true;
+            {
+                std::lock_guard<std::mutex> lk(session->octx->text_mtx);
+                session->octx->text_queue.clear();
+                session->octx->text_done_flag = true;
+            }
+            session->octx->text_cv.notify_all();
+            omni_prepare_for_reuse(session->octx);
+        }
+        session_mgr.close(session_id);
+    }
+
+    for (const auto & path : retained_media_files) {
+        fs::remove(path);
+    }
+    retained_media_files.clear();
 
     ws.close();
 }

--- a/tools/server/ws_handler.cpp
+++ b/tools/server/ws_handler.cpp
@@ -1,3 +1,15 @@
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <deque>
+#include <filesystem>
+#include <fstream>
+#include <thread>
+#include <vector>
+
+#include <cpp-httplib/httplib.h>
+
 #include "ws_handler.h"
 #include "session.h"
 #include "protocol.h"
@@ -7,18 +19,6 @@
 #include "log.h"
 #include "audition.h"
 #include "vision.h"
-
-#include <cpp-httplib/httplib.h>
-
-#include <thread>
-#include <filesystem>
-#include <fstream>
-#include <chrono>
-#include <deque>
-#include <vector>
-#include <algorithm>
-#include <cstdlib>
-#include <cstdio>
 
 namespace fs = std::filesystem;
 
@@ -285,6 +285,7 @@ std::string TempMediaFiles::write_audio_wav(const std::string & b64, const std::
     auto pcm = b64_to_float32_pcm(b64);
     if (pcm.empty()) return "";
 
+    // Backend protocol audio payloads are mono float32 PCM in this path.
     int n_samples = static_cast<int>(pcm.size());
     int sample_rate = 16000;
     int n_channels = 1;
@@ -686,6 +687,12 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
             fail_fast(session_id, "activate_failed");
             return;
         }
+        session_mgr.set_close_callback(session_id, [&ws, session_id]() {
+            // Preserve protocol ordering for older runtimes: emit session.closed
+            // before the transport close wakes a blocked ws.read().
+            ws.send(make_session_closed(session_id, "client_closed").dump());
+            ws.close(httplib::ws::CloseStatus::Normal, "client_closed");
+        });
     }
 
     // Send session.created

--- a/tools/server/ws_handler.cpp
+++ b/tools/server/ws_handler.cpp
@@ -131,14 +131,15 @@ static std::string parent_dir(const std::string & path) {
     return pos == std::string::npos ? "." : path.substr(0, pos);
 }
 
-// Fill vision/audio/TTS sub-model paths from --omni-model-dir (or, as a
-// fallback, the directory of the main -m model) when they weren't set explicitly.
+// Derive vision/audio/TTS sub-model paths from the directory of the main -m
+// model (same convention as omni-cli's resolve_model_paths): the llm is the
+// only quantized file, the F16 sub-models live in fixed sub-dirs next to it,
+// so the -m path is enough to locate them all. Only fills paths left unset.
 static void ensure_omni_model_paths(common_params & params) {
-    std::string root = params.omni_model_dir;
-    if (root.empty() && !params.model.path.empty()) {
-        root = parent_dir(params.model.path);
-        params.omni_model_dir = root;
+    if (params.model.path.empty()) {
+        return;
     }
+    const std::string root = parent_dir(params.model.path);
     if (root.empty()) {
         return;
     }

--- a/tools/server/ws_handler.h
+++ b/tools/server/ws_handler.h
@@ -25,6 +25,7 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
                        common_params & params_base,
                        llama_model * model,
                        llama_context * ctx,
+                       omni_context *& shared_octx,  // server-owned, reused across sessions
                        std::mutex & octx_mutex);
 
 // ============================================================================


### PR DESCRIPTION
…otocol

## Overview

将服务端（llama.cpp-omni）适配为遵循 backend 协议的后端。主要内容：
- WebSocket `/backend` 通道 + HTTP 一元 `close` 接口，覆盖完整会话生命周期（`session.created` / `input.append` / `response.output.delta`（text|audio|listen）/ `response.done` / `session.closed`）并附带运行时 metrics。
- 输入解析支持 文本 / 图像 / 音频 以及 MP4 视频（含抽帧），兼容字段别名与 data-URL 前缀。
- 跨会话复用服务端持有的 `omni_context`（每会话仅重置状态），避免每会话重新初始化模型导致的 OOM；`omni_prepare_for_reuse()` 在 close/断连时停止并 join 推理线程、清空队列。
- 新增 `--omni-model-dir`，自动推导 视觉/音频/TTS 子模型路径。
- `turn_based`：保留角色的 ChatML 历史，区分 纯文本 与 TTS/克隆音 提示词，并剥离 think 控制 token。
- 非流式 + TTS 时音频经 `response.done.audio` 返回；流式则持续发送 audio delta。`listen` 在两种模式下都以 delta 表达。
- 严格的 mode/输入形状校验（不匹配则 fail-fast `mode_mismatch`），以及面向文本 delta 的流式 UTF-8 清洗。

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
