### PR TITLE
fix(server): align omni backend protocol completion and model path resolution

### DIFF
--- a/tools/server/protocol.h
+++ b/tools/server/protocol.h
@@ -58,7 +58,7 @@ json make_listen_delta(const std::string & session_id,
                        const std::string & response_id = "",
                        const ProtocolMetrics & metrics = {});
 
-// response.done — turn_based response complete
+// response.done — semantic response complete
 // full_text: complete generated text (accumulated from deltas)
 // audio_base64: full audio if TTS enabled, empty/absent if not
 json make_response_done(const std::string & session_id,

--- a/tools/server/server-omni.cpp
+++ b/tools/server/server-omni.cpp
@@ -52,6 +52,34 @@ static bool server_sent_event(httplib::DataSink & sink, const json & ev) {
     return sink.write(str.data(), str.size());
 }
 
+static std::string parent_dir(const std::string & path) {
+    const size_t pos = path.find_last_of("/\\");
+    return pos == std::string::npos ? "." : path.substr(0, pos);
+}
+
+static bool ensure_omni_model_paths_from_llm(common_params & params) {
+    if (params.model.path.empty()) {
+        return false;
+    }
+    const std::string root = parent_dir(params.model.path);
+    if (root.empty()) {
+        return false;
+    }
+    if (params.vpm_model.empty()) {
+        params.vpm_model = root + "/vision/MiniCPM-o-4_5-vision-F16.gguf";
+    }
+    if (params.apm_model.empty()) {
+        params.apm_model = root + "/audio/MiniCPM-o-4_5-audio-F16.gguf";
+    }
+    if (params.tts_model.empty()) {
+        params.tts_model = root + "/tts/MiniCPM-o-4_5-tts-F16.gguf";
+    }
+    if (params.tts_bin_dir.empty()) {
+        params.tts_bin_dir = root + "/tts";
+    }
+    return true;
+}
+
 struct omni_server_state {
     omni_context * octx = nullptr;    // WS backend uses this as shared_octx
     std::mutex octx_mutex;            // protects omni_context lifecycle + prefill/decode entry
@@ -119,8 +147,6 @@ int main(int argc, char ** argv) {
         int media_type = data.value("msg_type", data.value("media_type", 2));
         bool use_tts   = data.value("use_tts", true);
         bool duplex_mode = data.value("duplex_mode", false);
-        std::string model_dir  = data.value("model_dir", "./tools/omni/convert/gguf/");
-        std::string tts_bin_dir = data.value("tts_bin_dir", model_dir + "/tts");
         int tts_gpu_layers = data.value("tts_gpu_layers", 100);
         std::string token2wav_device = data.value("token2wav_device", "gpu:0");
         std::string output_dir = data.value("output_dir", "./tools/omni/output");
@@ -138,18 +164,12 @@ int main(int argc, char ** argv) {
             return true;
         };
 
-        // Resolve omni model paths from `model_dir` (parity with old feat/web-demo
-        // server.cpp). common_params has no CLI parser for vpm/apm/tts paths,
-        // so they must be filled in here; otherwise omni_init() inside hits
-        // `apm_model.empty()` and returns NULL.
-        std::string model_dir_norm = model_dir;
-        if (!model_dir_norm.empty() &&
-            model_dir_norm.back() != '/' && model_dir_norm.back() != '\\') {
-            model_dir_norm += '/';
+        // Keep legacy HTTP aligned with /backend: the LLM path (-m) anchors the
+        // fixed MiniCPM-o sub-model layout; request model_dir is ignored.
+        if (!ensure_omni_model_paths_from_llm(params)) {
+            res_error(res, format_error_response("LLM model path (-m) is required to derive omni model paths"));
+            return;
         }
-        params.vpm_model = model_dir_norm + "vision/MiniCPM-o-4_5-vision-F16.gguf";
-        params.apm_model = model_dir_norm + "audio/MiniCPM-o-4_5-audio-F16.gguf";
-        params.tts_model = model_dir_norm + "tts/MiniCPM-o-4_5-tts-F16.gguf";
 
         if (!check_file("LLM",    params.model.path) ||
             !check_file("vision", params.vpm_model)  ||
@@ -166,7 +186,7 @@ int main(int argc, char ** argv) {
             }
         }
 
-        omni_context * octx = omni_init(&params, media_type, use_tts, tts_bin_dir, tts_gpu_layers,
+        omni_context * octx = omni_init(&params, media_type, use_tts, params.tts_bin_dir, tts_gpu_layers,
                                          token2wav_device, duplex_mode,
                                          /*existing_model=*/nullptr, /*existing_ctx=*/nullptr, output_dir);
         if (!octx) {

--- a/tools/server/ws_handler.cpp
+++ b/tools/server/ws_handler.cpp
@@ -714,6 +714,7 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
         // response.done.audio (full_audio_b64) instead of streaming deltas.
         bool accumulate = false;
         std::vector<float> accum;
+        bool emitted_audio = false;
     };
     auto audio_state = std::make_shared<AudioCbState>();
     audio_state->session_id = session_id;
@@ -740,6 +741,7 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
                 std::lock_guard<std::mutex> lk(audio_state->mtx);
                 response_id = audio_state->response_id;
                 response_start = audio_state->response_start;
+                audio_state->emitted_audio = true;
             }
             std::string b64 = float32_pcm_to_b64(samples, n_samples);
             ProtocolMetrics metrics = make_runtime_metrics(
@@ -796,6 +798,7 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
             std::lock_guard<std::mutex> lk(audio_state->mtx);
             audio_state->response_id = response_id; // update for audio callback
             audio_state->response_start = t_request_start;
+            audio_state->emitted_audio = false;
         }
 
         // Branch: full_duplex vs turn_based. The input shape MUST match the
@@ -1207,6 +1210,7 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
             if (decode_thread.joinable()) {
                 decode_thread.join();
             }
+            double generate_ms = elapsed_ms(t_generate_start);
             {
                 const std::string text = sanitize_utf8_stream(utf8_pending, "", true);
                 if (!text.empty()) {
@@ -1218,6 +1222,21 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
                                              elapsed_ms(t_request_start), 0,
                                              turn_vision_slices)));
                 }
+            }
+            bool emitted_audio = false;
+            {
+                std::lock_guard<std::mutex> lk(audio_state->mtx);
+                emitted_audio = audio_state->emitted_audio;
+            }
+            if (!full_text.empty() || emitted_audio) {
+                // Full-duplex speak responses also need an explicit completion
+                // boundary; pure listen steps are represented by listen delta only.
+                send_event(make_response_done(
+                    session_id, response_id, full_text, /*audio_base64*/"",
+                    "turn_end",
+                    make_runtime_metrics(octx, prefill_ms, generate_ms,
+                                         elapsed_ms(t_request_start), 0,
+                                         turn_vision_slices)));
             }
         }
     }


### PR DESCRIPTION
…solution

## Overview

1、补 full-duplex 的完成事件
之前 full-duplex 只发 text/audio/listen delta，缺少一次语义回复结束的 response.done。现在在实际产生文本或音频后补发完成边界，方便上游统计、收尾和协议对齐。

2、统一子模型路径推导
之前 legacy HTTP /v1/stream/omni_init 还依赖请求体里的 model_dir。现在和 /backend 一样，都从启动参数 -m 的 LLM 路径推导 vision/audio/tts 子模型。


## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
