### PR TITLE
Feat/vision batch encode sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,40 @@ cmake --build build --target llama-omni-cli -j
 | `-c, --ctx-size <n>` | Context size (default: 4096) |
 | `-ngl <n>` | Number of GPU layers (default: 99) |
 | `--no-tts` | Disable TTS output |
+| `--vision-batch-encode` | Encode same-size image slices in one batched pass (off by default; see below) |
 | `--test <prefix> <n>` | Run test with audio files |
+| `--bench-vision <img>` | Benchmark serial vs batched vision encoding on an image, then exit |
+
+### Vision Batch Encoding (optional optimization)
+
+For high-resolution / high-refresh inputs, an image is split into one overview plus
+many equally-sized slices, and each slice is encoded by the ViT. By default these
+slices are encoded **one at a time** (serial). `--vision-batch-encode` instead packs
+all same-size slices into a **single batched** ViT pass, which is significantly faster
+when there are many slices.
+
+- **When to enable**: large images / high-res / high-refresh modes, i.e. cases that
+  produce many slices. On a 4821×2259 image this gives roughly **1.5–2.3× faster**
+  vision encoding (more slices → larger speedup).
+- **Why it's off by default**: batched cuBLAS GEMM uses a different accumulation order
+  than per-slice GEMM, so the embeddings are *numerically very close but not bit-exact*
+  (avg diff ~1e-2). It also uses somewhat more VRAM. It is therefore opt-in rather than
+  a universal default.
+
+```bash
+# Enable the optimization
+./build/bin/llama-omni-cli \
+    -m /path/to/MiniCPM-o-4_5-gguf/MiniCPM-o-4_5-Q4_K_M.gguf \
+    --omni --vision-batch-encode
+
+# Benchmark serial vs batched (prints a per-slice-count comparison table)
+./build/bin/llama-omni-cli \
+    -m /path/to/MiniCPM-o-4_5-gguf/MiniCPM-o-4_5-Q4_K_M.gguf \
+    --bench-vision /path/to/large_image.png
+```
+
+Programmatically the same switch is exposed via `common_params.vpm_batch_encode`
+(applied in `omni_init`) and `vision_set_batch_encode(ctx_vision, true)`.
 
 ### Output
 

--- a/common/common.h
+++ b/common/common.h
@@ -577,6 +577,7 @@ struct common_params {
     std::string apm_model                = ""; // audio encoder GGUF
     std::string vpm_model                = ""; // vision encoder GGUF
     std::string projector_model          = ""; // projector GGUF
+    bool vpm_batch_encode                = false; // batch-encode same-size vision slices (off by default; helps large/high-res images)
 
     // Apple Neural Engine (CoreML) support
     std::string vision_coreml_model_path     = ""; // path to CoreML .mlmodelc for vision ANE

--- a/tools/omni/omni-cli.cpp
+++ b/tools/omni/omni-cli.cpp
@@ -68,6 +68,8 @@ static void show_usage(const char * prog_name) {
         "  --vision-coreml <path>   Path to CoreML model (.mlmodelc), required when backend=coreml\n"
         "  --t2w-coreml <path>  Enable token2wav CoreML backend (DiT on CoreML, encoder on GPU)\n"
         "                        Use 'auto' to auto-discover CoreML model in model dir\n"
+        "  --vision-batch-encode  Enable batched encoding of same-size vision slices\n"
+        "                          (off by default; helps large / high-res / high-refresh images)\n"
         "  --test <prefix> <n> Run test case with data prefix and count\n"
         "  --bench-vision <img> Benchmark serial vs batched vision encoding\n"
         "  -h, --help          Show this help message\n\n"
@@ -218,6 +220,7 @@ int main(int argc, char ** argv) {
     int media_type = 1;     // 1=audio only, 2=omni (audio+vision)
     bool use_tts = true;
     bool run_test = false;
+    bool vision_batch_encode = false;  // 多 slice 批量编码优化（默认关闭）
     std::string test_audio_prefix;
     int test_count = 0;
     
@@ -271,6 +274,9 @@ int main(int argc, char ** argv) {
         }
         else if (arg == "--t2w-coreml" && i + 1 < argc) {
             token2wav_coreml_model_path = argv[++i];
+        }
+        else if (arg == "--vision-batch-encode") {
+            vision_batch_encode = true;
         }
         else if (arg == "--test" && i + 2 < argc) {
             run_test = true;
@@ -359,6 +365,7 @@ int main(int argc, char ** argv) {
         params.vision_coreml_model_path = vision_coreml_model_path;
     }
     params.token2wav_coreml_model_path = token2wav_coreml_model_path;
+    params.vpm_batch_encode = vision_batch_encode;
     params.n_ctx = n_ctx;
     params.n_gpu_layers = n_gpu_layers;
     
@@ -378,6 +385,7 @@ int main(int argc, char ** argv) {
     printf("  Context size: %d\n", n_ctx);
     printf("  GPU layers: %d\n", n_gpu_layers);
     printf("  Vision backend: %s\n", vision_backend.c_str());
+    printf("  Vision batch encode: %s\n", vision_batch_encode ? "enabled" : "disabled");
     if (vision_backend == "coreml") {
         printf("  Vision CoreML: %s\n", vision_coreml_model_path.c_str());
     }

--- a/tools/omni/omni.cpp
+++ b/tools/omni/omni.cpp
@@ -465,8 +465,10 @@ static bool encode_image_with_vision_chunks(vision_ctx * ctx_vision, int n_threa
 
     // entry[0] is the overview image; entry[1..n] are slices (all same size)
     // strategy: encode overview separately, batch all slices together
+    // 批量编码优化由 vision_set_batch_encode 控制（默认关闭）。该优化只在
+    // 大图/高清高刷等 slice 数较多时收益明显，并非通用，因此需显式开启。
     const int n_slices = n_total - 1;
-    const bool use_batched = (n_slices > 1);
+    const bool use_batched = vision_get_batch_encode(ctx_vision) && (n_slices > 1);
 
     // 1) encode the overview image (entry 0)
     {
@@ -508,15 +510,19 @@ static bool encode_image_with_vision_chunks(vision_ctx * ctx_vision, int n_threa
 
             LOG_INF("%s: %d slices batch-encoded in %8.2f ms\n", __func__, n_slices, (ggml_time_us() - t_batch_us) / 1000.0);
         } else {
-            // single slice: encode directly
+            // serial path: encode every slice individually (entries[1..n_total-1])
             const int64_t t_step_us = ggml_time_us();
-            vision_chunks[1].resize(n_embd * n_tokens);
-            bool encoded = vision_image_encode(ctx_vision, n_threads, img_res_v.entries[1].get(), vision_chunks[1].data());
-            if (!encoded) {
-                LOG_ERR("Unable to encode slice\n");
-                return false;
+            for (int i = 1; i < n_total; i++) {
+                vision_chunks[i].resize(n_embd * n_tokens);
+                bool encoded = vision_image_encode(ctx_vision, n_threads, img_res_v.entries[i].get(), vision_chunks[i].data());
+                if (!encoded) {
+                    // entries[i] is the i-th slice (entry 0 is the overview), so the
+                    // 1-based slice number equals i, out of n_slices total.
+                    LOG_ERR("Unable to encode slice %d of %d\n", i, n_slices);
+                    return false;
+                }
             }
-            LOG_INF("%s: 1 slice encoded in %8.2f ms\n", __func__, (ggml_time_us() - t_step_us) / 1000.0);
+            LOG_INF("%s: %d slice(s) encoded serially in %8.2f ms\n", __func__, n_slices, (ggml_time_us() - t_step_us) / 1000.0);
         }
     }
 
@@ -530,18 +536,16 @@ static bool encode_image_with_vision_chunks(vision_ctx * ctx_vision, int n_threa
     return true;
 }
 
-bool vision_image_load_from_bytes(const unsigned char * bytes, size_t bytes_length, struct vision_image_u8 * img);
-
 static int query_gpu_memory_used_mb(int device_id = 0) {
-    char cmd[256];
-    snprintf(cmd, sizeof(cmd),
-             "nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits -i %d 2>/dev/null", device_id);
-    FILE * fp = popen(cmd, "r");
-    if (!fp) return -1;
-    int mb = -1;
-    if (fscanf(fp, "%d", &mb) != 1) mb = -1;
-    pclose(fp);
-    return mb;
+#ifdef GGML_USE_CUDA
+    size_t free_bytes = 0, total_bytes = 0;
+    ggml_backend_cuda_get_device_memory(device_id, &free_bytes, &total_bytes);
+    if (total_bytes == 0) return -1;
+    return (int)((total_bytes - free_bytes) / (1024 * 1024));
+#else
+    (void) device_id;
+    return -1;
+#endif
 }
 
 void omni_bench_vision(struct vision_ctx * ctx_vision, int n_threads, const char * image_path) {
@@ -573,6 +577,8 @@ void omni_bench_vision(struct vision_ctx * ctx_vision, int n_threads, const char
     LOG_INF("Per-slice: %d embd x %d tokens = %d floats (%.1f MB)\n",
             n_embd, n_tokens, per_image_floats, per_image_floats * 4.0f / 1048576.0f);
     LOG_INF("Baseline VRAM: %d MB\n", baseline_vram);
+    LOG_INF("NOTE: VRAM figures are device-wide (cudaMemGetInfo), single-point samples, "
+            "NOT per-process peak; they include other processes on the same GPU.\n");
     LOG_INF("Bench runs per config: %d\n\n", bench_runs);
 
     struct bench_result {
@@ -708,6 +714,7 @@ void omni_bench_vision(struct vision_ctx * ctx_vision, int n_threads, const char
     }
     LOG_INF("================================================================\n");
     LOG_INF("Baseline VRAM (model loaded, no encoding): %d MB\n", baseline_vram);
+    LOG_INF("VRAM_S/VRAM_B are device-wide single-point samples (not per-process peak).\n");
     LOG_INF("================================================================\n\n");
 }
 
@@ -4249,6 +4256,11 @@ struct omni_context * omni_init(struct common_params * params, int media_type, b
         const char * vision_path = ctx_omni->params->vpm_model.c_str();
         auto * ctx_vision = vision_init(vision_path, vision_context_params{true, GGML_LOG_LEVEL_INFO, nullptr});
         ctx_omni->ctx_vision = ctx_vision;
+
+        // 🔧 [batch encode 开关] 由 common_params 控制（默认关闭）
+        if (ctx_vision) {
+            vision_set_batch_encode(ctx_vision, ctx_omni->params->vpm_batch_encode);
+        }
 
         // Set CoreML model path if available (for vision ANE acceleration)
         // Note: .mlmodelc is a directory, not a file, so use stat instead of ifstream

--- a/tools/omni/vision.cpp
+++ b/tools/omni/vision.cpp
@@ -207,6 +207,11 @@ struct vision_ctx {
     // 🔧 [高清模式] 运行时覆盖 max_slice_nums，-1 表示使用模型默认值
     int max_slice_nums_override = -1;
 
+    // 🔧 [batch encode 开关] 是否对多个尺寸相同的 slice 启用批量编码优化。
+    // 默认 false（关闭）—— 该优化只在大图/高清高刷等 slice 数较多时收益明显，
+    // 并非通用场景，因此需要显式开启。
+    bool batch_encode = false;
+
     // CoreML / ANE model path
     std::string coreml_model_path;
 
@@ -2554,6 +2559,18 @@ void vision_set_max_slice_nums(struct vision_ctx * ctx, int max_slice_nums) {
         ctx->max_slice_nums_override = max_slice_nums;
         LOG_INF("%s: max_slice_nums_override set to %d\n", __func__, max_slice_nums);
     }
+}
+
+// 🔧 [batch encode 开关] 设置/读取多 slice 批量编码优化
+void vision_set_batch_encode(struct vision_ctx * ctx, bool enable) {
+    if (ctx) {
+        ctx->batch_encode = enable;
+        LOG_INF("%s: vision batch encode %s\n", __func__, enable ? "enabled" : "disabled");
+    }
+}
+
+bool vision_get_batch_encode(const struct vision_ctx * ctx) {
+    return ctx ? ctx->batch_encode : false;
 }
 
 //

--- a/tools/omni/vision.h
+++ b/tools/omni/vision.h
@@ -93,6 +93,9 @@ struct vision_image_u8        * vision_image_u8_init (void);
 struct vision_image_f32       * vision_image_f32_init(void);
 struct vision_image_f32_batch * vision_image_f32_batch_init(void);
 
+// decode an encoded image (PNG/JPEG/...) from memory into a vision_image_u8
+bool vision_image_load_from_bytes(const unsigned char * bytes, size_t bytes_length, struct vision_image_u8 * img);
+
 // vision query
 int vision_n_output_tokens(const struct vision_ctx * ctx);
 int vision_n_mmproj_embd(const struct vision_ctx * ctx);
@@ -103,6 +106,11 @@ bool vision_image_preprocess(struct vision_ctx * ctx, const struct vision_image_
 // vision forward
 bool vision_image_encode      (struct vision_ctx * ctx, int n_threads, struct vision_image_f32 * img, float * vec);
 bool vision_image_batch_encode(struct vision_ctx * ctx, int n_threads, const struct vision_image_f32_batch * imgs, float * vec);
+
+// batch encode 开关：是否对多个尺寸相同的 slice 启用批量编码优化
+// 默认关闭；只有大图/高清高刷等 slice 数较多的场景才建议开启
+void vision_set_batch_encode(struct vision_ctx * ctx, bool enable);
+bool vision_get_batch_encode(const struct vision_ctx * ctx);
 
 // CoreML / ANE support
 void vision_set_coreml_model_path(struct vision_ctx * ctx, const char * coreml_model_path);


### PR DESCRIPTION
## What

Re-applies the ViT slice batch-encoding optimization on top of current `master` and makes it a controllable, opt-in switch.

A high-res image is split into 1 overview + N equally-sized slices. Today each slice is encoded by the ViT one at a time (serial). This PR adds a path that packs all same-size slices into a single batched ViT pass, which is much faster when there are many slices (large / high-res / high-refresh inputs).

## Switch (off by default)

The optimization is disabled by default and gated behind a switch:

- CLI: `--vision-batch-encode`
- `common_params.vpm_batch_encode` (applied in `omni_init`)
- `vision_ctx.batch_encode` + `vision_set_batch_encode()` / `vision_get_batch_encode()`

When off, `encode_image_with_vision_chunks` keeps the original serial path.

## Why off by default

Batched cuBLAS GEMM uses a different accumulation order than per-slice GEMM, so the embeddings are numerically very close but not bit-exact (avg diff ~1e-2), and it uses somewhat more VRAM. It is a win for large images, not universally, so it is opt-in.

## Benchmark (RTX 4090, 4821×2259 image, via `--bench-vision`)

| slices | serial (ms) | batched (ms) | speedup |
|-------:|------------:|-------------:|--------:|
| 2      | 143.3       | 95.4         | 1.50x   |
| 8      | 541.7       | 248.7        | 2.18x   |
| 20     | 1322.2      | 589.3        | 2.24x   |
| 36     | 2465.3      | 1051.3       | 2.35x   |

avg diff between serial and batched output ~1e-2.

## Notes

- The CUDA `k_compute_batched_ptrs` launch fix from the original branch is dropped,
  because `master` already handles large batches via a 2D grid.
- Adds `omni_bench_vision` / `--bench-vision` to compare serial vs batched and verify
  output parity.
- Docs updated in README (CLI options + a "Vision Batch Encoding" section).

## Test

- Built `llama-omni-cli` with CUDA.
- Ran `--bench-vision` (table above); output parity verified.