### PR TITLE
Pr/duplex perf harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,40 @@ cmake --build build --target llama-omni-cli -j
 | `-c, --ctx-size <n>` | Context size (default: 4096) |
 | `-ngl <n>` | Number of GPU layers (default: 99) |
 | `--no-tts` | Disable TTS output |
+| `--vision-batch-encode` | Encode same-size image slices in one batched pass (off by default; see below) |
 | `--test <prefix> <n>` | Run test with audio files |
+| `--bench-vision <img>` | Benchmark serial vs batched vision encoding on an image, then exit |
+
+### Vision Batch Encoding (optional optimization)
+
+For high-resolution / high-refresh inputs, an image is split into one overview plus
+many equally-sized slices, and each slice is encoded by the ViT. By default these
+slices are encoded **one at a time** (serial). `--vision-batch-encode` instead packs
+all same-size slices into a **single batched** ViT pass, which is significantly faster
+when there are many slices.
+
+- **When to enable**: large images / high-res / high-refresh modes, i.e. cases that
+  produce many slices. On a 4821×2259 image this gives roughly **1.5–2.3× faster**
+  vision encoding (more slices → larger speedup).
+- **Why it's off by default**: batched cuBLAS GEMM uses a different accumulation order
+  than per-slice GEMM, so the embeddings are *numerically very close but not bit-exact*
+  (avg diff ~1e-2). It also uses somewhat more VRAM. It is therefore opt-in rather than
+  a universal default.
+
+```bash
+# Enable the optimization
+./build/bin/llama-omni-cli \
+    -m /path/to/MiniCPM-o-4_5-gguf/MiniCPM-o-4_5-Q4_K_M.gguf \
+    --omni --vision-batch-encode
+
+# Benchmark serial vs batched (prints a per-slice-count comparison table)
+./build/bin/llama-omni-cli \
+    -m /path/to/MiniCPM-o-4_5-gguf/MiniCPM-o-4_5-Q4_K_M.gguf \
+    --bench-vision /path/to/large_image.png
+```
+
+Programmatically the same switch is exposed via `common_params.vpm_batch_encode`
+(applied in `omni_init`) and `vision_set_batch_encode(ctx_vision, true)`.
 
 ### Output
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ MiniCPM-o-4_5-gguf/
 cmake -B build -DCMAKE_BUILD_TYPE=Release
 
 # Build
-cmake --build build --target llama-omni-cli -j
+cmake --build build --target llama-omni-server --target llama-omni-cli -j
 ```
 
 > CMake will auto-detect and enable Metal (macOS) or CUDA (Linux with NVIDIA GPU).
@@ -229,11 +229,11 @@ tools/omni/output/
 
 ## 🌐 Recommended Companion Demo — MiniCPM-o-Demo (Comni)
 
-For an out-of-the-box, end-to-end omni video-call experience built on top of `llama-server`, we recommend the **Comni** branch of the official demo:
+For an out-of-the-box, end-to-end omni video-call experience built on top of `llama-omni-server`, we recommend the **Comni** branch of the official demo:
 
 🔗 **[OpenBMB/MiniCPM-o-Demo @ Comni](https://github.com/OpenBMB/MiniCPM-o-Demo/tree/Comni)**
 
-It bundles a Python gateway + worker (which spawns and orchestrates `llama-server`) and a desktop + mobile React frontend, supporting **macOS (Metal)**, **Linux (CUDA)**, and **Windows (CUDA)**. Use it when you want a turnkey video-call demo without writing your own HTTP integration.
+It bundles a Python gateway + worker (which spawns and orchestrates `llama-omni-server`) and a desktop + mobile React frontend, supporting **macOS (Metal)**, **Linux (CUDA)**, and **Windows (CUDA)**. Use it when you want a turnkey video-call demo without writing your own HTTP integration.
 
 > 💡 **Don't want to compile?** Pre-built one-click installers (**Comni for Windows / macOS**) are available on the [llama.cpp-omni Releases page](https://github.com/tc-mb/llama.cpp-omni/releases).
 
@@ -246,7 +246,7 @@ If you already have the GGUF weights from [Prerequisites](#prerequisites):
 git clone https://github.com/tc-mb/llama.cpp-omni.git
 cd llama.cpp-omni && git checkout feat/web-demo \
     && cmake -B build -DCMAKE_BUILD_TYPE=Release \
-    && cmake --build build --target llama-server -j
+    && cmake --build build --target llama-omni-server --target llama-omni-cli -j
 cd ..
 
 # 2. Set up the demo (Python venv + mobile frontend)
@@ -282,7 +282,7 @@ gateway.py        :8040 (HTTPS)        ─┐
 worker.py         :22440 + i  GPU i    ─┘
     │  spawns + HTTP-calls
     ▼
-llama-server      :19080 + i  GPU i
+llama-omni-server      :19080 + i  GPU i
     /v1/stream/omni_init
     /v1/stream/update_session_config
     /v1/stream/prefill
@@ -292,17 +292,17 @@ llama-server      :19080 + i  GPU i
 
 ### Step-by-Step
 
-**1. Build `llama-server` from this repo**
+**1. Build `llama-omni-server` from this repo**
 
 ```bash
 git clone https://github.com/tc-mb/llama.cpp-omni.git
 cd llama.cpp-omni
 git checkout feat/web-demo
 cmake -B build -DCMAKE_BUILD_TYPE=Release
-cmake --build build --target llama-server -j
+cmake --build build --target llama-omni-server --target llama-omni-cli -j
 ```
 
-CMake auto-detects CUDA (Linux + NVIDIA) and Metal (macOS). After the build, `build/bin/llama-server` is the binary `worker.py` will spawn — you do **not** need to start `llama-server` yourself.
+CMake auto-detects CUDA (Linux + NVIDIA) and Metal (macOS). After the build, `build/bin/llama-omni-server` is the binary `worker.py` will spawn — you do **not** need to start `llama-omni-server` yourself.
 
 **2. Install Python dependencies**
 
@@ -351,11 +351,11 @@ cp config.example.json config.json
 
 | Field | Purpose |
 |-------|---------|
-| `cpp_backend.llamacpp_root` | Absolute path to your `llama.cpp-omni` checkout. `worker.py` runs `${llamacpp_root}/build/bin/llama-server` and uses `${llamacpp_root}/tools/omni/output_<port>/` as the TTS WAV output dir |
+| `cpp_backend.llamacpp_root` | Absolute path to your `llama.cpp-omni` checkout. `worker.py` runs `${llamacpp_root}/build/bin/llama-omni-server` and uses `${llamacpp_root}/tools/omni/output_<port>/` as the TTS WAV output dir |
 | `cpp_backend.model_dir` | Absolute path to the GGUF directory (LLM + `audio/` + `tts/` + `vision/` + `token2wav-gguf/`) |
 | `cpp_backend.llm_model` | LLM filename inside `model_dir`. Pick the quantization you downloaded (`Q4_K_M` / `Q8_0` / `F16`) |
-| `cpp_backend.cpp_server_port` | HTTP port `worker.py` will start `llama-server` on. Worker `i` uses `cpp_server_port + i` |
-| `cpp_backend.ctx_size` / `n_gpu_layers` | Forwarded to `llama-server` as `--ctx-size` / `--n-gpu-layers` |
+| `cpp_backend.cpp_server_port` | HTTP port `worker.py` will start `llama-omni-server` on. Worker `i` uses `cpp_server_port + i` |
+| `cpp_backend.ctx_size` / `n_gpu_layers` | Forwarded to `llama-omni-server` as `--ctx-size` / `--n-gpu-layers` |
 
 **4. Build the mobile frontend (one-time)**
 
@@ -389,10 +389,10 @@ Then open:
 ### Stop
 
 ```bash
-pkill -f "gateway.py|worker.py|llama-server"
+pkill -f "gateway.py|worker.py|llama-omni-server"
 ```
 
-`worker.py` automatically restarts `llama-server` after each session (`full_reinit`) to keep KV cache state clean across runs.
+`worker.py` automatically restarts `llama-omni-server` after each session (`full_reinit`) to keep KV cache state clean across runs.
 
 ### Multi-GPU
 
@@ -402,13 +402,13 @@ Set `service.num_workers > 1` in `config.json` and pass the visible devices:
 CUDA_VISIBLE_DEVICES=0,1 bash start_all.sh
 ```
 
-Each worker is bound to its own GPU (via `CUDA_VISIBLE_DEVICES`) and spawns its own `llama-server` on `cpp_server_port + worker_index`.
+Each worker is bound to its own GPU (via `CUDA_VISIBLE_DEVICES`) and spawns its own `llama-omni-server` on `cpp_server_port + worker_index`.
 
 ### Troubleshooting
 
 | Symptom | Likely cause |
 |---------|--------------|
-| Worker log: `llama-server not found` | `cpp_backend.llamacpp_root` is wrong, or `cmake --build … --target llama-server` was not run |
+| Worker log: `llama-omni-server not found` | `cpp_backend.llamacpp_root` is wrong, or `cmake --build … --target llama-omni-server` was not run |
 | Worker `/health` stays at `worker_status: "loading"` for a long time | `omni_init` is still loading GGUF modules. Check `tmp/worker_<i>.log` for lines tagged `[CPP]` |
 | WAV files appear under `${llamacpp_root}/tools/omni/output_<port>/round_XXX/` but the browser plays nothing | The gateway is HTTP — many browsers block `Audio` / `MediaDevices` on insecure origins. Use the default HTTPS mode |
 | `kv_cache_length` keeps shrinking mid-conversation | C++ side sliding-window pruning is kicking in. The desktop and mobile UIs expose a "Stop on KV pruning" toggle (default on) that ends the session cleanly when this happens |
@@ -422,16 +422,16 @@ For more details and Chinese documentation, see the demo repo: [`README.md`](htt
 ## HTTP API & Integration Guide
 > 📝 This section is based on community integration experience.
 
-This section documents the HTTP API call sequence for integrating llama-server into your own application (e.g. a Tauri/Electron desktop app). The official CLI is a black box — if you want programmatic control, you need to call these endpoints directly.
+This section documents the HTTP API call sequence for integrating llama-omni-server into your own application (e.g. a Tauri/Electron desktop app). The official CLI is a black box — if you want programmatic control, you need to call these endpoints directly.
 
 > This guide is based on real-world integration experience. Several critical details are **not documented elsewhere**.
 
 ---
 
-### 1. Start llama-server
+### 1. Start llama-omni-server
 
 ```bash
-./llama-server \
+./llama-omni-server \
   --host 0.0.0.0 \
   --port 9060 \
   --model /path/to/MiniCPM-o-4_5-Q4_K_M.gguf \
@@ -569,7 +569,7 @@ output_dir/
 ### Full Call Sequence Summary
 
 ```
-start llama-server
+start llama-omni-server
     ↓
 GET /health  (poll until 200)
     ↓

--- a/common/common.h
+++ b/common/common.h
@@ -577,6 +577,7 @@ struct common_params {
     std::string apm_model                = ""; // audio encoder GGUF
     std::string vpm_model                = ""; // vision encoder GGUF
     std::string projector_model          = ""; // projector GGUF
+    bool vpm_batch_encode                = false; // batch-encode same-size vision slices (off by default; helps large/high-res images)
 
     // Apple Neural Engine (CoreML) support
     std::string vision_coreml_model_path     = ""; // path to CoreML .mlmodelc for vision ANE

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2320,14 +2320,21 @@ static void ggml_cuda_mul_mat_batched_cublas_impl(ggml_backend_cuda_context & ct
 
         size_t src1_stride_size = sizeof(cuda_t);
 
-        const int threads_x = 16;
-        const int threads_y = 16;
-        dim3 block_dims(threads_x, threads_y);
-
-        dim3 grid_dims(
-            (ne13 + threads_x - 1) / threads_x,
-            (ne12 + threads_y - 1) / threads_y
-        );
+        {
+        const int64_t max_block = 1024;
+        int64_t bx = ne13;
+        int64_t by = ne12;
+        int64_t gx = 1;
+        int64_t gy = 1;
+        if (bx * by > max_block) {
+            bx = (ne13 <= 32) ? ne13 : 32;
+            by = max_block / bx;
+            if (by > ne12) by = ne12;
+            gx = (ne13 + bx - 1) / bx;
+            gy = (ne12 + by - 1) / by;
+        }
+        dim3 block_dims(bx, by);
+        dim3 grid_dims(gx, gy);
         k_compute_batched_ptrs<<<grid_dims, block_dims, 0, main_stream>>>(
                 src0_ptr, src1_ptr, dst_t,
                 ptrs_src.get(), ptrs_dst.get(),
@@ -2338,6 +2345,7 @@ static void ggml_cuda_mul_mat_batched_cublas_impl(ggml_backend_cuda_context & ct
                 (src1->type == src0_type) ? nb13 : s13*src1_stride_size,
                 nbd2, nbd3,
                 r2, r3);
+        }
 
         CUDA_CHECK(cudaGetLastError());
 

--- a/tools/omni/CMakeLists.txt
+++ b/tools/omni/CMakeLists.txt
@@ -175,6 +175,18 @@ set_target_properties  (${TARGET_DUPLEX_TEST} PROPERTIES OUTPUT_NAME llama-omni-
 target_link_libraries  (${TARGET_DUPLEX_TEST} PRIVATE llama-common omni Threads::Threads)
 target_compile_features(${TARGET_DUPLEX_TEST} PRIVATE cxx_std_17)
 
+# 双工性能测试 - 使用独立 perf runtime，不改 omni.cpp
+set(TARGET_DUPLEX_PERF_TEST llama-omni-perf-duplex)
+add_executable         (${TARGET_DUPLEX_PERF_TEST}
+                        test/perf-test/test-duplex-perf.cpp
+                        test/perf-test/omni_duplex_perf.cpp
+                        test/perf-test/omni_duplex_perf.h
+                        test/perf-test/omni_perf.cpp
+                        test/perf-test/omni_perf.h)
+set_target_properties  (${TARGET_DUPLEX_PERF_TEST} PROPERTIES OUTPUT_NAME llama-omni-perf-duplex)
+target_link_libraries  (${TARGET_DUPLEX_PERF_TEST} PRIVATE llama-common omni Threads::Threads ${CMAKE_DL_LIBS})
+target_compile_features(${TARGET_DUPLEX_PERF_TEST} PRIVATE cxx_std_17)
+
 # Token2Wav 测试程序 - 纯 C++ 单线程 baseline（用于 profile 对照，不占 LLM/TTS GPU）
 add_executable(token2wav-example token2wav/token2wav-example.cpp)
 target_link_libraries(token2wav-example PRIVATE llama-common omni Threads::Threads)

--- a/tools/omni/omni-cli.cpp
+++ b/tools/omni/omni-cli.cpp
@@ -1,5 +1,6 @@
 #include "omni-impl.h"
 #include "omni.h"
+#include "vision.h"
 
 #include "arg.h"
 #include "log.h"
@@ -67,7 +68,10 @@ static void show_usage(const char * prog_name) {
         "  --vision-coreml <path>   Path to CoreML model (.mlmodelc), required when backend=coreml\n"
         "  --t2w-coreml <path>  Enable token2wav CoreML backend (DiT on CoreML, encoder on GPU)\n"
         "                        Use 'auto' to auto-discover CoreML model in model dir\n"
+        "  --vision-batch-encode  Enable batched encoding of same-size vision slices\n"
+        "                          (off by default; helps large / high-res / high-refresh images)\n"
         "  --test <prefix> <n> Run test case with data prefix and count\n"
+        "  --bench-vision <img> Benchmark serial vs batched vision encoding\n"
         "  -h, --help          Show this help message\n\n"
         "Example:\n"
         "  %s -m ./models/MiniCPM-o-4_5-gguf/MiniCPM-o-4_5-Q4_K_M.gguf\n"
@@ -210,11 +214,13 @@ int main(int argc, char ** argv) {
     std::string vision_coreml_model_path;  // CoreML model path (required when vision_backend=coreml)
     std::string token2wav_coreml_model_path; // CoreML model path for token2wav DiT (empty = GPU only)
     std::string ref_audio_path = "tools/omni/assets/default_ref_audio/default_ref_audio.wav";
+    std::string bench_vision_image;
     int n_ctx = 4096;
     int n_gpu_layers = 99;  // GPU 层数，默认 99
     int media_type = 1;     // 1=audio only, 2=omni (audio+vision)
     bool use_tts = true;
     bool run_test = false;
+    bool vision_batch_encode = false;  // 多 slice 批量编码优化（默认关闭）
     std::string test_audio_prefix;
     int test_count = 0;
     
@@ -269,10 +275,16 @@ int main(int argc, char ** argv) {
         else if (arg == "--t2w-coreml" && i + 1 < argc) {
             token2wav_coreml_model_path = argv[++i];
         }
+        else if (arg == "--vision-batch-encode") {
+            vision_batch_encode = true;
+        }
         else if (arg == "--test" && i + 2 < argc) {
             run_test = true;
             test_audio_prefix = argv[++i];
             test_count = std::atoi(argv[++i]);
+        }
+        else if (arg == "--bench-vision" && i + 1 < argc) {
+            bench_vision_image = argv[++i];
         }
         else {
             fprintf(stderr, "Unknown argument: %s\n", arg.c_str());
@@ -281,6 +293,31 @@ int main(int argc, char ** argv) {
         }
     }
     
+    // vision-only benchmark: only needs vision model, skip full init
+    if (!bench_vision_image.empty()) {
+        if (llm_path.empty()) {
+            fprintf(stderr, "Error: -m <llm_model_path> is required (for auto-detecting vision model path)\n");
+            return 1;
+        }
+        OmniModelPaths paths = resolve_model_paths(llm_path);
+        if (!vision_path_override.empty()) paths.vision = vision_path_override;
+        printf("Vision model: %s\n", paths.vision.c_str());
+        printf("Benchmark image: %s\n", bench_vision_image.c_str());
+
+        vision_context_params vparams;
+        vparams.use_gpu = true;
+        vparams.verbosity = GGML_LOG_LEVEL_INFO;
+        vparams.coreml_model_path = nullptr;
+        struct vision_ctx * ctx_v = vision_init(paths.vision.c_str(), vparams);
+        if (!ctx_v) {
+            fprintf(stderr, "Error: failed to init vision model\n");
+            return 1;
+        }
+        omni_bench_vision(ctx_v, 4, bench_vision_image.c_str());
+        vision_free(ctx_v);
+        return 0;
+    }
+
     // 检查必需参数
     if (llm_path.empty()) {
         fprintf(stderr, "Error: -m <llm_model_path> is required\n\n");
@@ -328,6 +365,7 @@ int main(int argc, char ** argv) {
         params.vision_coreml_model_path = vision_coreml_model_path;
     }
     params.token2wav_coreml_model_path = token2wav_coreml_model_path;
+    params.vpm_batch_encode = vision_batch_encode;
     params.n_ctx = n_ctx;
     params.n_gpu_layers = n_gpu_layers;
     
@@ -347,6 +385,7 @@ int main(int argc, char ** argv) {
     printf("  Context size: %d\n", n_ctx);
     printf("  GPU layers: %d\n", n_gpu_layers);
     printf("  Vision backend: %s\n", vision_backend.c_str());
+    printf("  Vision batch encode: %s\n", vision_batch_encode ? "enabled" : "disabled");
     if (vision_backend == "coreml") {
         printf("  Vision CoreML: %s\n", vision_coreml_model_path.c_str());
     }

--- a/tools/omni/omni-cli.cpp
+++ b/tools/omni/omni-cli.cpp
@@ -12,6 +12,7 @@
 
 #include <iostream>
 #include <chrono>
+#include <thread>
 #include <vector>
 #include <limits.h>
 #include <cinttypes>
@@ -421,7 +422,7 @@ int main(int argc, char ** argv) {
         for (int i = 0; i < 1200; ++i) {  // 最多等 120 秒
             FILE * f = fopen(done_flag.c_str(), "r");
             if (f) { fclose(f); fprintf(stderr, "Audio generation completed.\n"); break; }
-            usleep(100000);  // 100ms
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
         }
     }
 

--- a/tools/omni/omni.cpp
+++ b/tools/omni/omni.cpp
@@ -443,6 +443,7 @@ void omni_embed_free(struct omni_embed * embed) {
 
 // 🔧 [高清模式] 返回分离的 chunk embeds（二维 vector）
 // 返回值: vision_chunks[0] = overview, vision_chunks[1..n] = slices
+// 当 slice 数 > 1 时，使用 batched encoding 加速
 static bool encode_image_with_vision_chunks(vision_ctx * ctx_vision, int n_threads, const vision_image_u8 * img, 
                                             std::vector<std::vector<float>> & vision_chunks) {
     const int64_t t_img_enc_start_us = ggml_time_us();
@@ -457,36 +458,264 @@ static bool encode_image_with_vision_chunks(vision_ctx * ctx_vision, int n_threa
     
     int n_embd = vision_n_mmproj_embd(ctx_vision);
     int n_tokens = vision_n_output_tokens(ctx_vision);
+    const int n_total = (int)img_res_v.entries.size();
     
     vision_chunks.clear();
-    vision_chunks.resize(img_res_v.entries.size());
-    
-    for (size_t i = 0; i < img_res_v.entries.size(); i++) {
-        const int64_t t_img_enc_step_start_us = ggml_time_us();
-        
-        // 为每个 chunk 分配空间
-        vision_chunks[i].resize(n_embd * n_tokens);
-        
-        bool encoded = vision_image_encode(ctx_vision, n_threads, img_res_v.entries[i].get(), vision_chunks[i].data());
+    vision_chunks.resize(n_total);
+
+    // entry[0] is the overview image; entry[1..n] are slices (all same size)
+    // strategy: encode overview separately, batch all slices together
+    // 批量编码优化由 vision_set_batch_encode 控制（默认关闭）。该优化只在
+    // 大图/高清高刷等 slice 数较多时收益明显，并非通用，因此需显式开启。
+    const int n_slices = n_total - 1;
+    const bool use_batched = vision_get_batch_encode(ctx_vision) && (n_slices > 1);
+
+    // 1) encode the overview image (entry 0)
+    {
+        const int64_t t_step_us = ggml_time_us();
+        vision_chunks[0].resize(n_embd * n_tokens);
+        bool encoded = vision_image_encode(ctx_vision, n_threads, img_res_v.entries[0].get(), vision_chunks[0].data());
         if (!encoded) {
-            LOG_ERR("Unable to encode image - spatial_unpad - subimage %d of %d\n", (int) i+1, (int) img_res_v.entries.size());
+            LOG_ERR("Unable to encode overview image\n");
             return false;
         }
-        const int64_t t_img_enc_steop_batch_us = ggml_time_us();
-        LOG_INF("%s: step %d of %d encoded in %8.2f ms\n", __func__, (int)i+1, (int)img_res_v.entries.size(), (t_img_enc_steop_batch_us - t_img_enc_step_start_us) / 1000.0);
+        LOG_INF("%s: overview encoded in %8.2f ms\n", __func__, (ggml_time_us() - t_step_us) / 1000.0);
     }
-    const int64_t t_img_enc_batch_us = ggml_time_us();
-    LOG_INF("%s: all %d chunks encoded in %8.2f ms (grid: %dx%d)\n", __func__, 
-            (int)img_res_v.entries.size(), (t_img_enc_batch_us - t_img_enc_start_us) / 1000.0,
-            img_res_v.grid_x, img_res_v.grid_y);
+
+    // 2) encode slices
+    if (n_slices > 0) {
+        if (use_batched) {
+            // batched encoding: group all slices into a single batch
+            const int64_t t_batch_us = ggml_time_us();
+            vision_image_f32_batch slice_batch;
+            for (int i = 1; i < n_total; i++) {
+                slice_batch.entries.push_back(std::move(img_res_v.entries[i]));
+            }
+
+            std::vector<float> batched_output(n_embd * n_tokens * n_slices);
+            bool encoded = vision_image_batch_encode(ctx_vision, n_threads, &slice_batch, batched_output.data());
+            if (!encoded) {
+                LOG_ERR("Unable to batch-encode %d slices\n", n_slices);
+                return false;
+            }
+
+            // split batched output into individual chunks
+            const int per_image_floats = n_embd * n_tokens;
+            for (int i = 0; i < n_slices; i++) {
+                vision_chunks[1 + i].resize(per_image_floats);
+                std::memcpy(vision_chunks[1 + i].data(),
+                            batched_output.data() + i * per_image_floats,
+                            per_image_floats * sizeof(float));
+            }
+
+            LOG_INF("%s: %d slices batch-encoded in %8.2f ms\n", __func__, n_slices, (ggml_time_us() - t_batch_us) / 1000.0);
+        } else {
+            // serial path: encode every slice individually (entries[1..n_total-1])
+            const int64_t t_step_us = ggml_time_us();
+            for (int i = 1; i < n_total; i++) {
+                vision_chunks[i].resize(n_embd * n_tokens);
+                bool encoded = vision_image_encode(ctx_vision, n_threads, img_res_v.entries[i].get(), vision_chunks[i].data());
+                if (!encoded) {
+                    // entries[i] is the i-th slice (entry 0 is the overview), so the
+                    // 1-based slice number equals i, out of n_slices total.
+                    LOG_ERR("Unable to encode slice %d of %d\n", i, n_slices);
+                    return false;
+                }
+            }
+            LOG_INF("%s: %d slice(s) encoded serially in %8.2f ms\n", __func__, n_slices, (ggml_time_us() - t_step_us) / 1000.0);
+        }
+    }
 
     const int64_t t_img_enc_end_us = ggml_time_us();
     float t_img_enc_ms = (t_img_enc_end_us - t_img_enc_start_us) / 1000.0;
-    int total_tokens = (int)vision_chunks.size() * n_tokens;
-    LOG_INF("\n%s: image encoded in %8.2f ms by vision (%8.2f ms per chunk, %d total tokens)\n", 
-            __func__, t_img_enc_ms, t_img_enc_ms / vision_chunks.size(), total_tokens);
+    int total_tokens = n_total * n_tokens;
+    LOG_INF("\n%s: image encoded in %8.2f ms by vision (%d chunks, %d total tokens, grid: %dx%d)\n", 
+            __func__, t_img_enc_ms, n_total, total_tokens,
+            img_res_v.grid_x, img_res_v.grid_y);
 
     return true;
+}
+
+static int query_gpu_memory_used_mb(int device_id = 0) {
+#ifdef GGML_USE_CUDA
+    size_t free_bytes = 0, total_bytes = 0;
+    ggml_backend_cuda_get_device_memory(device_id, &free_bytes, &total_bytes);
+    if (total_bytes == 0) return -1;
+    return (int)((total_bytes - free_bytes) / (1024 * 1024));
+#else
+    (void) device_id;
+    return -1;
+#endif
+}
+
+void omni_bench_vision(struct vision_ctx * ctx_vision, int n_threads, const char * image_path) {
+    unsigned char* image_bytes;
+    long image_bytes_length;
+    if (!load_file_to_bytes(image_path, &image_bytes, &image_bytes_length)) {
+        LOG_ERR("bench: failed to load %s\n", image_path);
+        return;
+    }
+    vision_image_u8 * img = vision_image_u8_init();
+    if (!vision_image_load_from_bytes(image_bytes, image_bytes_length, img)) {
+        vision_image_u8_free(img);
+        free(image_bytes);
+        LOG_ERR("bench: can't load image\n");
+        return;
+    }
+    free(image_bytes);
+
+    int n_embd = vision_n_mmproj_embd(ctx_vision);
+    int n_tokens = vision_n_output_tokens(ctx_vision);
+    const int per_image_floats = n_embd * n_tokens;
+    const int bench_runs = 3;
+
+    const int baseline_vram = query_gpu_memory_used_mb();
+    LOG_INF("\n================================================================\n");
+    LOG_INF("  Vision Encoding Benchmark: Serial vs Batched (GPU %d)\n", 0);
+    LOG_INF("================================================================\n");
+    LOG_INF("Image: %s\n", image_path);
+    LOG_INF("Per-slice: %d embd x %d tokens = %d floats (%.1f MB)\n",
+            n_embd, n_tokens, per_image_floats, per_image_floats * 4.0f / 1048576.0f);
+    LOG_INF("Baseline VRAM: %d MB\n", baseline_vram);
+    LOG_INF("NOTE: VRAM figures are device-wide (cudaMemGetInfo), single-point samples, "
+            "NOT per-process peak; they include other processes on the same GPU.\n");
+    LOG_INF("Bench runs per config: %d\n\n", bench_runs);
+
+    struct bench_result {
+        int max_slice_cfg;
+        int actual_slices;
+        int grid_x, grid_y;
+        double serial_ms;
+        double batch_ms;
+        double speedup;
+        int vram_serial_mb;
+        int vram_batch_mb;
+        double max_diff;
+        double avg_diff;
+    };
+    std::vector<bench_result> results;
+
+    const int slice_configs[] = {1, 2, 3, 4, 6, 8, 9, 12, 16, 20, 25, 30, 36};
+    const int n_configs = sizeof(slice_configs) / sizeof(slice_configs[0]);
+
+    // warmup with 1 slice
+    vision_set_max_slice_nums(ctx_vision, 1);
+    {
+        vision_image_f32_batch warmup_batch;
+        vision_image_preprocess(ctx_vision, img, &warmup_batch);
+        if (!warmup_batch.entries.empty()) {
+            std::vector<float> tmp(per_image_floats);
+            vision_image_encode(ctx_vision, n_threads, warmup_batch.entries[0].get(), tmp.data());
+        }
+    }
+
+    for (int ci = 0; ci < n_configs; ci++) {
+        int max_s = slice_configs[ci];
+        vision_set_max_slice_nums(ctx_vision, max_s);
+
+        vision_image_f32_batch img_res_v;
+        if (!vision_image_preprocess(ctx_vision, img, &img_res_v)) {
+            LOG_ERR("bench: preprocess failed for max_slice=%d\n", max_s);
+            continue;
+        }
+
+        const int n_total = (int)img_res_v.entries.size();
+        const int n_slices = n_total - 1;
+
+        if (n_slices < 2) {
+            LOG_INF("[max_slice=%2d] grid=%dx%d => %d slice(s), skipping (need >=2)\n",
+                    max_s, img_res_v.grid_x, img_res_v.grid_y, n_slices);
+            continue;
+        }
+
+        LOG_INF("\n--- max_slice_nums=%2d => grid=%dx%d, %d slices ---\n",
+                max_s, img_res_v.grid_x, img_res_v.grid_y, n_slices);
+
+        bench_result br;
+        br.max_slice_cfg = max_s;
+        br.actual_slices = n_slices;
+        br.grid_x = img_res_v.grid_x;
+        br.grid_y = img_res_v.grid_y;
+
+        // --- serial encoding ---
+        std::vector<std::vector<float>> serial_out(n_slices);
+        double serial_total = 0;
+        for (int r = 0; r < bench_runs; r++) {
+            const int64_t t0 = ggml_time_us();
+            for (int i = 0; i < n_slices; i++) {
+                serial_out[i].resize(per_image_floats);
+                vision_image_encode(ctx_vision, n_threads, img_res_v.entries[1 + i].get(), serial_out[i].data());
+            }
+            double ms = (ggml_time_us() - t0) / 1000.0;
+            serial_total += ms;
+            LOG_INF("  serial  run %d: %8.2f ms\n", r, ms);
+        }
+        br.serial_ms = serial_total / bench_runs;
+        br.vram_serial_mb = query_gpu_memory_used_mb();
+
+        // --- batched encoding ---
+        std::vector<float> batch_out(per_image_floats * n_slices);
+        double batch_total = 0;
+        for (int r = 0; r < bench_runs; r++) {
+            vision_image_f32_batch slice_batch;
+            for (int i = 0; i < n_slices; i++) {
+                vision_image_f32_ptr cp(new vision_image_f32(*img_res_v.entries[1 + i]));
+                slice_batch.entries.push_back(std::move(cp));
+            }
+            const int64_t t0 = ggml_time_us();
+            vision_image_batch_encode(ctx_vision, n_threads, &slice_batch, batch_out.data());
+            double ms = (ggml_time_us() - t0) / 1000.0;
+            batch_total += ms;
+            LOG_INF("  batched run %d: %8.2f ms\n", r, ms);
+        }
+        br.batch_ms = batch_total / bench_runs;
+        br.vram_batch_mb = query_gpu_memory_used_mb();
+        br.speedup = br.serial_ms / br.batch_ms;
+
+        // --- correctness ---
+        double max_d = 0, sum_d = 0;
+        int n_vals = per_image_floats * n_slices;
+        for (int i = 0; i < n_slices; i++) {
+            for (int j = 0; j < per_image_floats; j++) {
+                double d = std::abs((double)serial_out[i][j] - (double)batch_out[i * per_image_floats + j]);
+                if (d > max_d) max_d = d;
+                sum_d += d;
+            }
+        }
+        br.max_diff = max_d;
+        br.avg_diff = sum_d / n_vals;
+
+        LOG_INF("  => serial=%7.1f ms  batch=%7.1f ms  speedup=%.2fx  vram_s=%dMB vram_b=%dMB  max_diff=%.3e avg_diff=%.3e\n",
+                br.serial_ms, br.batch_ms, br.speedup,
+                br.vram_serial_mb, br.vram_batch_mb, br.max_diff, br.avg_diff);
+
+        results.push_back(br);
+    }
+    vision_image_u8_free(img);
+
+    // === summary table ===
+    LOG_INF("\n\n================================================================\n");
+    LOG_INF("                      SUMMARY TABLE\n");
+    LOG_INF("================================================================\n");
+    LOG_INF("%-6s %-6s %-8s %-10s %-10s %-8s %-10s %-10s %-10s %-10s\n",
+            "MaxS", "Grid", "Slices", "Serial(ms)", "Batch(ms)", "Speedup",
+            "VRAM_S(MB)", "VRAM_B(MB)", "MaxDiff", "AvgDiff");
+    LOG_INF("%-6s %-6s %-8s %-10s %-10s %-8s %-10s %-10s %-10s %-10s\n",
+            "------", "------", "--------", "----------", "----------", "--------",
+            "----------", "----------", "----------", "----------");
+    for (auto & r : results) {
+        char grid_str[16];
+        snprintf(grid_str, sizeof(grid_str), "%dx%d", r.grid_x, r.grid_y);
+        LOG_INF("%-6d %-6s %-8d %-10.1f %-10.1f %-8.2f %-10d %-10d %-10.3e %-10.3e\n",
+                r.max_slice_cfg, grid_str, r.actual_slices,
+                r.serial_ms, r.batch_ms, r.speedup,
+                r.vram_serial_mb, r.vram_batch_mb,
+                r.max_diff, r.avg_diff);
+    }
+    LOG_INF("================================================================\n");
+    LOG_INF("Baseline VRAM (model loaded, no encoding): %d MB\n", baseline_vram);
+    LOG_INF("VRAM_S/VRAM_B are device-wide single-point samples (not per-process peak).\n");
+    LOG_INF("================================================================\n\n");
 }
 
 // 保留原有函数用于兼容（将所有 chunk 拼成一个 flat buffer）
@@ -4027,6 +4256,11 @@ struct omni_context * omni_init(struct common_params * params, int media_type, b
         const char * vision_path = ctx_omni->params->vpm_model.c_str();
         auto * ctx_vision = vision_init(vision_path, vision_context_params{true, GGML_LOG_LEVEL_INFO, nullptr});
         ctx_omni->ctx_vision = ctx_vision;
+
+        // 🔧 [batch encode 开关] 由 common_params 控制（默认关闭）
+        if (ctx_vision) {
+            vision_set_batch_encode(ctx_vision, ctx_omni->params->vpm_batch_encode);
+        }
 
         // Set CoreML model path if available (for vision ANE acceleration)
         // Note: .mlmodelc is a directory, not a file, so use stat instead of ifstream

--- a/tools/omni/omni.h
+++ b/tools/omni/omni.h
@@ -611,3 +611,6 @@ void sliding_window_reset(struct omni_context * ctx_omni);
 // ==================== 高清模式函数声明 ====================
 // 设置 vision max_slice_nums 覆盖值，用于高清模式
 void vision_set_max_slice_nums(struct vision_ctx * ctx_vision, int max_slice_nums);
+
+// benchmark: serial vs batched vision encoding
+void omni_bench_vision(struct vision_ctx * ctx_vision, int n_threads, const char * image_path);

--- a/tools/omni/test/perf-test/README.md
+++ b/tools/omni/test/perf-test/README.md
@@ -1,0 +1,55 @@
+# Duplex Perf Test
+
+This directory contains a duplex performance harness for `tools/omni`.
+
+The harness drives the existing duplex session path and relies on internal
+profiling hooks in the encoder thread, duplex LLM thread, TTS thread, and T2W
+thread. Those hooks emit `[DUPLEX_PERF]` / `[DUPLEX_GPU]` lines through
+`tools/omni/omni-perf.cpp`.
+
+## Build
+
+```sh
+cmake --build build --target llama-omni-perf-duplex
+```
+
+Use the build directory name used by your local configuration.
+
+## Run
+
+```sh
+./build/bin/llama-omni-perf-duplex \
+  -m ./models/MiniCPM-o-4_5-gguf/MiniCPM-o-4_5-Q4_K_M.gguf \
+  --omni \
+  --test tools/omni/assets/test_case/omni_test_case/omni_test_case_ 9 \
+  --stream-interval 1000 \
+  -o ./tools/omni/output \
+  2>&1 | tee duplex-perf.log
+```
+
+Useful modes:
+
+- `--stream-interval 0`: back-to-back pressure test.
+- `--stream-interval 1000`: approximate realtime streaming input.
+- `--no-tts`: measure duplex frame decisions without waiting for TTS/T2W audio.
+- `--timeout-ms <ms>`: per-frame wait timeout.
+- `--llama-perf`: also print llama context perf counters.
+
+The binary emits stable lines such as:
+
+```text
+[DUPLEX_PERF] seq=0 stage=duplex.llm.prefill event=start chunk=1 t_ms=1.000 dur_ms=-1.000 rss_mb=100.00 gpu_used_mb=NA gpu_total_mb=NA n_past=123 detail="frame_id=1,user_seq=1"
+[DUPLEX_FRAME] seq=1 frame_id=1 ok=1 is_speak=0 prefill_submit_ms=1.234 decode_ms=10.000 e2e_ms=20.000 n_past=123 text=""
+[DUPLEX_PERF_CASE] event=end chunks=9 pushed=9 completed=9 total_ms=9000.000 avg_prefill_submit_ms=1.000 avg_decode_ms=10.000 avg_e2e_ms=20.000 speak=3 listen=6
+```
+
+## Analyze
+
+```sh
+python3 tools/omni/test/perf-test/analyze_duplex_perf.py \
+  --log duplex-perf.log \
+  --out-dir duplex-perf-report
+```
+
+The analyzer is the full duplex perf parser. It understands `[DUPLEX_PERF]`,
+`[DUPLEX_GPU]`, and frame summary lines.

--- a/tools/omni/test/perf-test/analyze_duplex_perf.py
+++ b/tools/omni/test/perf-test/analyze_duplex_perf.py
@@ -1,0 +1,1478 @@
+#!/usr/bin/env python3
+# Duplex profiling usage:
+#   OMNI_GPU_PROF=1 \
+#   OMNI_GPU_PROF_INTERVAL_MS=20 \
+#   OMNI_GPU_PROF_DEVICES=0 \
+#   OMNI_GPU_PROF_FILE=duplex.gpu.log \
+#   ./bin/llama-omni-test-duplex \
+#     -m <model.gguf> \
+#     --omni \
+#     --test <duplex_test_case_prefix> <case_count> \
+#     --stream-interval 1000 \
+#     --ref-audio <ref_audio.wav> \
+#     -ngl 99 \
+#     -c 4096 \
+#     -o <output_dir> \
+#     2>&1 | tee duplex.log
+#
+# GPU sampling:
+#   - OMNI_GPU_PROF_DEVICES uses NVML physical GPU indexes, e.g. 0 or 0,2.
+#   - Without OMNI_GPU_PROF_DEVICES, the first CUDA_VISIBLE_DEVICES entry is sampled.
+#   - Without either variable, only device 0 is sampled.
+#
+# Analyze:
+#   python3 tools/omni/test/analyze_duplex_perf.py \
+#     --log <duplex.log> \
+#     --gpu-log <duplex.gpu.log> \
+#     --out-dir <report_dir>
+"""Parse duplex omni perf logs and generate SVG/CSV/Markdown assets.
+
+This script uses only the Python standard library so it can run on the benchmark
+host without creating a conda environment.
+"""
+
+from __future__ import annotations
+
+import argparse
+import bisect
+import csv
+import html
+import re
+import statistics
+import subprocess
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+PERF_RE = re.compile(
+    r"(?P<wall>\d{2}:\d{2}:\d{2}\.\d{3}) "
+    r"\[DUPLEX_PERF\] (?:seq=(?P<seq>\d+) )?stage=(?P<stage>\S+) event=(?P<event>\S+) "
+    r"chunk=(?P<chunk>-?\d+) t_ms=(?P<t_ms>[-\d.]+) dur_ms=(?P<dur_ms>[-\d.]+) "
+    r"rss_mb=(?P<rss_mb>[-\d.]+|NA) gpu_used_mb=(?P<gpu_used_mb>[-\d.]+|NA) "
+    r"gpu_total_mb=(?P<gpu_total_mb>[-\d.]+|NA) n_past=(?P<n_past>-?\d+) "
+    r'detail="(?P<detail>[^"]*)"'
+)
+GPU_SAMPLE_RE = re.compile(
+    r"(?P<wall>\d{2}:\d{2}:\d{2}\.\d{3}) "
+    r"\[DUPLEX_GPU\] sample_id=(?P<sample_id>\d+) t_ms=(?P<t_ms>[-\d.]+) "
+    r"device=(?P<device>\d+) sm_util_pct=(?P<sm_util_pct>[-\d.]+|NA) "
+    r"mem_util_pct=(?P<mem_util_pct>[-\d.]+|NA) gpu_used_mb=(?P<gpu_used_mb>[-\d.]+|NA) "
+    r"gpu_total_mb=(?P<gpu_total_mb>[-\d.]+|NA) power_w=(?P<power_w>[-\d.]+|NA) "
+    r"temp_c=(?P<temp_c>[-\d.]+|NA) graphics_clock_mhz=(?P<graphics_clock_mhz>[-\d.]+|NA) "
+    r"mem_clock_mhz=(?P<mem_clock_mhz>[-\d.]+|NA)"
+)
+GPU_STATUS_RE = re.compile(
+    r"(?P<wall>\d{2}:\d{2}:\d{2}\.\d{3}) "
+    r'\[DUPLEX_GPU\] event=(?P<event>\S+) reason="(?P<reason>[^"]*)"'
+)
+CHUNK_RE = re.compile(r"prefill:\s*([0-9.]+) s \| decode:\s*([0-9.]+) s \| total:\s*([0-9.]+) s \| n_past:\s*(\d+)")
+OPT4_CHUNK_RE = re.compile(
+    r"--- Chunk (?P<seq>\d+)/(?P<count>\d+) --- "
+    r"prefill (?P<prefill_ms>[0-9.]+)ms \| decode (?P<decode_ms>[0-9.]+)ms \| "
+    r"e2e (?P<e2e_ms>[0-9.]+)ms \| n_past (?P<n_past>\d+) \| "
+    r"<\|(?P<decision>speak|listen)\|>(?: \"(?P<text>[^\"]*)\")?"
+)
+DECISION_RE = re.compile(r"决策:\s*<\|(speak|listen)\|>(?:\s*→\s*\"([^\"]*)\")?")
+
+STAGE_ROWS = [
+    ("duplex.encode", "#4c78a8"),
+    ("duplex.llm.prefill", "#b279a2"),
+    ("duplex.llm.decode", "#e45756"),
+    ("tts.condition", "#8cd17d"),
+    ("tts.prefill", "#54a24b"),
+    ("tts.decode", "#2ca02c"),
+    ("t2w.infer", "#3182bd"),
+    ("t2w.write", "#9e9ac8"),
+]
+
+REQUESTED_STAGES = {stage for stage, _ in STAGE_ROWS}
+TOKEN_SPEED_STAGES = ["duplex.llm.prefill", "duplex.llm.decode", "tts.prefill", "tts.decode"]
+
+FRAME_STAGE_ALIASES = {
+    "encode": ["duplex.encode"],
+    "llm_prefill": ["duplex.llm.prefill"],
+    "llm_decode": ["duplex.llm.decode"],
+    "tts": ["tts.condition", "tts.prefill", "tts.decode"],
+    "t2w_infer": ["t2w.infer"],
+    "t2w_write": ["t2w.write"],
+}
+
+FRAME_CORE_STAGES = {
+    stage
+    for names in FRAME_STAGE_ALIASES.values()
+    for stage in names
+}
+
+
+@dataclass
+class TokenStageAccumulator:
+    n: int = 0
+    tokens: int = 0
+    total_ms: float = 0.0
+    event_tokens_per_s: list[float] = field(default_factory=list)
+    event_ms_per_token: list[float] = field(default_factory=list)
+
+
+@dataclass
+class GpuStageAccumulator:
+    n_intervals: int = 0
+    n_samples: int = 0
+    total_ms: float = 0.0
+    estimated_samples: int = 0
+    sm: list[float] = field(default_factory=list)
+    mem: list[float] = field(default_factory=list)
+    power: list[float] = field(default_factory=list)
+
+
+def esc(value: object) -> str:
+    return html.escape(str(value), quote=True)
+
+
+def avg(values):
+    values = list(values)
+    return statistics.mean(values) if values else 0.0
+
+
+def pctl(values, pct):
+    values = sorted(values)
+    if not values:
+        return 0.0
+    if len(values) == 1:
+        return values[0]
+    pos = (len(values) - 1) * pct
+    lo = int(pos)
+    hi = min(lo + 1, len(values) - 1)
+    frac = pos - lo
+    return values[lo] * (1 - frac) + values[hi] * frac
+
+
+def parse_metric(value: str) -> float:
+    return -1.0 if value == "NA" else float(value)
+
+
+def parse_detail(detail: str):
+    result = {}
+    for part in detail.split(","):
+        if "=" not in part:
+            continue
+        key, value = part.split("=", 1)
+        result[key.strip()] = value.strip()
+    return result
+
+
+def detail_int(detail, key, default=0):
+    try:
+        return int(detail.get(key, default))
+    except (TypeError, ValueError):
+        return default
+
+
+def token_count_for_event(event):
+    detail = parse_detail(event["detail"])
+    if "tokens" in detail:
+        return detail_int(detail, "tokens", -1)
+    if event["stage"] == "tts.decode":
+        return detail_int(detail, "audio_tokens_generated", -1)
+    if event["stage"] == "duplex.llm.prefill":
+        return detail_int(detail, "n_past_delta", -1)
+    if event["stage"] == "duplex.llm.decode":
+        return detail_int(detail, "tokens", -1)
+    return -1
+
+
+def parse_log(path: Path, gpu_log_path=None):
+    text = path.read_text(errors="replace")
+    gpu_text = ""
+    if gpu_log_path and gpu_log_path != path:
+        gpu_text = gpu_log_path.read_text(errors="replace")
+    combined_gpu_text = text + "\n" + gpu_text
+
+    events = []
+    for match in PERF_RE.finditer(text):
+        group = match.groupdict()
+        events.append({
+            "wall": group["wall"],
+            "seq": int(group["seq"]) if group.get("seq") is not None else -1,
+            "stage": group["stage"],
+            "event": group["event"],
+            "chunk": int(group["chunk"]),
+            "t_ms": float(group["t_ms"]),
+            "dur_ms": float(group["dur_ms"]),
+            "rss_mb": parse_metric(group["rss_mb"]),
+            "gpu_used_mb": parse_metric(group["gpu_used_mb"]),
+            "gpu_total_mb": parse_metric(group["gpu_total_mb"]),
+            "n_past": int(group["n_past"]),
+            "detail": group["detail"],
+        })
+
+    gpu_samples = []
+    for match in GPU_SAMPLE_RE.finditer(combined_gpu_text):
+        group = match.groupdict()
+        gpu_samples.append({
+            "wall": group["wall"],
+            "sample_id": int(group["sample_id"]),
+            "t_ms": float(group["t_ms"]),
+            "device": int(group["device"]),
+            "sm_util_pct": parse_metric(group["sm_util_pct"]),
+            "mem_util_pct": parse_metric(group["mem_util_pct"]),
+            "gpu_used_mb": parse_metric(group["gpu_used_mb"]),
+            "gpu_total_mb": parse_metric(group["gpu_total_mb"]),
+            "power_w": parse_metric(group["power_w"]),
+            "temp_c": parse_metric(group["temp_c"]),
+            "graphics_clock_mhz": parse_metric(group["graphics_clock_mhz"]),
+            "mem_clock_mhz": parse_metric(group["mem_clock_mhz"]),
+        })
+    gpu_samples.sort(key=lambda row: (row["device"], row["t_ms"], row["sample_id"]))
+
+    gpu_statuses = []
+    for match in GPU_STATUS_RE.finditer(combined_gpu_text):
+        group = match.groupdict()
+        gpu_statuses.append({
+            "wall": group["wall"],
+            "event": group["event"],
+            "reason": group["reason"],
+        })
+
+    chunks = []
+    for match in OPT4_CHUNK_RE.finditer(text):
+        group = match.groupdict()
+        chunks.append({
+            "chunk": int(group["seq"]),
+            "prefill_ms": float(group["prefill_ms"]),
+            "decode_ms": float(group["decode_ms"]),
+            "total_ms": float(group["e2e_ms"]),
+            "n_past": int(group["n_past"]),
+            "decision": group["decision"],
+            "text": group["text"] or "",
+        })
+    if not chunks:
+        decisions = list(DECISION_RE.finditer(text))
+        for idx, match in enumerate(CHUNK_RE.finditer(text)):
+            decision = decisions[idx].group(1) if idx < len(decisions) else ""
+            decision_text = decisions[idx].group(2) if idx < len(decisions) and decisions[idx].group(2) else ""
+            chunks.append({
+                "chunk": idx,
+                "prefill_ms": float(match.group(1)) * 1000.0,
+                "decode_ms": float(match.group(2)) * 1000.0,
+                "total_ms": float(match.group(3)) * 1000.0,
+                "n_past": int(match.group(4)),
+                "decision": decision,
+                "text": decision_text,
+            })
+    return text, events, chunks, gpu_samples, gpu_statuses
+
+
+def stage_stats(events):
+    grouped = defaultdict(list)
+    for event in events:
+        if event["stage"] not in REQUESTED_STAGES:
+            continue
+        if event["event"] == "end" and event["dur_ms"] >= 0:
+            grouped[event["stage"]].append(event["dur_ms"])
+    stats = {}
+    for stage, values in grouped.items():
+        stats[stage] = {
+            "n": len(values),
+            "total": sum(values),
+            "avg": avg(values),
+            "p50": statistics.median(values),
+            "p90": pctl(values, 0.90),
+            "min": min(values),
+            "max": max(values),
+        }
+    return stats
+
+
+def stage_token_stats(events, speak_frame_ids=None):
+    filter_speak_frames = speak_frame_ids is not None
+    speak_frame_ids = set(speak_frame_ids or [])
+    grouped = defaultdict(TokenStageAccumulator)
+    for event in events:
+        if event["stage"] not in TOKEN_SPEED_STAGES or event["event"] != "end" or event["dur_ms"] < 0:
+            continue
+        if filter_speak_frames and event["chunk"] not in speak_frame_ids:
+            continue
+        tokens = token_count_for_event(event)
+        if tokens < 0:
+            continue
+        row = grouped[event["stage"]]
+        row.n += 1
+        row.tokens += tokens
+        row.total_ms += event["dur_ms"]
+        if tokens > 0 and event["dur_ms"] > 0:
+            row.event_tokens_per_s.append(tokens * 1000.0 / event["dur_ms"])
+            row.event_ms_per_token.append(event["dur_ms"] / tokens)
+
+    stats = {}
+    for stage, row in grouped.items():
+        tokens = row.tokens
+        total_ms = row.total_ms
+        stats[stage] = {
+            "n": row.n,
+            "tokens": tokens,
+            "total_ms": total_ms,
+            "tokens_per_s": tokens * 1000.0 / total_ms if tokens > 0 and total_ms > 0 else 0.0,
+            "ms_per_token": total_ms / tokens if tokens > 0 else 0.0,
+            "avg_event_tokens_per_s": avg(row.event_tokens_per_s),
+            "p50_event_tokens_per_s": statistics.median(row.event_tokens_per_s) if row.event_tokens_per_s else 0.0,
+            "avg_event_ms_per_token": avg(row.event_ms_per_token),
+        }
+    return stats
+
+
+def tts_token_rows(events):
+    rows = []
+    for event in sorted(events, key=lambda item: (item["t_ms"], item.get("seq", -1))):
+        if event["stage"] != "tts.decode" or event["event"] != "end":
+            continue
+        detail = parse_detail(event["detail"])
+        def to_int(key, default=0):
+            try:
+                return int(detail.get(key, default))
+            except ValueError:
+                return default
+        llm_tokens = to_int("llm_tokens")
+        filtered_llm_tokens = to_int("filtered_llm_tokens", llm_tokens)
+        condition_tokens = to_int("condition_tokens")
+        compute_tokens = to_int("compute_tokens", to_int("tokens", -1))
+        audio_tokens = to_int("audio_tokens_generated", -1)
+        if compute_tokens < 0:
+            compute_tokens = audio_tokens
+        rows.append({
+            "chunk": event["chunk"],
+            "tts_chunk": to_int("tts_chunk", event["chunk"]),
+            "dur_ms": event["dur_ms"],
+            "llm_tokens": llm_tokens,
+            "filtered_llm_tokens": filtered_llm_tokens,
+            "condition_tokens": condition_tokens,
+            "compute_tokens": compute_tokens,
+            "audio_tokens_generated": audio_tokens,
+            "is_end_of_turn": to_int("is_end_of_turn"),
+            "flush_only": to_int("flush_only"),
+            "compute_tokens_per_s": compute_tokens * 1000.0 / event["dur_ms"] if compute_tokens >= 0 and event["dur_ms"] > 0 else 0.0,
+            "audio_tokens_per_ms": audio_tokens / event["dur_ms"] if audio_tokens >= 0 and event["dur_ms"] > 0 else 0.0,
+            "audio_tokens_per_s": audio_tokens * 1000.0 / event["dur_ms"] if audio_tokens >= 0 and event["dur_ms"] > 0 else 0.0,
+            "ms_per_audio_token": event["dur_ms"] / audio_tokens if audio_tokens > 0 else 0.0,
+            "has_audio_token_detail": int(audio_tokens >= 0),
+        })
+    return rows
+
+
+def build_stage_intervals(events):
+    starts = defaultdict(list)
+    intervals = []
+    for event in sorted(events, key=lambda item: (item["t_ms"], item.get("seq", -1))):
+        key = (event["stage"], event["chunk"])
+        if event["event"] == "start":
+            starts[key].append(event)
+        elif event["event"] == "end" and event["dur_ms"] >= 0:
+            start = starts[key].pop(0) if starts[key] else None
+            begin = start["t_ms"] if start else event["t_ms"] - event["dur_ms"]
+            finish = event["t_ms"]
+            if finish >= begin:
+                intervals.append({
+                    "stage": event["stage"],
+                    "chunk": event["chunk"],
+                    "begin_ms": begin,
+                    "end_ms": finish,
+                    "duration_ms": finish - begin,
+                })
+    return intervals
+
+
+def intervals_for_aliases(by_stage, aliases):
+    for stage in aliases:
+        if by_stage.get(stage):
+            return by_stage[stage]
+    rows = []
+    for stage in aliases:
+        rows.extend(by_stage.get(stage, []))
+    return rows
+
+
+def sum_duration(rows):
+    return sum(row["duration_ms"] for row in rows)
+
+
+def max_end(rows):
+    return max((row["end_ms"] for row in rows), default=0.0)
+
+
+def infer_frame_decisions(events, chunks):
+    decisions = {chunk["chunk"]: chunk.get("decision", "") for chunk in chunks if chunk.get("chunk", -1) > 0}
+    for event in events:
+        chunk = event["chunk"]
+        if chunk <= 0 or decisions.get(chunk):
+            continue
+        detail = parse_detail(event["detail"])
+        if event["stage"] == "duplex.llm.decode" and event["event"] == "end":
+            if detail.get("is_speak") == "1":
+                decisions[chunk] = "speak"
+            elif detail.get("is_speak") == "0":
+                decisions[chunk] = "listen"
+    return decisions
+
+
+def build_frame_summaries(events, chunks, intervals, sla_ms=1000.0):
+    chunk_info = {chunk["chunk"]: chunk for chunk in chunks if chunk.get("chunk", -1) > 0}
+    decisions = infer_frame_decisions(events, chunks)
+    frame_ids = {interval["chunk"] for interval in intervals if interval["chunk"] > 0 and interval["stage"] in FRAME_CORE_STAGES}
+    frame_ids.update(chunk_info)
+    frame_ids.update(decisions)
+
+    rows = []
+    for frame_id in sorted(frame_ids):
+        frame_intervals = [
+            interval for interval in intervals
+            if interval["chunk"] == frame_id and interval["stage"] in FRAME_CORE_STAGES
+        ]
+        if not frame_intervals and frame_id not in chunk_info:
+            continue
+        by_stage = defaultdict(list)
+        for interval in frame_intervals:
+            by_stage[interval["stage"]].append(interval)
+
+        encode_rows = intervals_for_aliases(by_stage, FRAME_STAGE_ALIASES["encode"])
+        llm_prefill_rows = intervals_for_aliases(by_stage, FRAME_STAGE_ALIASES["llm_prefill"])
+        llm_decode_rows = intervals_for_aliases(by_stage, FRAME_STAGE_ALIASES["llm_decode"])
+        tts_rows = intervals_for_aliases(by_stage, FRAME_STAGE_ALIASES["tts"])
+        t2w_infer_rows = intervals_for_aliases(by_stage, FRAME_STAGE_ALIASES["t2w_infer"])
+        t2w_write_rows = intervals_for_aliases(by_stage, FRAME_STAGE_ALIASES["t2w_write"])
+
+        decision = decisions.get(frame_id, "")
+        if not decision:
+            if t2w_write_rows or tts_rows:
+                decision = "speak"
+            else:
+                decision = "unknown"
+
+        begin_ms = min((row["begin_ms"] for row in frame_intervals), default=0.0)
+        decode_end_ms = max_end(llm_decode_rows)
+        t2w_write_end_ms = max_end(t2w_write_rows)
+        if decision == "speak":
+            end_ms = t2w_write_end_ms
+            complete = bool(begin_ms and t2w_write_end_ms)
+        elif decision == "listen":
+            end_ms = decode_end_ms
+            complete = bool(begin_ms and decode_end_ms)
+        else:
+            end_ms = max((row["end_ms"] for row in frame_intervals), default=0.0)
+            complete = bool(begin_ms and end_ms)
+
+        e2e_ms = end_ms - begin_ms if complete and end_ms >= begin_ms else 0.0
+        missing = []
+        if not encode_rows:
+            missing.append("encode")
+        if not llm_prefill_rows:
+            missing.append("llm_prefill")
+        if not llm_decode_rows:
+            missing.append("llm_decode")
+        if decision == "speak":
+            if not tts_rows:
+                missing.append("tts")
+            if not t2w_infer_rows:
+                missing.append("t2w_infer")
+            if not t2w_write_rows:
+                missing.append("t2w_write")
+
+        chunk_meta = chunk_info.get(frame_id, {})
+        rows.append({
+            "frame_id": frame_id,
+            "decision": decision,
+            "complete": complete and not (decision == "speak" and missing),
+            "begin_ms": begin_ms,
+            "end_ms": end_ms,
+            "e2e_ms": e2e_ms,
+            "encode_ms": sum_duration(encode_rows),
+            "llm_prefill_ms": sum_duration(llm_prefill_rows),
+            "llm_decode_ms": sum_duration(llm_decode_rows),
+            "tts_ms": sum_duration(tts_rows),
+            "t2w_infer_ms": sum_duration(t2w_infer_rows),
+            "t2w_write_ms": sum_duration(t2w_write_rows),
+            "n_past": chunk_meta.get("n_past", 0),
+            "text": chunk_meta.get("text", ""),
+            "over_1s": bool(decision == "speak" and complete and e2e_ms > sla_ms),
+            "missing": ",".join(missing),
+        })
+    assign_utterance_ids(rows)
+    return rows
+
+
+def assign_utterance_ids(frame_rows):
+    utterance_id = 0
+    in_speak = False
+    for row in frame_rows:
+        if row["decision"] == "speak":
+            if not in_speak:
+                utterance_id += 1
+                in_speak = True
+            row["utterance_id"] = utterance_id
+        else:
+            row["utterance_id"] = 0
+            in_speak = False
+
+
+def choose_focus_frames(frame_rows):
+    groups = defaultdict(list)
+    for row in frame_rows:
+        if row.get("utterance_id", 0) > 0:
+            groups[row["utterance_id"]].append(row)
+    if not groups:
+        return frame_rows[: min(len(frame_rows), 6)]
+
+    # Prefer the longest complete SPEAK segment; it best shows a full duplex turn.
+    best_utt, speak_rows = max(
+        groups.items(),
+        key=lambda item: (
+            len([row for row in item[1] if row["complete"]]),
+            sum(row["e2e_ms"] for row in item[1]),
+        ),
+    )
+    first_idx = next(i for i, row in enumerate(frame_rows) if row.get("utterance_id") == best_utt)
+    last_idx = max(i for i, row in enumerate(frame_rows) if row.get("utterance_id") == best_utt)
+    start_idx = max(0, first_idx - 2)
+    end_idx = min(len(frame_rows) - 1, last_idx + 2)
+    return frame_rows[start_idx:end_idx + 1]
+
+
+def nearest_sample(samples, times, target):
+    if not samples:
+        return None
+    idx = bisect.bisect_left(times, target)
+    candidates = []
+    if idx < len(samples):
+        candidates.append(samples[idx])
+    if idx > 0:
+        candidates.append(samples[idx - 1])
+    return min(candidates, key=lambda sample: abs(sample["t_ms"] - target)) if candidates else None
+
+
+def stage_gpu_stats(intervals, gpu_samples):
+    by_device = defaultdict(list)
+    for sample in gpu_samples:
+        by_device[sample["device"]].append(sample)
+    for samples in by_device.values():
+        samples.sort(key=lambda sample: sample["t_ms"])
+
+    grouped = defaultdict(GpuStageAccumulator)
+
+    for interval in intervals:
+        if interval["stage"] not in REQUESTED_STAGES:
+            continue
+        for device, samples in by_device.items():
+            times = [sample["t_ms"] for sample in samples]
+            lo = bisect.bisect_left(times, interval["begin_ms"])
+            hi = bisect.bisect_right(times, interval["end_ms"])
+            selected = samples[lo:hi]
+            estimated = False
+            if not selected:
+                sample = nearest_sample(samples, times, (interval["begin_ms"] + interval["end_ms"]) / 2.0)
+                selected = [sample] if sample else []
+                estimated = bool(sample)
+
+            row = grouped[(interval["stage"], device)]
+            row.n_intervals += 1
+            row.total_ms += interval["duration_ms"]
+            if estimated:
+                row.estimated_samples += 1
+            row.n_samples += len(selected)
+            row.sm.extend(sample["sm_util_pct"] for sample in selected if sample["sm_util_pct"] >= 0)
+            row.mem.extend(sample["mem_util_pct"] for sample in selected if sample["mem_util_pct"] >= 0)
+            row.power.extend(sample["power_w"] for sample in selected if sample["power_w"] >= 0)
+
+    stats = {}
+    for (stage, device), row in grouped.items():
+        avg_sm = avg(row.sm)
+        stats[(stage, device)] = {
+            "stage": stage,
+            "device": device,
+            "n_intervals": row.n_intervals,
+            "n_samples": row.n_samples,
+            "total_ms": row.total_ms,
+            "avg_sm_util_pct": avg_sm,
+            "p50_sm_util_pct": pctl(row.sm, 0.50),
+            "p90_sm_util_pct": pctl(row.sm, 0.90),
+            "max_sm_util_pct": max(row.sm) if row.sm else 0.0,
+            "avg_mem_util_pct": avg(row.mem),
+            "max_mem_util_pct": max(row.mem) if row.mem else 0.0,
+            "avg_power_w": avg(row.power),
+            "max_power_w": max(row.power) if row.power else 0.0,
+            "estimated_samples": row.estimated_samples,
+            "stage_gpu_busy_ms": row.total_ms * avg_sm / 100.0,
+        }
+    return stats
+
+
+def svg_base(width, height, body):
+    return "\n".join([
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}">',
+        "<style>",
+        "text{font-family:Arial,'Noto Sans CJK SC','Microsoft YaHei',sans-serif;fill:#172033}",
+        ".title{font-size:22px;font-weight:700}.subtitle{font-size:13px;fill:#5b6475}",
+        ".label{font-size:13px}.small{font-size:11px;fill:#5b6475}.tiny{font-size:10px;fill:#5b6475}",
+        ".lane{fill:#f6f8fb;stroke:#d6dde8}.box{rx:12;ry:12;stroke:#29415f;stroke-width:1.2}",
+        "</style>",
+        *body,
+        "</svg>",
+        "",
+    ])
+
+
+def write(path: Path, content: str):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def cleanup_report_dir(out_dir: Path):
+    stale_files = [
+        "omni-duplex-frame-summary.csv",
+        "omni-duplex-gpu-samples.csv",
+        "omni-duplex-sla.md",
+        "omni-duplex-stage-gpu-stats.csv",
+        "omni-duplex-stage-stats.csv",
+        "omni-duplex-stage-timing-table.md",
+        "omni-duplex-stage-token-speed.csv",
+        "omni-duplex-tts-token-stats.csv",
+        "figures/omni-duplex-overlap-timeline.svg",
+        "figures/omni-duplex-stage-latency.svg",
+    ]
+    for name in stale_files:
+        path = out_dir / name
+        if path.exists():
+            path.unlink()
+
+
+def pipeline_svg(path: Path):
+    body = [
+        '<rect width="1180" height="520" fill="#ffffff"/>',
+        '<text x="40" y="42" class="title">Omni Duplex 实测流水线</text>',
+        '<text x="40" y="66" class="subtitle">只展示用户关心的数据处理阶段；计时从线程拿到队列数据后开始，不包含等待队列时间</text>',
+    ]
+    lanes = [("Encode", 120), ("LLM", 235), ("TTS", 350), ("T2W", 465)]
+    for lane, y in lanes:
+        body += [f'<rect x="30" y="{y - 42}" width="1120" height="76" class="lane" rx="14"/>', f'<text x="48" y="{y - 14}" class="label" font-weight="700">{esc(lane)}</text>']
+    boxes = [
+        (225, 96, 190, 48, "duplex.encode", "frame -> embeddings", "#dcecff"),
+        (225, 211, 190, 48, "duplex.llm.prefill", "embeddings -> KV", "#e6dcff"),
+        (505, 211, 190, 48, "duplex.llm.decode", "KV -> text/hidden", "#ffd6a5"),
+        (420, 326, 150, 48, "tts.condition", "hidden -> condition", "#d8f3d0"),
+        (590, 326, 150, 48, "tts.prefill", "condition -> KV", "#d0f4de"),
+        (760, 326, 150, 48, "tts.decode", "KV -> audio tokens", "#c2e8c2"),
+        (505, 441, 190, 48, "t2w.infer", "audio tokens -> wav", "#cde7ff"),
+        (775, 441, 190, 48, "t2w.write", "write wav", "#e6e1f2"),
+    ]
+    for x, y, w, h, title, sub, color in boxes:
+        body += [f'<rect x="{x}" y="{y}" width="{w}" height="{h}" fill="{color}" class="box"/>', f'<text x="{x + 12}" y="{y + 20}" class="label" font-weight="700">{esc(title)}</text>', f'<text x="{x + 12}" y="{y + 38}" class="small">{esc(sub)}</text>']
+    body.append('<defs><marker id="arrow" markerWidth="10" markerHeight="8" refX="9" refY="4" orient="auto"><path d="M0,0 L10,4 L0,8 Z" fill="#29415f"/></marker></defs>')
+    for x1, y1, x2, y2 in [
+        (415, 120, 225, 235),
+        (415, 235, 505, 235),
+        (695, 235, 420, 350),
+        (570, 350, 590, 350),
+        (740, 350, 760, 350),
+        (910, 350, 505, 465),
+        (695, 465, 775, 465),
+    ]:
+        body.append(f'<line x1="{x1}" y1="{y1}" x2="{x2}" y2="{y2}" stroke="#29415f" stroke-width="1.8" marker-end="url(#arrow)"/>')
+    body.append(f'<text x="60" y="505" class="small">• {esc("LISTEN 帧只要求 encode + LLM；SPEAK 帧 e2e 到最后一次 t2w.write.end")}</text>')
+    write(path, svg_base(1180, 520, body))
+
+
+def frame_pipeline_svg(path: Path, frame_rows, intervals):
+    if not frame_rows:
+        pipeline_svg(path)
+        return
+
+    lane_names = ["Encode", "LLM", "TTS", "T2W"]
+    stage_lane = {
+        "duplex.encode": "Encode",
+        "duplex.llm.prefill": "LLM",
+        "duplex.llm.decode": "LLM",
+        "tts.condition": "TTS",
+        "tts.prefill": "TTS",
+        "tts.decode": "TTS",
+        "t2w.infer": "T2W",
+        "t2w.write": "T2W",
+    }
+    colors = {stage: color for stage, color in STAGE_ROWS}
+    colors.update({
+        "duplex.encode": "#4c78a8",
+        "duplex.llm.prefill": "#b279a2",
+        "duplex.llm.decode": "#e45756",
+    })
+
+    focus_rows = choose_focus_frames(frame_rows)
+    focus_frame_ids = {row["frame_id"] for row in focus_rows}
+    focus_utterances = sorted({row.get("utterance_id", 0) for row in focus_rows if row.get("utterance_id", 0) > 0})
+    focus_utterance = focus_utterances[0] if focus_utterances else 0
+
+    drawable = [
+        interval for interval in intervals
+        if interval["chunk"] in focus_frame_ids and interval["stage"] in stage_lane
+    ]
+    if not drawable:
+        pipeline_svg(path)
+        return
+
+    start_ms = min(row["begin_ms"] for row in focus_rows if row["begin_ms"] > 0)
+    end_ms = max(max(row["end_ms"], row["begin_ms"] + 1000.0) for row in focus_rows if row["begin_ms"] > 0)
+    span = max(1.0, end_ms - start_ms)
+    width = 1320
+    left, chart_w = 170, 1080
+    top, lane_h = 140, 82
+    height = top + len(lane_names) * lane_h + 118
+
+    def x_of(t_ms):
+        return left + (t_ms - start_ms) / span * chart_w
+
+    lane_y = {lane: top + idx * lane_h for idx, lane in enumerate(lane_names)}
+    body = [
+        f'<rect width="{width}" height="{height}" fill="#ffffff"/>',
+        '<text x="40" y="42" class="title">Duplex Pipeline: One SPEAK Turn</text>',
+        '<text x="40" y="66" class="subtitle">竖线标记 1s 输入间隔；同色细线连接同一 frame 的各阶段产物</text>',
+    ]
+
+    for row in focus_rows:
+        if row["begin_ms"] <= 0:
+            continue
+        x = x_of(row["begin_ms"])
+        body += [
+            f'<line x1="{x:.1f}" y1="100" x2="{x:.1f}" y2="{top + len(lane_names) * lane_h - 26}" stroke="#cfd8e6" stroke-width="1.5"/>',
+            f'<text x="{x + 4:.1f}" y="{top - 24}" class="tiny">f{row["frame_id"]}</text>',
+        ]
+    # Draw regular 1s cadence labels so the input rhythm is obvious.
+    cadence = 0.0
+    while cadence <= span + 1.0:
+        x = left + cadence / span * chart_w
+        body.append(f'<text x="{x - 8:.1f}" y="{height - 28}" class="tiny">{cadence / 1000.0:.0f}s</text>')
+        cadence += 1000.0
+
+    for lane in lane_names:
+        y = lane_y[lane]
+        body += [
+            f'<rect x="40" y="{y - 18}" width="{width - 80}" height="54" fill="#f6f8fb" stroke="#d6dde8" rx="10"/>',
+            f'<text x="56" y="{y + 5}" class="label" font-weight="700">{esc(lane)}</text>',
+        ]
+
+    for row in focus_rows:
+        if row["begin_ms"] <= 0 or row["end_ms"] <= 0:
+            continue
+        x = x_of(row["begin_ms"])
+        w = max(2.0, x_of(row["end_ms"]) - x)
+        stroke = "#2ca25f" if row["decision"] == "speak" else "#8b95a5"
+        body.append(
+            f'<rect x="{x:.1f}" y="{top - 24}" width="{w:.1f}" height="{len(lane_names) * lane_h - 32}" '
+            f'fill="none" stroke="{stroke}" stroke-width="1" stroke-dasharray="4 4" rx="8"/>'
+        )
+        label = f'f{row["frame_id"]} {row["decision"]}'
+        if row.get("utterance_id", 0) > 0:
+            label += f' u{row["utterance_id"]}'
+        body.append(f'<text x="{x + 4:.1f}" y="{top - 10}" class="tiny">{esc(label)}</text>')
+
+    stage_offsets = {
+        "duplex.encode": -8,
+        "duplex.llm.prefill": -8,
+        "duplex.llm.decode": 10,
+        "tts.condition": -8,
+        "tts.prefill": 0,
+        "tts.decode": 10,
+        "t2w.infer": -8,
+        "t2w.write": 10,
+    }
+    stage_order = {
+        "duplex.encode": 0,
+        "duplex.llm.prefill": 1,
+        "duplex.llm.decode": 2,
+        "tts.condition": 3,
+        "tts.prefill": 4,
+        "tts.decode": 5,
+        "t2w.infer": 6,
+        "t2w.write": 7,
+    }
+    row_by_frame = {row["frame_id"]: row for row in focus_rows}
+
+    def bar_geometry(interval):
+        lane = stage_lane[interval["stage"]]
+        x = x_of(interval["begin_ms"])
+        raw_w = (interval["end_ms"] - interval["begin_ms"]) / span * chart_w
+        w = max(2.0, raw_w)
+        y = lane_y[lane] - 2 + stage_offsets.get(interval["stage"], 0)
+        return {
+            "x": x,
+            "y": y,
+            "w": w,
+            "raw_w": raw_w,
+            "cx": x + w / 2.0,
+            "cy": y + 7.0,
+        }
+
+    bar_rows = [
+        (interval, bar_geometry(interval))
+        for interval in sorted(drawable, key=lambda item: (item["begin_ms"], item["chunk"], item["stage"]))
+    ]
+
+    by_frame = defaultdict(list)
+    for interval, geom in bar_rows:
+        by_frame[interval["chunk"]].append((interval, geom))
+
+    # Draw same-frame data-flow connectors before the bars so colored stage bars
+    # stay readable while overlapping SPEAK windows can still be traced.
+    for frame_id in sorted(by_frame):
+        frame_row = row_by_frame.get(frame_id, {})
+        stroke = "#2ca25f" if frame_row.get("decision") == "speak" else "#6b7280"
+        points = [
+            (geom["cx"], geom["cy"])
+            for interval, geom in sorted(
+                by_frame[frame_id],
+                key=lambda item: (stage_order.get(item[0]["stage"], 99), item[0]["begin_ms"], item[0]["end_ms"]),
+            )
+        ]
+        for (x1, y1), (x2, y2) in zip(points, points[1:]):
+            body.append(
+                f'<line x1="{x1:.1f}" y1="{y1:.1f}" x2="{x2:.1f}" y2="{y2:.1f}" '
+                f'stroke="{stroke}" stroke-width="1.3" opacity="0.55"/>'
+            )
+
+    for interval, geom in bar_rows:
+        x = geom["x"]
+        y = geom["y"]
+        w = geom["w"]
+        raw_w = geom["raw_w"]
+        body.append(
+            f'<rect x="{x:.1f}" y="{y:.1f}" width="{w:.1f}" height="14" '
+            f'fill="{colors.get(interval["stage"], "#8b95a5")}" rx="3"/>'
+        )
+        if raw_w < 4.0:
+            # Keep tiny stages honest in time scale: the bar remains short, while
+            # a small tick makes the stage visible without implying a longer duration.
+            body.append(
+                f'<line x1="{x:.1f}" y1="{y - 2:.1f}" x2="{x:.1f}" y2="{y + 16:.1f}" '
+                f'stroke="{colors.get(interval["stage"], "#8b95a5")}" stroke-width="2"/>'
+            )
+        if w > 42:
+            label = interval["stage"].replace("duplex.", "")
+            body.append(f'<text x="{x + 4:.1f}" y="{y + 11:.1f}" class="tiny">{esc(label)} {interval["duration_ms"]:.0f}ms</text>')
+
+    legend_x = 40
+    legend_y = height - 88
+    legend_items = [
+        ("SPEAK frame", "#2ca25f"),
+        ("LISTEN frame", "#8b95a5"),
+        ("duplex.encode", colors["duplex.encode"]),
+        ("duplex.llm.prefill", colors["duplex.llm.prefill"]),
+        ("duplex.llm.decode", colors["duplex.llm.decode"]),
+        ("tts.condition", colors["tts.condition"]),
+        ("tts.prefill", colors["tts.prefill"]),
+        ("tts.decode", colors["tts.decode"]),
+        ("t2w.infer", colors["t2w.infer"]),
+        ("t2w.write", colors["t2w.write"]),
+    ]
+    body.append(f'<text x="{legend_x}" y="{legend_y}" class="label" font-weight="700">Legend</text>')
+    for idx, (label, color) in enumerate(legend_items):
+        col = idx % 4
+        row = idx // 4
+        x = legend_x + col * 295
+        y = legend_y + 16 + row * 22
+        body += [
+            f'<rect x="{x}" y="{y}" width="22" height="12" fill="{color}" rx="3"/>',
+            f'<text x="{x + 30}" y="{y + 11}" class="small">{esc(label)}</text>',
+        ]
+
+    write(path, svg_base(width, height, body))
+
+
+def stage_latency_svg(path: Path, stats):
+    width = 1080
+    left, top, bar_w, row_h = 270, 88, 650, 42
+    chart_bottom = top + len(STAGE_ROWS) * row_h + 10
+    height = max(470, chart_bottom + 50)
+    max_value = max([stats.get(stage, {}).get("avg", 0) for stage, _ in STAGE_ROWS] + [260])
+    body = [f'<rect width="1080" height="{height}" fill="#ffffff"/>', '<text x="40" y="42" class="title">阶段耗时均值</text>', '<text x="40" y="66" class="subtitle">单位 ms；横条为平均值，灰线为 p50 到 max</text>']
+    for tick in range(0, 301, 50):
+        x = left + tick / max_value * bar_w
+        body += [f'<line x1="{x:.1f}" y1="78" x2="{x:.1f}" y2="{chart_bottom}" stroke="#edf1f7"/>', f'<text x="{x - 8:.1f}" y="{chart_bottom + 19}" class="tiny">{tick}</text>']
+    for idx, (stage, color) in enumerate(STAGE_ROWS):
+        y = top + idx * row_h
+        row = stats.get(stage, {})
+        avgv, p50, maxv, n = row.get("avg", 0), row.get("p50", 0), row.get("max", 0), int(row.get("n", 0))
+        w = avgv / max_value * bar_w
+        p50x, maxx = left + p50 / max_value * bar_w, left + maxv / max_value * bar_w
+        body += [f'<text x="40" y="{y + 18}" class="label">{esc(stage)}</text>', f'<rect x="{left}" y="{y}" width="{w:.1f}" height="22" fill="{color}" rx="5"/>', f'<line x1="{p50x:.1f}" y1="{y + 31}" x2="{maxx:.1f}" y2="{y + 31}" stroke="#7f8897" stroke-width="2"/>', f'<circle cx="{p50x:.1f}" cy="{y + 31}" r="3" fill="#7f8897"/>', f'<circle cx="{maxx:.1f}" cy="{y + 31}" r="3" fill="#7f8897"/>', f'<text x="{left + w + 8:.1f}" y="{y + 16}" class="small">{avgv:.1f} ms</text>', f'<text x="940" y="{y + 18}" class="tiny">n={n} p50={p50:.1f} max={maxv:.1f}</text>']
+    write(path, svg_base(width, height, body))
+
+
+def overlap_svg(path: Path, events, start_ms=850.0, end_ms=1400.0):
+    width, height = 1180, 530
+    left, top, chart_w = 210, 86, 900
+    lanes = [
+        ("encode", ["duplex.encode"]),
+        ("llm", ["duplex.llm.prefill", "duplex.llm.decode"]),
+        ("tts", ["tts.condition", "tts.prefill", "tts.decode"]),
+        ("t2w", ["t2w.infer", "t2w.write"]),
+    ]
+    colors = {
+        "duplex.encode":"#4c78a8", "duplex.llm.prefill":"#b279a2", "duplex.llm.decode":"#e45756",
+        "tts.condition":"#8cd17d", "tts.prefill":"#54a24b", "tts.decode":"#2ca02c",
+        "t2w.infer":"#3182bd", "t2w.write":"#9e9ac8",
+    }
+    stage_lane = {stage: lane for lane, stages in lanes for stage in stages}
+    lane_y = {}
+    body = ['<rect width="1180" height="530" fill="#ffffff"/>', '<text x="40" y="42" class="title">异步重叠时间线：约 0.85s 到 1.40s</text>', '<text x="40" y="66" class="subtitle">只显示 encode、LLM、TTS、T2W 数据处理区间；不包含队列等待</text>']
+    for tick in range(int(start_ms), int(end_ms) + 1, 50):
+        x = left + (tick - start_ms) / (end_ms - start_ms) * chart_w
+        body += [f'<line x1="{x:.1f}" y1="80" x2="{x:.1f}" y2="455" stroke="#edf1f7"/>', f'<text x="{x - 14:.1f}" y="478" class="tiny">{tick}</text>']
+    for idx, (lane, _) in enumerate(lanes):
+        y = top + idx * 92
+        lane_y[lane] = y
+        body += [f'<rect x="40" y="{y - 20}" width="1070" height="62" fill="#f6f8fb" stroke="#d6dde8" rx="10"/>', f'<text x="58" y="{y + 5}" class="label" font-weight="700">{esc(lane)}</text>']
+    starts = defaultdict(list)
+    bars = []
+    for event in sorted(events, key=lambda item: item["t_ms"]):
+        key = (event["stage"], event["chunk"])
+        if event["event"] == "start":
+            starts[key].append(event)
+        elif event["event"] == "end" and event["stage"] in stage_lane:
+            start = starts[key].pop(0) if starts[key] else None
+            begin = start["t_ms"] if start else event["t_ms"] - max(event["dur_ms"], 0)
+            finish = event["t_ms"]
+            if finish >= start_ms and begin <= end_ms:
+                bars.append((begin, finish, event["stage"], event["chunk"]))
+    offsets = {stage: (i % 3) * 16 for i, stage in enumerate(colors)}
+    for begin, finish, stage, chunk in bars:
+        lane = stage_lane[stage]
+        x = left + (max(begin, start_ms) - start_ms) / (end_ms - start_ms) * chart_w
+        w = max(2, (min(finish, end_ms) - max(begin, start_ms)) / (end_ms - start_ms) * chart_w)
+        y = lane_y[lane] - 4 + offsets.get(stage, 0)
+        body.append(f'<rect x="{x:.1f}" y="{y:.1f}" width="{w:.1f}" height="13" fill="{colors[stage]}" rx="3"/>')
+        if w > 62:
+            body.append(f'<text x="{x + 4:.1f}" y="{y + 10:.1f}" class="tiny">c{chunk} {esc(stage.split(".")[-1])}</text>')
+    write(path, svg_base(width, height, body))
+
+
+def gpu_utilization_svg(path: Path, gpu_samples, intervals):
+    width = 1180
+    left, chart_w = 80, 1010
+    device_ids = sorted({sample["device"] for sample in gpu_samples})
+    if not gpu_samples or not device_ids:
+        body = ['<rect width="1180" height="180" fill="#ffffff"/>', '<text x="40" y="42" class="title">GPU 利用率时间线</text>', '<text x="40" y="72" class="subtitle">未解析到 [DUPLEX_GPU] sample</text>']
+        write(path, svg_base(width, 180, body))
+        return
+    if gpu_valid_metric_count(gpu_samples) == 0:
+        body = [
+            '<rect width="1180" height="210" fill="#ffffff"/>',
+            '<text x="40" y="42" class="title">GPU 利用率时间线</text>',
+            '<text x="40" y="72" class="subtitle">解析到了 [DUPLEX_GPU] sample，但所有 GPU 指标均为 NA</text>',
+            '<text x="40" y="104" class="small">Jetson/Orin 上 NVML 常不支持 util/memory/power 字段；请使用带 jetson_sysfs fallback 的新采样器重新运行。</text>',
+        ]
+        write(path, svg_base(width, 210, body))
+        return
+
+    sample_min = min(sample["t_ms"] for sample in gpu_samples)
+    sample_max = max(sample["t_ms"] for sample in gpu_samples)
+    interval_min = min([interval["begin_ms"] for interval in intervals] + [sample_min])
+    interval_max = max([interval["end_ms"] for interval in intervals] + [sample_max])
+    start_ms = min(sample_min, interval_min)
+    end_ms = max(sample_max, interval_max)
+    span = max(1.0, end_ms - start_ms)
+    device_h = 115
+    stage_top = 96 + len(device_ids) * device_h
+    height = stage_top + 270
+    body = ['<rect width="1180" height="%d" fill="#ffffff"/>' % height, '<text x="40" y="42" class="title">GPU 利用率时间线</text>', '<text x="40" y="66" class="subtitle">蓝线=SM util，橙线=memory controller util；下方为主要阶段 interval</text>']
+
+    def x_of(t_ms):
+        return left + (t_ms - start_ms) / span * chart_w
+
+    for tick in range(int(start_ms // 100 * 100), int(end_ms) + 101, 100):
+        x = x_of(tick)
+        body += [f'<line x1="{x:.1f}" y1="84" x2="{x:.1f}" y2="{height - 40}" stroke="#edf1f7"/>', f'<text x="{x - 18:.1f}" y="{height - 18}" class="tiny">{tick}</text>']
+
+    for idx, device in enumerate(device_ids):
+        y0 = 90 + idx * device_h
+        body += [f'<rect x="40" y="{y0 - 10}" width="1070" height="92" fill="#f6f8fb" stroke="#d6dde8" rx="10"/>', f'<text x="50" y="{y0 + 10}" class="label" font-weight="700">device {device}</text>']
+        for pct in (0, 50, 100):
+            y = y0 + 70 - pct / 100.0 * 62
+            body += [f'<line x1="{left}" y1="{y:.1f}" x2="{left + chart_w}" y2="{y:.1f}" stroke="#e8edf5"/>', f'<text x="46" y="{y + 4:.1f}" class="tiny">{pct}%</text>']
+        samples = [sample for sample in gpu_samples if sample["device"] == device]
+        for key, color in (("sm_util_pct", "#2f6fed"), ("mem_util_pct", "#f58518")):
+            points = []
+            for sample in samples:
+                value = sample[key]
+                if value < 0:
+                    continue
+                points.append(f'{x_of(sample["t_ms"]):.1f},{y0 + 70 - min(100.0, value) / 100.0 * 62:.1f}')
+            if len(points) >= 2:
+                body.append(f'<polyline points="{" ".join(points)}" fill="none" stroke="{color}" stroke-width="1.8"/>')
+
+    stage_colors = {stage: color for stage, color in STAGE_ROWS}
+    focus_stages = ["duplex.encode", "duplex.llm.prefill", "duplex.llm.decode", "tts.condition", "tts.prefill", "tts.decode", "t2w.infer", "t2w.write"]
+    lane_y = {stage: stage_top + 22 + idx * 26 for idx, stage in enumerate(focus_stages)}
+    body += [f'<text x="40" y="{stage_top}" class="label" font-weight="700">stage intervals</text>']
+    for stage in focus_stages:
+        y = lane_y[stage]
+        body += [f'<text x="40" y="{y + 10}" class="tiny">{esc(stage)}</text>', f'<line x1="{left}" y1="{y + 5}" x2="{left + chart_w}" y2="{y + 5}" stroke="#edf1f7"/>']
+    for interval in intervals:
+        stage = interval["stage"]
+        if stage not in lane_y:
+            continue
+        x = x_of(interval["begin_ms"])
+        w = max(1.5, (interval["end_ms"] - interval["begin_ms"]) / span * chart_w)
+        y = lane_y[stage]
+        body.append(f'<rect x="{x:.1f}" y="{y:.1f}" width="{w:.1f}" height="11" fill="{stage_colors.get(stage, "#8b95a5")}" opacity="0.58" rx="3"/>')
+
+    body += ['<rect x="875" y="90" width="220" height="52" fill="#ffffff" stroke="#d6dde8" rx="10"/>', '<line x1="895" y1="110" x2="930" y2="110" stroke="#2f6fed" stroke-width="2"/><text x="940" y="114" class="small">SM util</text>', '<line x1="895" y1="132" x2="930" y2="132" stroke="#f58518" stroke-width="2"/><text x="940" y="136" class="small">mem util</text>']
+    write(path, svg_base(width, height, body))
+
+
+def write_csvs(out_dir: Path, stats, gpu_samples, gpu_stats, tts_tokens, token_stats):
+    with (out_dir / "omni-duplex-stage-stats.csv").open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["stage", "n", "total_ms", "avg_ms", "p50_ms", "p90_ms", "min_ms", "max_ms"])
+        for stage in sorted(stats):
+            row = stats[stage]
+            writer.writerow([stage, row["n"], f'{row["total"]:.3f}', f'{row["avg"]:.3f}', f'{row["p50"]:.3f}', f'{row["p90"]:.3f}', f'{row["min"]:.3f}', f'{row["max"]:.3f}'])
+    with (out_dir / "omni-duplex-gpu-samples.csv").open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["sample_id", "t_ms", "device", "sm_util_pct", "mem_util_pct", "gpu_used_mb", "gpu_total_mb", "power_w", "temp_c", "graphics_clock_mhz", "mem_clock_mhz"])
+        for sample in gpu_samples:
+            writer.writerow([sample["sample_id"], f'{sample["t_ms"]:.3f}', sample["device"], sample["sm_util_pct"], sample["mem_util_pct"], sample["gpu_used_mb"], sample["gpu_total_mb"], sample["power_w"], sample["temp_c"], sample["graphics_clock_mhz"], sample["mem_clock_mhz"]])
+    with (out_dir / "omni-duplex-stage-gpu-stats.csv").open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["stage", "device", "n_intervals", "n_samples", "total_ms", "avg_sm_util_pct", "p50_sm_util_pct", "p90_sm_util_pct", "max_sm_util_pct", "avg_mem_util_pct", "max_mem_util_pct", "avg_power_w", "max_power_w", "estimated_samples", "stage_gpu_busy_ms"])
+        for key in sorted(gpu_stats):
+            row = gpu_stats[key]
+            writer.writerow([row["stage"], row["device"], row["n_intervals"], row["n_samples"], f'{row["total_ms"]:.3f}', f'{row["avg_sm_util_pct"]:.3f}', f'{row["p50_sm_util_pct"]:.3f}', f'{row["p90_sm_util_pct"]:.3f}', f'{row["max_sm_util_pct"]:.3f}', f'{row["avg_mem_util_pct"]:.3f}', f'{row["max_mem_util_pct"]:.3f}', f'{row["avg_power_w"]:.3f}', f'{row["max_power_w"]:.3f}', row["estimated_samples"], f'{row["stage_gpu_busy_ms"]:.3f}'])
+    with (out_dir / "omni-duplex-stage-token-speed.csv").open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["stage", "n", "tokens", "total_ms", "tokens_per_s", "ms_per_token", "avg_event_tokens_per_s", "p50_event_tokens_per_s", "avg_event_ms_per_token"])
+        for stage in TOKEN_SPEED_STAGES:
+            row = token_stats.get(stage, {})
+            writer.writerow([
+                stage,
+                int(row.get("n", 0)),
+                int(row.get("tokens", 0)),
+                f'{row.get("total_ms", 0.0):.3f}',
+                f'{row.get("tokens_per_s", 0.0):.3f}',
+                f'{row.get("ms_per_token", 0.0):.6f}',
+                f'{row.get("avg_event_tokens_per_s", 0.0):.3f}',
+                f'{row.get("p50_event_tokens_per_s", 0.0):.3f}',
+                f'{row.get("avg_event_ms_per_token", 0.0):.6f}',
+            ])
+    with (out_dir / "omni-duplex-tts-token-stats.csv").open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["chunk", "tts_chunk", "dur_ms", "llm_tokens", "filtered_llm_tokens", "condition_tokens", "compute_tokens", "audio_tokens_generated", "is_end_of_turn", "flush_only", "compute_tokens_per_s", "audio_tokens_per_ms", "audio_tokens_per_s", "ms_per_audio_token", "has_audio_token_detail"])
+        for row in tts_tokens:
+            writer.writerow([row["chunk"], row["tts_chunk"], f'{row["dur_ms"]:.3f}', row["llm_tokens"], row["filtered_llm_tokens"], row["condition_tokens"], row["compute_tokens"], row["audio_tokens_generated"], row["is_end_of_turn"], row["flush_only"], f'{row["compute_tokens_per_s"]:.3f}', f'{row["audio_tokens_per_ms"]:.6f}', f'{row["audio_tokens_per_s"]:.3f}', f'{row["ms_per_audio_token"]:.3f}', row["has_audio_token_detail"]])
+
+
+def write_frame_summary_csv(out_dir: Path, frame_rows):
+    with (out_dir / "omni-duplex-frame-summary.csv").open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow([
+            "frame_id",
+            "utterance_id",
+            "decision",
+            "complete",
+            "audio_e2e_ms",
+            "encode_ms",
+            "llm_prefill_ms",
+            "llm_decode_ms",
+            "tts_ms",
+            "t2w_infer_ms",
+            "t2w_write_ms",
+            "n_past",
+            "over_1s",
+            "missing",
+            "text",
+        ])
+        for row in frame_rows:
+            writer.writerow([
+                row["frame_id"],
+                row.get("utterance_id", 0),
+                row["decision"],
+                int(row["complete"]),
+                f'{row["e2e_ms"]:.3f}',
+                f'{row["encode_ms"]:.3f}',
+                f'{row["llm_prefill_ms"]:.3f}',
+                f'{row["llm_decode_ms"]:.3f}',
+                f'{row["tts_ms"]:.3f}',
+                f'{row["t2w_infer_ms"]:.3f}',
+                f'{row["t2w_write_ms"]:.3f}',
+                row["n_past"],
+                int(row["over_1s"]),
+                row["missing"],
+                row["text"],
+            ])
+
+
+def write_sla_report(path: Path, frame_rows, sla_ms=1000.0):
+    speak_rows = [row for row in frame_rows if row["decision"] == "speak"]
+    complete_speak = [row for row in speak_rows if row["complete"] and row["e2e_ms"] > 0]
+    listen_rows = [row for row in frame_rows if row["decision"] == "listen"]
+    incomplete_speak = [row for row in speak_rows if not row["complete"]]
+    values = [row["e2e_ms"] for row in complete_speak]
+    passed = bool(values) and not incomplete_speak and max(values) <= sla_ms
+    result = "PASS" if passed else "FAIL"
+
+    lines = [
+        "# Omni Duplex SPEAK SLA",
+        "",
+        f"- SLA：SPEAK 帧 audio e2e `<= {sla_ms:.0f} ms`，起点为该帧底层 encode 开始，终点为该帧最后一次 `t2w.write.end`。",
+        f"- 结论：`{result}`。",
+        f"- Frames：总计 `{len(frame_rows)}`，SPEAK `{len(speak_rows)}`，LISTEN `{len(listen_rows)}`，完整 SPEAK `{len(complete_speak)}`，不完整 SPEAK `{len(incomplete_speak)}`。",
+    ]
+    if values:
+        lines.extend([
+            f"- SPEAK e2e：avg `{avg(values):.1f} ms`，p50 `{statistics.median(values):.1f} ms`，p95 `{pctl(values, 0.95):.1f} ms`，max `{max(values):.1f} ms`。",
+            "",
+            "| frame | e2e ms | encode | llm prefill | llm decode | tts | t2w infer | t2w write | status |",
+            "| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
+        ])
+        for row in complete_speak:
+            status = "over_1s" if row["over_1s"] else "ok"
+            lines.append(
+                f"| {row['frame_id']} | {row['e2e_ms']:.1f} | {row['encode_ms']:.1f} | "
+                f"{row['llm_prefill_ms']:.1f} | {row['llm_decode_ms']:.1f} | {row['tts_ms']:.1f} | "
+                f"{row['t2w_infer_ms']:.1f} | {row['t2w_write_ms']:.1f} | `{status}` |"
+            )
+    else:
+        lines.append("- 未找到完整 SPEAK 帧，无法给出有效 e2e 统计。")
+
+    if incomplete_speak:
+        lines.extend([
+            "",
+            "## 不完整 SPEAK 帧",
+            "",
+            "| frame | missing | text |",
+            "| ---: | --- | --- |",
+        ])
+        for row in incomplete_speak:
+            lines.append(
+                f"| {row['frame_id']} | `{row['missing'] or 'unknown'}` | {esc(row['text'][:80])} |"
+            )
+
+    lines.append("")
+    write(path, "\n".join(lines))
+
+
+def stage_kind(stage: str) -> str:
+    if stage.endswith(".write"):
+        return "io"
+    return "compute"
+
+
+def ordered_stage_names(stats):
+    preferred = [stage for stage, _ in STAGE_ROWS]
+    return preferred + [stage for stage in sorted(stats) if stage not in preferred]
+
+
+def write_stage_timing_table(path: Path, stats):
+    lines = [
+        "# Duplex 阶段用时统计表",
+        "",
+        "单位均为 ms。`total` 是该 stage 所有 end 事件的耗时总和；异步/父子阶段不要直接相加。",
+        "",
+        "| type | stage | n | total | avg | p50 | p90 | min | max |",
+        "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for stage in ordered_stage_names(stats):
+        row = stats.get(stage, {})
+        if not row:
+            continue
+        lines.append(
+            f"| `{stage_kind(stage)}` | `{stage}` | {int(row['n'])} | "
+            f"{row['total']:.1f} | {row['avg']:.1f} | {row['p50']:.1f} | "
+            f"{row['p90']:.1f} | {row['min']:.1f} | {row['max']:.1f} |"
+        )
+    lines.append("")
+    write(path, "\n".join(lines))
+
+
+def gpu_stage_summary(gpu_stats, stage):
+    rows = [row for (row_stage, _), row in gpu_stats.items() if row_stage == stage]
+    if not rows:
+        return None
+    total_samples = sum(row["n_samples"] for row in rows)
+    avg_sm = avg(row["avg_sm_util_pct"] for row in rows)
+    max_sm = max(row["max_sm_util_pct"] for row in rows)
+    avg_power = avg(row["avg_power_w"] for row in rows)
+    estimated = sum(row["estimated_samples"] for row in rows)
+    devices = ",".join(str(row["device"]) for row in sorted(rows, key=lambda item: item["device"]))
+    return {
+        "devices": devices,
+        "total_samples": total_samples,
+        "avg_sm": avg_sm,
+        "max_sm": max_sm,
+        "avg_power": avg_power,
+        "estimated": estimated,
+    }
+
+
+def active_gpu_ids(gpu_samples, max_devices=1):
+    by_device = defaultdict(list)
+    for sample in gpu_samples:
+        by_device[sample["device"]].append(sample)
+    scores = []
+    for device, samples in by_device.items():
+        sm_values = [sample["sm_util_pct"] for sample in samples if sample["sm_util_pct"] >= 0]
+        mem_values = [sample["gpu_used_mb"] for sample in samples if sample["gpu_used_mb"] >= 0]
+        max_sm = max(sm_values) if sm_values else 0.0
+        avg_sm = avg(sm_values)
+        mem_delta = (max(mem_values) - min(mem_values)) if mem_values else 0.0
+        score = max_sm * 1000.0 + avg_sm * 100.0 + mem_delta
+        if score > 0:
+            scores.append((score, device))
+    scores.sort(reverse=True)
+    return [device for _, device in scores[:max_devices]]
+
+
+def gpu_device_names(device_ids):
+    device_ids = sorted(set(device_ids))
+    if not device_ids:
+        return {}
+    try:
+        proc = subprocess.run(
+            ["nvidia-smi", "--query-gpu=index,name", "--format=csv,noheader"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=2.0,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return {}
+    if proc.returncode != 0:
+        return {}
+
+    names = {}
+    for line in proc.stdout.splitlines():
+        if "," not in line:
+            continue
+        idx_text, name = line.split(",", 1)
+        try:
+            idx = int(idx_text.strip())
+        except ValueError:
+            continue
+        if idx in device_ids:
+            names[idx] = name.strip()
+    return names
+
+
+def gpu_device_summary(gpu_samples):
+    device_ids = sorted({sample["device"] for sample in gpu_samples})
+    if not device_ids:
+        return ""
+    names = gpu_device_names(device_ids)
+    parts = []
+    for device in device_ids:
+        name = names.get(device)
+        parts.append(f"device {device} ({name})" if name else f"device {device}")
+    return ", ".join(parts)
+
+
+def filter_gpu_samples(gpu_samples, device_ids):
+    if not device_ids:
+        return gpu_samples
+    keep = set(device_ids)
+    return [sample for sample in gpu_samples if sample["device"] in keep]
+
+
+def gpu_valid_metric_count(gpu_samples):
+    keys = ("sm_util_pct", "mem_util_pct", "gpu_used_mb", "power_w", "graphics_clock_mhz")
+    return sum(1 for sample in gpu_samples if any(sample.get(key, -1.0) >= 0 for key in keys))
+
+
+def stage_display_name(stage):
+    return {
+        "duplex.encode": "Encode",
+        "duplex.llm.prefill": "LLM Prefill",
+        "duplex.llm.decode": "LLM Decode",
+        "tts.condition": "TTS Condition",
+        "tts.prefill": "TTS Prefill",
+        "tts.decode": "TTS Decode",
+        "t2w.infer": "T2W",
+        "t2w.write": "Wav Write",
+    }.get(stage, stage)
+
+
+FRAME_STAGE_METRICS = [
+    ("encode_ms", "Encode"),
+    ("llm_prefill_ms", "LLM Prefill"),
+    ("llm_decode_ms", "LLM Decode"),
+    ("tts_ms", "TTS"),
+    ("t2w_infer_ms", "T2W"),
+    ("t2w_write_ms", "Wav Write"),
+]
+
+
+def stage_bottleneck_note(supports_duplex, complete_speak_frames, stats):
+    if supports_duplex:
+        return ""
+
+    if complete_speak_frames:
+        avg_e2e = avg(row["e2e_ms"] for row in complete_speak_frames)
+        stage_avgs = []
+        for key, label in FRAME_STAGE_METRICS:
+            values = [row.get(key, 0.0) for row in complete_speak_frames]
+            stage_avgs.append((avg(values), key, label))
+
+        bottleneck_avg, _, bottleneck_label = max(stage_avgs, key=lambda item: item[0])
+        share = bottleneck_avg / avg_e2e * 100.0 if avg_e2e > 0 else 0.0
+
+        worst_frame = max(complete_speak_frames, key=lambda row: row["e2e_ms"])
+        worst_stage_key, worst_stage_label = max(
+            FRAME_STAGE_METRICS,
+            key=lambda item: worst_frame.get(item[0], 0.0),
+        )
+        worst_stage_ms = worst_frame.get(worst_stage_key, 0.0)
+        return (
+            f"- 瓶颈阶段：按完整 SPEAK 帧平均耗时，`{bottleneck_label}` 最长，"
+            f"avg `{bottleneck_avg:.1f} ms`，约占 SPEAK e2e 平均 `{share:.1f}%`；"
+            f"最慢 frame `f{worst_frame['frame_id']}` 的最长阶段是 `{worst_stage_label}` "
+            f"`{worst_stage_ms:.1f} ms`。"
+        )
+
+    stage_avgs = [
+        (row.get("avg", 0.0), stage_display_name(stage))
+        for stage, row in stats.items()
+        if row
+    ]
+    if not stage_avgs:
+        return "- 瓶颈阶段：缺少完整 SPEAK frame 和阶段统计，无法定位耗时最长阶段。"
+
+    bottleneck_avg, bottleneck_label = max(stage_avgs, key=lambda item: item[0])
+    return (
+        f"- 瓶颈阶段：未找到完整 SPEAK frame，退化使用全局阶段平均耗时；"
+        f"`{bottleneck_label}` 最长，avg `{bottleneck_avg:.1f} ms`。"
+    )
+
+
+def write_report(path: Path, log_path: Path, text: str, events, chunks, stats, gpu_samples, gpu_stats, gpu_statuses, token_stats, frame_rows):
+    decisions = Counter(c["decision"] for c in chunks)
+    def speed(stage):
+        return token_stats.get(stage, {}).get("tokens_per_s", 0.0)
+    complete_speak_frames = [
+        row for row in frame_rows
+        if row["decision"] == "speak" and row["complete"] and row["e2e_ms"] > 0
+    ]
+    speak_rows = [row for row in frame_rows if row["decision"] == "speak"]
+    listen_rows = [row for row in frame_rows if row["decision"] == "listen"]
+    incomplete_speak = [row for row in speak_rows if not row["complete"]]
+    speak_e2e = [row["e2e_ms"] for row in complete_speak_frames]
+    sla_ms = 1000.0
+    supports_duplex = bool(speak_e2e) and not incomplete_speak and max(speak_e2e) <= sla_ms
+    conclusion = "支持双工" if supports_duplex else "暂不满足双工"
+    reason = (
+        f"完整 SPEAK 帧最慢 {max(speak_e2e):.1f} ms，低于 1s 输入间隔"
+        if supports_duplex and speak_e2e
+        else "存在不完整 SPEAK 帧或最慢 SPEAK e2e 超过 1s"
+    )
+    bottleneck_note = stage_bottleneck_note(supports_duplex, complete_speak_frames, stats)
+
+    utterances = sorted({row.get("utterance_id", 0) for row in speak_rows if row.get("utterance_id", 0) > 0})
+
+    lines = [
+        "# Duplex 1s 流式测试结论",
+        "",
+        f"**结论：{conclusion}。** {reason}。",
+        "",
+        f"- 输入节奏：`1s/frame`；日志：`{log_path.name}`。",
+        f"- Frames：`{len(frame_rows)}`；SPEAK `{len(speak_rows)}`，LISTEN `{len(listen_rows)}`，SPEAK utterance `{len(utterances)}` 段。",
+        f"- 完整 SPEAK e2e：avg `{avg(speak_e2e):.1f} ms`，p95 `{pctl(speak_e2e, 0.95):.1f} ms`，max `{max(speak_e2e) if speak_e2e else 0.0:.1f} ms`。",
+        f"- 判定口径：从 `duplex.encode.start` 到该 SPEAK frame 最后一次 `t2w.write.end`；不统计队列等待。",
+        *([bottleneck_note] if bottleneck_note else []),
+        "",
+        "## 流水线",
+        "",
+        "![Omni Duplex 实测流水线](figures/omni-duplex-pipeline.svg)",
+        "",
+        "图中只展示一个连续 SPEAK turn，并保留前后 LISTEN frame；竖线标出 1s 输入节奏，同色细线连接同一 frame 的各阶段产物。",
+        "",
+        "## 阶段概览",
+        "",
+        "| 阶段 | 平均耗时 | p90 | SPEAK tokens | SPEAK 速度 |",
+        "| --- | ---: | ---: | ---: | ---: |",
+    ]
+    for stage, _ in STAGE_ROWS:
+        row = stats.get(stage, {})
+        if not row:
+            continue
+        speed_text = ""
+        token_text = ""
+        if stage in TOKEN_SPEED_STAGES:
+            unit = "tok/s" if not stage.startswith("tts.") else "TTS tok/s"
+            speed_text = f"{speed(stage):.1f} {unit}"
+            token_text = str(int(token_stats.get(stage, {}).get("tokens", 0)))
+        lines.append(
+            f"| `{stage_display_name(stage)}` | {row.get('avg', 0.0):.1f} ms | "
+            f"{row.get('p90', 0.0):.1f} ms | {token_text or '-'} | {speed_text or '-'} |"
+        )
+
+    lines += [
+        "",
+        "## GPU 利用率",
+        "",
+    ]
+    if gpu_samples and gpu_valid_metric_count(gpu_samples) == 0:
+        gpu_summary = gpu_device_summary(gpu_samples)
+        if gpu_summary:
+            lines.append(f"- 使用 GPU：`{gpu_summary}`。")
+        lines.append(
+            f"- GPU sample：`{len(gpu_samples)}` 条，但所有利用率/显存/功耗字段均为 `NA`；"
+            "当前采样源未拿到有效指标，Jetson 上通常需要 `jetson_sysfs` fallback 或外部 `tegrastats`。"
+        )
+        lines.extend([
+            "",
+            "![GPU 利用率时间线](figures/omni-duplex-gpu-utilization.svg)",
+        ])
+    elif gpu_samples:
+        devices = ", ".join(str(d) for d in sorted({s["device"] for s in gpu_samples}))
+        gpu_summary = gpu_device_summary(gpu_samples)
+        if gpu_summary:
+            lines.append(f"- 使用 GPU：`{gpu_summary}`。")
+        lines.append(f"- GPU sample：`{len(gpu_samples)}` 条；device：`{devices}`。")
+        for stage in ["tts.prefill", "tts.decode", "t2w.infer", "duplex.llm.decode"]:
+            row = gpu_stage_summary(gpu_stats, stage)
+            if row:
+                lines.append(f"- `{stage_display_name(stage)}`: avg SM `{row['avg_sm']:.1f}%`, max SM `{row['max_sm']:.1f}%`, avg power `{row['avg_power']:.1f} W`。")
+        lines.extend([
+            "",
+            "![GPU 利用率时间线](figures/omni-duplex-gpu-utilization.svg)",
+        ])
+    elif gpu_statuses:
+        reasons = ", ".join(f"{status['event']}:{status['reason']}" for status in gpu_statuses)
+        lines.append(f"- 未解析到 GPU sample；状态：`{reasons}`。")
+    else:
+        lines.append("- 未解析到 `[DUPLEX_GPU]` sample。运行时设置 `OMNI_GPU_PROF=1` 可启用 NVML 采样。")
+    lines.append("")
+    write(path, "\n".join(lines))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--log", type=Path, default=Path("duplex_perf.log"))
+    parser.add_argument("--gpu-log", type=Path, default=None, help="Optional separate OMNI_GPU_PROF_FILE log")
+    parser.add_argument("--out-dir", type=Path, default=Path("duplex_perf_report"))
+    args = parser.parse_args()
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    cleanup_report_dir(args.out_dir)
+
+    text, events, chunks, gpu_samples, gpu_statuses = parse_log(args.log, args.gpu_log)
+    stats = stage_stats(events)
+    intervals = build_stage_intervals(events)
+    frame_rows = build_frame_summaries(events, chunks, intervals)
+    speak_frame_ids = {row["frame_id"] for row in frame_rows if row["decision"] == "speak"}
+    token_stats = stage_token_stats(events, speak_frame_ids)
+    active_devices = active_gpu_ids(gpu_samples, max_devices=1)
+    focused_gpu_samples = filter_gpu_samples(gpu_samples, active_devices)
+    gpu_stats = stage_gpu_stats(intervals, focused_gpu_samples)
+    figures = args.out_dir / "figures"
+    frame_pipeline_svg(figures / "omni-duplex-pipeline.svg", frame_rows, intervals)
+    gpu_utilization_svg(figures / "omni-duplex-gpu-utilization.svg", focused_gpu_samples, intervals)
+    write_report(args.out_dir / "omni-duplex-perf-report.md", args.log, text, events, chunks, stats, focused_gpu_samples, gpu_stats, gpu_statuses, token_stats, frame_rows)
+    print(f"parsed_events={len(events)} raw_markers={text.count('[DUPLEX_PERF]')} chunks={len(chunks)} frames={len(frame_rows)} gpu_samples={len(focused_gpu_samples)} active_gpus={','.join(str(d) for d in active_devices)}")
+    print(f"wrote={args.out_dir / 'omni-duplex-perf-report.md'}")
+    print(f"pipeline={figures / 'omni-duplex-pipeline.svg'}")
+    print(f"gpu={figures / 'omni-duplex-gpu-utilization.svg'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/omni/test/perf-test/omni_duplex_perf.cpp
+++ b/tools/omni/test/perf-test/omni_duplex_perf.cpp
@@ -1,0 +1,1117 @@
+#include "omni_duplex_perf.h"
+
+#include "common.h"
+#include "omni_perf.h"
+#include "sampling.h"
+#include "tts-condition-graph.h"
+#include "token2wav/token2wav-impl.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <sstream>
+#include <vector>
+
+bool omni_image_embed_make_chunks_with_filename(struct vision_ctx * ctx_vision,
+                                                int n_threads,
+                                                std::string image_path,
+                                                std::vector<std::vector<float>> & vision_chunks);
+
+llama_token sample_tts_token(struct common_sampler * smpl,
+                             struct omni_context * ctx_omni,
+                             common_params * params,
+                             int * n_past_tts,
+                             const std::vector<llama_token> * all_generated_tokens,
+                             const std::vector<llama_token> * chunk_generated_tokens,
+                             int token_index_in_chunk,
+                             bool force_no_eos,
+                             bool is_final_text_chunk);
+
+namespace {
+
+enum class PerfOmniTokenType {
+    NORMAL,
+    SPEAK,
+    LISTEN,
+    CHUNK_EOS,
+    CHUNK_TTS_EOS,
+    TURN_EOS,
+    TTS_EOS,
+    EOS,
+};
+
+double elapsed_ms(std::chrono::high_resolution_clock::time_point begin,
+                  std::chrono::high_resolution_clock::time_point end) {
+    return std::chrono::duration<double, std::milli>(end - begin).count();
+}
+
+PerfOmniTokenType get_token_type(struct omni_context * ctx, llama_token token) {
+    if (token == ctx->special_token_speak) {
+        return PerfOmniTokenType::SPEAK;
+    }
+    if (token == ctx->special_token_listen) {
+        return PerfOmniTokenType::LISTEN;
+    }
+    if (token == ctx->special_token_chunk_eos) {
+        return PerfOmniTokenType::CHUNK_EOS;
+    }
+    if (token == ctx->special_token_chunk_tts_eos) {
+        return PerfOmniTokenType::CHUNK_TTS_EOS;
+    }
+    if (token == ctx->special_token_turn_eos) {
+        return PerfOmniTokenType::TURN_EOS;
+    }
+    if (token == ctx->special_token_tts_eos) {
+        return PerfOmniTokenType::TTS_EOS;
+    }
+    if (token == ctx->special_token_eos) {
+        return PerfOmniTokenType::EOS;
+    }
+    return PerfOmniTokenType::NORMAL;
+}
+
+bool is_end_token(struct omni_context * ctx, llama_token token) {
+    const PerfOmniTokenType type = get_token_type(ctx, token);
+    return type == PerfOmniTokenType::LISTEN ||
+           type == PerfOmniTokenType::CHUNK_EOS ||
+           type == PerfOmniTokenType::CHUNK_TTS_EOS;
+}
+
+bool is_valid_tts_token(llama_token tid) {
+    // Keep this copy intentionally conservative: the perf LLM path only needs
+    // tokens that can feed TTS condition construction.
+    return tid >= 0 && tid < 150000;
+}
+
+bool perf_eval_tokens(struct omni_context * ctx, common_params * params,
+                      const std::vector<llama_token> & tokens,
+                      int n_batch,
+                      int * n_past,
+                      bool get_emb = false) {
+    (void) params;
+    const int n_tokens = (int) tokens.size();
+    for (int i = 0; i < n_tokens; i += n_batch) {
+        int n_eval = std::min(n_tokens - i, n_batch);
+        if (n_eval == 0) {
+            break;
+        }
+        if (get_emb) {
+            llama_set_embeddings(ctx->ctx_llama, true);
+        }
+        llama_batch batch = llama_batch_get_one(const_cast<llama_token *>(&tokens[i]), n_eval);
+        std::vector<llama_pos> pos_vec;
+        if (batch.pos == nullptr) {
+            pos_vec.resize(n_eval);
+            batch.pos = pos_vec.data();
+        }
+        for (int j = 0; j < n_eval; ++j) {
+            batch.pos[j] = *n_past + j;
+        }
+        if (llama_decode(ctx->ctx_llama, batch)) {
+            std::fprintf(stderr, "%s: failed to eval token batch\n", __func__);
+            if (get_emb) {
+                llama_set_embeddings(ctx->ctx_llama, false);
+            }
+            return false;
+        }
+        if (get_emb) {
+            llama_set_embeddings(ctx->ctx_llama, false);
+        }
+        *n_past += n_eval;
+    }
+    return true;
+}
+
+bool perf_eval_tokens_with_hidden(struct omni_context * ctx, common_params * params,
+                                  const std::vector<llama_token> & tokens,
+                                  int n_batch,
+                                  int * n_past,
+                                  float *& hidden_states) {
+    (void) params;
+    const int n_tokens = (int) tokens.size();
+    if (n_tokens == 0) {
+        hidden_states = nullptr;
+        return true;
+    }
+
+    const int n_embd = llama_model_n_embd(llama_get_model(ctx->ctx_llama));
+    hidden_states = (float *) malloc((size_t) n_tokens * n_embd * sizeof(float));
+    if (hidden_states == nullptr) {
+        return false;
+    }
+
+    int processed = 0;
+    for (int i = 0; i < n_tokens; i += n_batch) {
+        int n_eval = std::min(n_tokens - i, n_batch);
+        if (n_eval == 0) {
+            break;
+        }
+
+        llama_set_embeddings(ctx->ctx_llama, true);
+        llama_batch batch = llama_batch_get_one(const_cast<llama_token *>(&tokens[i]), n_eval);
+        std::vector<llama_pos> pos_vec;
+        if (batch.pos == nullptr) {
+            pos_vec.resize(n_eval);
+            batch.pos = pos_vec.data();
+        }
+        for (int j = 0; j < n_eval; ++j) {
+            batch.pos[j] = *n_past + j;
+        }
+        if (llama_decode(ctx->ctx_llama, batch)) {
+            llama_set_embeddings(ctx->ctx_llama, false);
+            free(hidden_states);
+            hidden_states = nullptr;
+            return false;
+        }
+        float * emb = llama_get_embeddings(ctx->ctx_llama);
+        if (emb != nullptr) {
+            std::memcpy(hidden_states + (size_t) processed * n_embd, emb, (size_t) n_eval * n_embd * sizeof(float));
+        }
+        llama_set_embeddings(ctx->ctx_llama, false);
+        *n_past += n_eval;
+        processed += n_eval;
+    }
+    return true;
+}
+
+bool perf_eval_string(struct omni_context * ctx, common_params * params,
+                      const char * text, int n_batch, int * n_past, bool add_bos) {
+    std::vector<llama_token> tokens = common_tokenize(ctx->ctx_llama, text, add_bos, true);
+    return perf_eval_tokens(ctx, params, tokens, n_batch, n_past);
+}
+
+bool perf_eval_id_with_hidden(struct omni_context * ctx, common_params * params,
+                              llama_token id, int * n_past, float *& hidden_states) {
+    std::vector<llama_token> tokens = {id};
+    return perf_eval_tokens_with_hidden(ctx, params, tokens, 1, n_past, hidden_states);
+}
+
+const char * perf_sample_with_hidden_and_token(struct common_sampler * smpl,
+                                               struct omni_context * ctx,
+                                               common_params * params,
+                                               int * n_past,
+                                               float *& hidden_states,
+                                               llama_token & token_id) {
+    float * logits = llama_get_logits_ith(ctx->ctx_llama, -1);
+    if (ctx->duplex_mode && logits != nullptr) {
+        if (ctx->special_token_listen >= 0) {
+            const float listen_bias = (ctx->listen_prob_scale - 1.0f) * 2.0f;
+            logits[ctx->special_token_listen] += listen_bias;
+        }
+        if (ctx->special_token_tts_pad >= 0) {
+            logits[ctx->special_token_tts_pad] = -INFINITY;
+        }
+        if (ctx->length_penalty != 1.0f && ctx->special_token_turn_eos >= 0) {
+            float eos_logit = logits[ctx->special_token_turn_eos];
+            logits[ctx->special_token_turn_eos] = eos_logit > 0 ? eos_logit / ctx->length_penalty
+                                                                : eos_logit * ctx->length_penalty;
+        }
+    }
+
+    const llama_token id = common_sampler_sample(smpl, ctx->ctx_llama, -1);
+    token_id = id;
+    common_sampler_accept(smpl, id, true);
+
+    static std::string piece;
+    if (llama_vocab_is_eog(llama_model_get_vocab(llama_get_model(ctx->ctx_llama)), id)) {
+        piece = "</s>";
+    } else {
+        piece = common_token_to_piece(ctx->ctx_llama, id);
+    }
+    perf_eval_id_with_hidden(ctx, params, id, n_past, hidden_states);
+    return piece.c_str();
+}
+
+std::string clean_response_text(std::string response) {
+    static const std::vector<std::string> end_tokens = {
+        "<|tts_eos|>", "</s>", "<|listen|>", "<|turn_eos|>",
+        "<|chunk_eos|>", "<|chunk_tts_eos|>"
+    };
+    for (const auto & token : end_tokens) {
+        const size_t pos = response.find(token);
+        if (pos != std::string::npos) {
+            response = response.substr(0, pos);
+        }
+    }
+    size_t speak_pos = response.find("<|speak|>");
+    while (speak_pos != std::string::npos) {
+        response.erase(speak_pos, std::string("<|speak|>").length());
+        speak_pos = response.find("<|speak|>");
+    }
+    return response;
+}
+
+std::string frame_detail(int64_t frame_id, int64_t user_seq) {
+    std::ostringstream ss;
+    ss << "frame_id=" << frame_id << ",user_seq=" << user_seq;
+    return ss.str();
+}
+
+bool emb_text_lookup(struct omni_context * ctx, llama_token token, std::vector<float> & out, int tts_n_embd) {
+    if (ctx->emb_text_weight == nullptr || token < 0 || token >= ctx->emb_text_vocab_size) {
+        return false;
+    }
+    out.resize(tts_n_embd);
+    const float * src = ctx->emb_text_weight + (size_t) token * tts_n_embd;
+    std::copy(src, src + tts_n_embd, out.begin());
+    return true;
+}
+
+void write_wav_file(const std::string & path, const std::vector<float> & wav, int sample_rate) {
+    std::vector<int16_t> pcm(wav.size());
+    for (size_t i = 0; i < wav.size(); ++i) {
+        float x = wav[i];
+        if (!std::isfinite(x)) {
+            x = 0.0f;
+        }
+        x = std::max(-1.0f, std::min(1.0f, x));
+        pcm[i] = (int16_t) (x * 32767.0f);
+    }
+
+    const int16_t num_channels = 1;
+    const int16_t bits_per_sample = 16;
+    const int16_t block_align = num_channels * (bits_per_sample / 8);
+    const int32_t byte_rate = sample_rate * block_align;
+    const uint32_t data_bytes = (uint32_t) (pcm.size() * sizeof(int16_t));
+    const uint32_t riff_size = 36u + data_bytes;
+
+    FILE * f = std::fopen(path.c_str(), "wb");
+    if (f == nullptr) {
+        return;
+    }
+    std::fwrite("RIFF", 1, 4, f);
+    std::fwrite(&riff_size, 4, 1, f);
+    std::fwrite("WAVE", 1, 4, f);
+    std::fwrite("fmt ", 1, 4, f);
+    uint32_t fmt_size = 16;
+    uint16_t audio_format = 1;
+    std::fwrite(&fmt_size, 4, 1, f);
+    std::fwrite(&audio_format, 2, 1, f);
+    std::fwrite(&num_channels, 2, 1, f);
+    std::fwrite(&sample_rate, 4, 1, f);
+    std::fwrite(&byte_rate, 4, 1, f);
+    std::fwrite(&block_align, 2, 1, f);
+    std::fwrite(&bits_per_sample, 2, 1, f);
+    std::fwrite("data", 1, 4, f);
+    std::fwrite(&data_bytes, 4, 1, f);
+    std::fwrite(pcm.data(), 1, data_bytes, f);
+    std::fclose(f);
+}
+
+} // namespace
+
+OmniDuplexPerfSession::~OmniDuplexPerfSession() {
+    end();
+}
+
+bool OmniDuplexPerfSession::begin(struct omni_context * ctx_omni,
+                                  const std::string & voice_audio,
+                                  const std::string & debug_dir_) {
+    if (ctx_omni == nullptr) {
+        return false;
+    }
+    ctx = ctx_omni;
+    params = ctx_omni->params;
+    debug_dir = debug_dir_.empty() ? std::string("./") : debug_dir_;
+    running.store(true);
+
+    omni_gpu_perf_sampler_start();
+    // Reuse the existing system prompt initialization for now. Subsequent frame
+    // prefill/decode goes through this perf pipeline instead of omni.cpp's
+    // duplex_prefill / duplex_decode route.
+    const bool old_async = ctx->async;
+    ctx->async = false;
+    if (!stream_prefill(ctx, voice_audio, "", 0)) {
+        ctx->async = old_async;
+        running.store(false);
+        omni_gpu_perf_sampler_stop();
+        return false;
+    }
+    ctx->async = old_async;
+
+    encoder_thread = std::thread(&OmniDuplexPerfSession::encoder_thread_func, this);
+    llm_thread = std::thread(&OmniDuplexPerfSession::llm_thread_func, this);
+    if (ctx->use_tts) {
+        tts_thread = std::thread(&OmniDuplexPerfSession::tts_thread_func, this);
+        t2w_thread = std::thread(&OmniDuplexPerfSession::t2w_thread_func, this);
+    }
+    return true;
+}
+
+int64_t OmniDuplexPerfSession::push_frame(const OmniDuplexFrame & frame) {
+    if (!running.load()) {
+        return -1;
+    }
+
+    auto * req = new EncodeReq();
+    req->frame = frame;
+    req->frame_id = frame_id_counter.fetch_add(1) + 1;
+    req->t_push = std::chrono::high_resolution_clock::now();
+
+    {
+        std::unique_lock<std::mutex> lock(encode_mtx);
+        encode_cv.wait(lock, [&] {
+            return encode_queue.size() < ENCODE_QUEUE_CAP || !running.load();
+        });
+        if (!running.load()) {
+            delete req;
+            return -1;
+        }
+        encode_queue.push(req);
+    }
+
+    in_flight.fetch_add(1);
+    encode_cv.notify_all();
+    return req->frame_id;
+}
+
+bool OmniDuplexPerfSession::wait_next_frame(OmniDuplexFrameResult * out, int timeout_ms) {
+    if (out == nullptr) {
+        return false;
+    }
+
+    std::unique_lock<std::mutex> lock(done_mtx);
+    if (timeout_ms < 0) {
+        done_cv.wait(lock, [&] { return !done_results.empty() || !running.load(); });
+    } else if (timeout_ms == 0) {
+        if (done_results.empty()) {
+            return false;
+        }
+    } else {
+        bool got = done_cv.wait_for(lock, std::chrono::milliseconds(timeout_ms), [&] {
+            return !done_results.empty() || !running.load();
+        });
+        if (!got) {
+            return false;
+        }
+    }
+
+    if (done_results.empty()) {
+        return false;
+    }
+    *out = std::move(done_results.front());
+    done_results.pop();
+    return true;
+}
+
+void OmniDuplexPerfSession::end() {
+    if (!running.exchange(false)) {
+        return;
+    }
+    while (in_flight.load() > 0) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    encode_cv.notify_all();
+    llm_cv.notify_all();
+    tts_cv.notify_all();
+    t2w_cv.notify_all();
+    done_cv.notify_all();
+    if (encoder_thread.joinable()) {
+        encoder_thread.join();
+    }
+    if (llm_thread.joinable()) {
+        llm_thread.join();
+    }
+    if (tts_thread.joinable()) {
+        tts_thread.join();
+    }
+    if (t2w_thread.joinable()) {
+        t2w_thread.join();
+    }
+    omni_perf_print_token_stats(ctx);
+    omni_gpu_perf_sampler_stop();
+}
+
+void OmniDuplexPerfSession::encoder_thread_func() {
+    const int hidden_size = llama_model_n_embd(llama_get_model(ctx->ctx_llama));
+    while (running.load()) {
+        EncodeReq * req = nullptr;
+        {
+            std::unique_lock<std::mutex> lock(encode_mtx);
+            encode_cv.wait(lock, [&] { return !encode_queue.empty() || !running.load(); });
+            if (!running.load() && encode_queue.empty()) {
+                break;
+            }
+            req = encode_queue.front();
+            encode_queue.pop();
+        }
+        encode_cv.notify_all();
+
+        auto * packet = new PrefillPacket();
+        packet->frame_id = req->frame_id;
+        packet->user_seq = req->frame.user_seq;
+        packet->t_push = req->t_push;
+
+        const bool has_img = !req->frame.img_fname.empty() && ctx->ctx_vision != nullptr;
+        const bool has_aud = !req->frame.aud_fname.empty();
+        const int perf_chunk_index = (int) req->frame_id;
+        const auto t0 = std::chrono::high_resolution_clock::now();
+        std::string start_detail = frame_detail(req->frame_id, req->frame.user_seq) +
+                                   ",has_img=" + std::to_string(has_img ? 1 : 0) +
+                                   ",has_aud=" + std::to_string(has_aud ? 1 : 0);
+        omni_perf_mark(ctx, "duplex.encode", "start", perf_chunk_index, -1.0, start_detail.c_str());
+
+        if (has_img && req->frame.max_slice_nums >= 1) {
+            vision_set_max_slice_nums(ctx->ctx_vision, req->frame.max_slice_nums);
+        }
+        if (has_img) {
+            omni_image_embed_make_chunks_with_filename(ctx->ctx_vision,
+                                                       params->cpuparams.n_threads,
+                                                       req->frame.img_fname,
+                                                       packet->vision_embed);
+        }
+        if (has_aud) {
+            auto * audio = omni_audio_embed_make_with_filename(ctx->ctx_audio,
+                                                               params->cpuparams.n_threads,
+                                                               req->frame.aud_fname);
+            if (audio != nullptr && audio->n_pos > 0) {
+                packet->audio_embed.resize((size_t) audio->n_pos * hidden_size);
+                std::memcpy(packet->audio_embed.data(), audio->embed, packet->audio_embed.size() * sizeof(float));
+                omni_embed_free(audio);
+            }
+        }
+        packet->t_encoded = std::chrono::high_resolution_clock::now();
+        const double enc_ms = elapsed_ms(t0, packet->t_encoded);
+        std::string end_detail = start_detail +
+                                 ",vision_chunks=" + std::to_string(packet->vision_embed.size()) +
+                                 ",audio_tokens=" + std::to_string(hidden_size > 0 ? (int) packet->audio_embed.size() / hidden_size : 0);
+        omni_perf_mark(ctx, "duplex.encode", "end", perf_chunk_index, enc_ms, end_detail.c_str());
+
+        delete req;
+        {
+            std::unique_lock<std::mutex> lock(llm_mtx);
+            llm_cv.wait(lock, [&] { return prefill_queue.size() < PREFILL_QUEUE_CAP || !running.load(); });
+            if (!running.load()) {
+                delete packet;
+                break;
+            }
+            prefill_queue.push(packet);
+        }
+        llm_cv.notify_all();
+    }
+}
+
+bool OmniDuplexPerfSession::do_prefill(PrefillPacket * packet, double & prefill_ms, long long & prefill_tokens) {
+    const int hidden_size = llama_model_n_embd(llama_get_model(ctx->ctx_llama));
+    const int n_past_before = ctx->n_past;
+    const auto t0 = std::chrono::high_resolution_clock::now();
+    const int perf_chunk_index = (int) packet->frame_id;
+    std::string detail = frame_detail(packet->frame_id, packet->user_seq);
+    omni_perf_mark(ctx, "duplex.llm.prefill", "start", perf_chunk_index, -1.0, detail.c_str());
+
+    if (ctx->sliding_window_config.mode != "off") {
+        sliding_window_register_unit_start(ctx);
+    }
+
+    bool ok = true;
+    const bool has_vision = !packet->vision_embed.empty();
+    const int n_audio_tokens = hidden_size > 0 ? (int) packet->audio_embed.size() / hidden_size : 0;
+    const bool has_audio = n_audio_tokens > 0;
+
+    if (has_vision) {
+        const int n_chunks = (int) packet->vision_embed.size();
+        const int tokens_per_chunk = (int) packet->vision_embed[0].size() / hidden_size;
+        ok &= perf_eval_string(ctx, params, "<unit><image>", params->n_batch, &ctx->n_past, false);
+        ok &= prefill_with_emb(ctx, params, packet->vision_embed[0].data(), tokens_per_chunk, params->n_batch, &ctx->n_past);
+        ok &= perf_eval_string(ctx, params, "</image>", params->n_batch, &ctx->n_past, false);
+        for (int i = 1; ok && i < n_chunks; ++i) {
+            ok &= perf_eval_string(ctx, params, "<slice>", params->n_batch, &ctx->n_past, false);
+            ok &= prefill_with_emb(ctx, params, packet->vision_embed[i].data(), tokens_per_chunk, params->n_batch, &ctx->n_past);
+            ok &= perf_eval_string(ctx, params, "</slice>", params->n_batch, &ctx->n_past, false);
+        }
+        if (ok && n_chunks > 1) {
+            ok &= perf_eval_string(ctx, params, "\n", params->n_batch, &ctx->n_past, false);
+        }
+        if (ok && has_audio) {
+            ok &= prefill_with_emb(ctx, params, packet->audio_embed.data(), n_audio_tokens, params->n_batch, &ctx->n_past);
+        }
+    } else {
+        ok &= perf_eval_string(ctx, params, "<unit>", params->n_batch, &ctx->n_past, false);
+        if (ok && has_audio) {
+            ok &= prefill_with_emb(ctx, params, packet->audio_embed.data(), n_audio_tokens, params->n_batch, &ctx->n_past);
+        }
+    }
+
+    if (ctx->sliding_window_config.mode != "off") {
+        std::string unit_type = "audio";
+        if (has_vision) {
+            unit_type = has_audio ? "omni" : "video";
+        }
+        sliding_window_register_unit_end(ctx, unit_type);
+    }
+
+    const auto t1 = std::chrono::high_resolution_clock::now();
+    prefill_ms = elapsed_ms(t0, t1);
+    prefill_tokens = ctx->n_past - n_past_before;
+    std::string end_detail = detail +
+                             ",tokens=" + std::to_string(prefill_tokens) +
+                             omni_perf_speed_detail(prefill_tokens, prefill_ms);
+    omni_perf_record_tokens(ctx, "duplex.llm.prefill", prefill_tokens, prefill_ms);
+    omni_perf_mark(ctx, "duplex.llm.prefill", ok ? "end" : "error", perf_chunk_index, prefill_ms, end_detail.c_str());
+    return ok;
+}
+
+bool OmniDuplexPerfSession::do_decode(const DecodeReq & req, OmniDuplexFrameResult & result) {
+    const int perf_chunk_index = (int) req.frame_id;
+    const auto t0 = std::chrono::high_resolution_clock::now();
+    const int n_past_before = ctx->n_past;
+    const int llm_n_embd = llama_model_n_embd(llama_get_model(ctx->ctx_llama));
+    result.user_seq = req.user_seq;
+    result.frame_id = req.frame_id;
+
+    std::string start_detail = frame_detail(req.frame_id, req.user_seq);
+    omni_perf_mark(ctx, "duplex.llm.decode", "start", perf_chunk_index, -1.0, start_detail.c_str());
+
+    ctx->stream_decode_start_time = t0;
+    ctx->ended_with_listen = false;
+    if (ctx->break_event.load()) {
+        ctx->break_event.store(false);
+    }
+    {
+        std::lock_guard<std::mutex> lock(ctx->text_mtx);
+        ctx->text_queue.clear();
+        ctx->text_done_flag = false;
+        ctx->text_streaming = true;
+    }
+    if (ctx->use_tts) {
+        ctx->speek_done = false;
+    }
+
+    if (ctx->force_listen_used < ctx->force_listen_count) {
+        ctx->force_listen_used++;
+        ctx->ended_with_listen = true;
+        ctx->slide_last_was_listen = true;
+        ctx->current_turn_ended = false;
+        if (ctx->use_tts) {
+            ctx->speek_done = true;
+        }
+        {
+            std::lock_guard<std::mutex> lock(ctx->text_mtx);
+            ctx->text_queue.push_back("__IS_LISTEN__");
+            ctx->text_done_flag = true;
+            ctx->text_streaming = false;
+            ctx->text_cv.notify_all();
+        }
+        const auto t1 = std::chrono::high_resolution_clock::now();
+        result.ok = true;
+        result.is_speak = false;
+        result.n_past_after = ctx->n_past;
+        result.ms_decode = elapsed_ms(t0, t1);
+        omni_perf_mark(ctx, "duplex.llm.decode", "end", perf_chunk_index, result.ms_decode,
+                       (start_detail + ",tokens=0,is_speak=0,force_listen=1").c_str());
+        return true;
+    }
+
+    const int max_tgt_len = params->n_predict < 0 ? params->n_ctx : params->n_predict;
+    const int step_size = 10;
+    bool llm_finish = false;
+    bool local_is_end_of_turn = false;
+    int current_chunk_tokens = 0;
+    const int max_chunk_tokens = ctx->max_new_speak_tokens_per_chunk;
+    bool chunk_limit_reached = false;
+    const int decode_start_cache_len = ctx->n_past;
+    std::string response;
+
+    for (int il = 0; il < max_tgt_len && !llm_finish; ) {
+        if (ctx->break_event.load()) {
+            llm_finish = true;
+            break;
+        }
+
+        response.clear();
+        int jl = 0;
+        int total_tokens_generated = 0;
+        std::vector<llama_token> chunk_token_ids;
+        std::vector<float> chunk_hidden_states;
+        local_is_end_of_turn = false;
+
+        while (jl < step_size && !llm_finish && !ctx->break_event.load() && !chunk_limit_reached) {
+            float * hidden_states = nullptr;
+            llama_token sampled_token = 0;
+            const char * piece = perf_sample_with_hidden_and_token(ctx->ctx_sampler, ctx, params,
+                                                                   &ctx->n_past, hidden_states, sampled_token);
+            total_tokens_generated++;
+            if (piece == nullptr) {
+                break;
+            }
+            if (hidden_states != nullptr && is_valid_tts_token(sampled_token)) {
+                chunk_token_ids.push_back(sampled_token);
+                chunk_hidden_states.insert(chunk_hidden_states.end(), hidden_states, hidden_states + llm_n_embd);
+                jl++;
+                current_chunk_tokens++;
+                if (max_chunk_tokens > 0 && current_chunk_tokens >= max_chunk_tokens) {
+                    chunk_limit_reached = true;
+                }
+            }
+
+            const PerfOmniTokenType token_type = get_token_type(ctx, sampled_token);
+            if (token_type == PerfOmniTokenType::TURN_EOS ||
+                token_type == PerfOmniTokenType::TTS_EOS ||
+                token_type == PerfOmniTokenType::EOS) {
+                local_is_end_of_turn = true;
+                ctx->current_turn_ended = true;
+            } else if (token_type == PerfOmniTokenType::LISTEN && !ctx->slide_last_was_listen.load()) {
+                local_is_end_of_turn = true;
+            }
+            if (is_end_token(ctx, sampled_token)) {
+                llm_finish = true;
+                if (token_type == PerfOmniTokenType::LISTEN) {
+                    ctx->ended_with_listen = true;
+                    ctx->slide_last_was_listen = true;
+                    std::lock_guard<std::mutex> lock(ctx->text_mtx);
+                    ctx->text_queue.push_back("__IS_LISTEN__");
+                    ctx->text_cv.notify_all();
+                } else {
+                    ctx->slide_last_was_listen = false;
+                }
+                break;
+            }
+            response += piece;
+        }
+
+        if (chunk_limit_reached) {
+            if (ctx->special_token_chunk_eos >= 0) {
+                std::vector<llama_token> chunk_eos_tokens = {ctx->special_token_chunk_eos};
+                perf_eval_tokens(ctx, params, chunk_eos_tokens, params->n_batch, &ctx->n_past);
+            }
+            llm_finish = true;
+            current_chunk_tokens = 0;
+        }
+
+        if (ctx->special_token_unit_end >= 0) {
+            std::vector<llama_token> unit_end = {ctx->special_token_unit_end};
+            perf_eval_tokens(ctx, params, unit_end, params->n_batch, &ctx->n_past);
+        }
+
+        il += total_tokens_generated;
+        response = clean_response_text(response);
+        if (!response.empty()) {
+            std::lock_guard<std::mutex> lock(ctx->text_mtx);
+            ctx->text_queue.push_back(response);
+            ctx->text_cv.notify_all();
+            result.text += response;
+        }
+
+        if (ctx->use_tts && (!response.empty() || llm_finish)) {
+            auto * llm_out = new PerfLLMOut();
+            llm_out->text = response;
+            llm_out->n_past = ctx->n_past;
+            llm_out->llm_finish = llm_finish;
+            llm_out->debug_dir = debug_dir;
+            llm_out->token_ids = chunk_token_ids;
+            llm_out->hidden_states = chunk_hidden_states;
+            llm_out->n_embd = llm_n_embd;
+            llm_out->is_end_of_turn = local_is_end_of_turn;
+            llm_out->perf_chunk_index = perf_chunk_index;
+            {
+                std::unique_lock<std::mutex> lock(tts_mtx);
+                tts_cv.wait(lock, [&] {
+                    return tts_queue.size() < TTS_QUEUE_CAP || !running.load();
+                });
+                tts_queue.push(llm_out);
+            }
+            tts_cv.notify_all();
+        }
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(ctx->text_mtx);
+        if (!ctx->ended_with_listen) {
+            ctx->text_queue.push_back("__END_OF_TURN__");
+        }
+        ctx->text_done_flag = true;
+        ctx->text_streaming = false;
+        ctx->text_cv.notify_all();
+    }
+
+    if (ctx->sliding_window_config.mode != "off") {
+        int response_len = ctx->n_past - decode_start_cache_len;
+        if (response_len > 0) {
+            UnitEntry entry;
+            entry.unit_id = ctx->next_unit_id++;
+            entry.length = response_len;
+            entry.type = "response";
+            entry.is_listen = ctx->ended_with_listen.load();
+            entry.turn_id = ctx->current_turn_id;
+            ctx->unit_history.push_back(entry);
+        }
+    }
+
+    if (ctx->ended_with_listen) {
+        ctx->round_start_positions.push_back(ctx->n_past);
+        ctx->current_turn_id++;
+    }
+
+    const auto t1 = std::chrono::high_resolution_clock::now();
+    result.ok = true;
+    result.is_speak = !ctx->ended_with_listen.load();
+    result.n_past_after = ctx->n_past;
+    result.ms_decode = elapsed_ms(t0, t1);
+    const long long decode_tokens = ctx->n_past - n_past_before;
+    std::string end_detail = start_detail +
+                             ",tokens=" + std::to_string(decode_tokens) +
+                             ",is_speak=" + std::to_string(result.is_speak ? 1 : 0) +
+                             omni_perf_speed_detail(decode_tokens, result.ms_decode);
+    omni_perf_record_tokens(ctx, "duplex.llm.decode", decode_tokens, result.ms_decode);
+    omni_perf_mark(ctx, "duplex.llm.decode", "end", perf_chunk_index, result.ms_decode, end_detail.c_str());
+    return true;
+}
+
+bool OmniDuplexPerfSession::generate_audio_tokens(const std::vector<float> & merged_embeddings,
+                                                  int n_tokens,
+                                                  int tts_n_embd,
+                                                  int tts_chunk_idx,
+                                                  bool is_end_of_turn,
+                                                  int perf_chunk_index) {
+    const int audio_bos_token_id = 151687;
+    const int text_eos_token_id = 151692;
+    const int num_audio_tokens = 6562;
+    std::vector<float> condition = merged_embeddings;
+    if (is_end_of_turn) {
+        std::vector<float> text_eos;
+        if (emb_text_lookup(ctx, text_eos_token_id, text_eos, tts_n_embd)) {
+            condition.insert(condition.end(), text_eos.begin(), text_eos.end());
+            n_tokens += 1;
+        }
+    }
+    std::vector<float> audio_bos;
+    if (emb_text_lookup(ctx, audio_bos_token_id, audio_bos, tts_n_embd)) {
+        condition.insert(condition.end(), audio_bos.begin(), audio_bos.end());
+        n_tokens += 1;
+    }
+
+    if (n_tokens <= 0 || condition.empty()) {
+        return false;
+    }
+
+    if (tts_chunk_idx == 0) {
+        llama_memory_t mem = llama_get_memory(ctx->ctx_tts_llama);
+        if (mem) {
+            llama_memory_seq_rm(mem, 0, 0, -1);
+        }
+        ctx->tts_n_past_accumulated = 0;
+        ctx->tts_all_generated_tokens.clear();
+        ctx->tts_condition_saved = false;
+    }
+
+    ctx->tts_condition_embeddings = condition;
+    ctx->tts_condition_length = n_tokens;
+    ctx->tts_condition_n_embd = tts_n_embd;
+    ctx->tts_condition_saved = true;
+
+    int n_past_tts = tts_chunk_idx == 0 ? 0 : ctx->tts_n_past_accumulated;
+    std::string prefill_detail = "tts_chunk=" + std::to_string(tts_chunk_idx) +
+                                 ",tokens=" + std::to_string(n_tokens) +
+                                 ",is_end_of_turn=" + std::to_string(is_end_of_turn ? 1 : 0);
+    {
+        OmniPerfScope scope(ctx, "tts.prefill", perf_chunk_index, prefill_detail);
+        scope.set_tokens(n_tokens);
+        if (!prefill_with_emb_tts(ctx, params, condition.data(), n_tokens, params->n_batch, &n_past_tts)) {
+            return false;
+        }
+    }
+
+    common_params_sampling tts_sampling = params->sampling;
+    tts_sampling.temp = ctx->tts_temperature;
+    tts_sampling.top_p = 0.85f;
+    tts_sampling.top_k = 25;
+    tts_sampling.penalty_repeat = 1.05f;
+    tts_sampling.min_p = 0.01f;
+    tts_sampling.penalty_last_n = 16;
+    common_sampler * sampler = common_sampler_init(ctx->model_tts, tts_sampling);
+    if (sampler == nullptr) {
+        return false;
+    }
+
+    const int min_new_tokens = is_end_of_turn ? 0 : 26;
+    const int max_audio_tokens = is_end_of_turn ? 100 : 26;
+    std::vector<llama_token> chunk_generated_tokens;
+    std::vector<int32_t> stream_buffer;
+    bool first_chunk_pushed = false;
+    bool produced = false;
+
+    std::string decode_detail = "tts_chunk=" + std::to_string(tts_chunk_idx) +
+                                ",max_audio_tokens=" + std::to_string(max_audio_tokens) +
+                                ",is_end_of_turn=" + std::to_string(is_end_of_turn ? 1 : 0);
+    {
+        OmniPerfScope scope(ctx, "tts.decode", perf_chunk_index, decode_detail);
+        for (int t = 0; t < max_audio_tokens; ++t) {
+            const bool force_no_eos = t < min_new_tokens;
+            llama_token sampled = sample_tts_token(sampler, ctx, params, &n_past_tts,
+                                                   &ctx->tts_all_generated_tokens,
+                                                   &chunk_generated_tokens,
+                                                   t,
+                                                   force_no_eos,
+                                                   is_end_of_turn);
+            if (sampled == 0) {
+                break;
+            }
+            int relative_idx = sampled - audio_bos_token_id;
+            if (relative_idx < 0 || relative_idx >= num_audio_tokens) {
+                break;
+            }
+            const bool is_eos = relative_idx == num_audio_tokens - 1;
+            if (!is_eos) {
+                stream_buffer.push_back(relative_idx);
+                ctx->tts_all_generated_tokens.push_back(sampled);
+                chunk_generated_tokens.push_back(sampled);
+                produced = true;
+            }
+
+            const int push_threshold = first_chunk_pushed ? 25 : 28;
+            if ((int) stream_buffer.size() >= push_threshold && !is_end_of_turn) {
+                first_chunk_pushed = true;
+                auto * out = new PerfT2WOut();
+                out->audio_tokens.assign(stream_buffer.begin(), stream_buffer.end());
+                out->is_final = false;
+                out->is_chunk_end = false;
+                out->round_idx = ctx->simplex_round_idx;
+                out->perf_chunk_index = perf_chunk_index;
+                {
+                    std::lock_guard<std::mutex> lock(t2w_mtx);
+                    t2w_queue.push(out);
+                }
+                t2w_cv.notify_all();
+                stream_buffer.clear();
+            }
+            if (is_eos) {
+                break;
+            }
+        }
+        scope.set_tokens((long long) chunk_generated_tokens.size());
+    }
+
+    {
+        auto * out = new PerfT2WOut();
+        out->audio_tokens.assign(stream_buffer.begin(), stream_buffer.end());
+        out->is_final = is_end_of_turn;
+        out->is_chunk_end = !is_end_of_turn;
+        out->round_idx = ctx->simplex_round_idx;
+        out->perf_chunk_index = perf_chunk_index;
+        {
+            std::lock_guard<std::mutex> lock(t2w_mtx);
+            t2w_queue.push(out);
+        }
+        t2w_cv.notify_all();
+    }
+
+    ctx->tts_n_past_accumulated = n_past_tts;
+    common_sampler_free(sampler);
+    return produced || is_end_of_turn;
+}
+
+void OmniDuplexPerfSession::tts_thread_func() {
+    int tts_chunk_idx = 0;
+    while (running.load() || !tts_queue.empty()) {
+        std::vector<PerfLLMOut *> items;
+        {
+            std::unique_lock<std::mutex> lock(tts_mtx);
+            tts_cv.wait(lock, [&] { return !tts_queue.empty() || !running.load(); });
+            while (!tts_queue.empty()) {
+                PerfLLMOut * item = tts_queue.front();
+                tts_queue.pop();
+                items.push_back(item);
+                if (item->is_end_of_turn) {
+                    break;
+                }
+            }
+        }
+        if (items.empty()) {
+            continue;
+        }
+
+        std::vector<llama_token> token_ids;
+        std::vector<float> hidden_states;
+        int n_embd = 0;
+        bool is_end_of_turn = false;
+        int perf_chunk_index = -1;
+        for (PerfLLMOut * item : items) {
+            if (perf_chunk_index < 0) {
+                perf_chunk_index = item->perf_chunk_index;
+            }
+            is_end_of_turn = is_end_of_turn || item->is_end_of_turn;
+            if (!item->token_ids.empty() && !item->hidden_states.empty()) {
+                token_ids.insert(token_ids.end(), item->token_ids.begin(), item->token_ids.end());
+                hidden_states.insert(hidden_states.end(), item->hidden_states.begin(), item->hidden_states.end());
+                n_embd = item->n_embd;
+            }
+            delete item;
+        }
+
+        if (token_ids.empty() || hidden_states.empty() || n_embd <= 0) {
+            if (is_end_of_turn) {
+                auto * out = new PerfT2WOut();
+                out->is_final = true;
+                out->round_idx = ctx->simplex_round_idx;
+                out->perf_chunk_index = perf_chunk_index;
+                {
+                    std::lock_guard<std::mutex> lock(t2w_mtx);
+                    t2w_queue.push(out);
+                }
+                t2w_cv.notify_all();
+            }
+            continue;
+        }
+
+        std::vector<float> merged_embeddings;
+        int tts_n_embd = 0;
+        std::string condition_detail = "tts_chunk=" + std::to_string(tts_chunk_idx) +
+                                       ",llm_tokens=" + std::to_string(token_ids.size()) +
+                                       ",is_end_of_turn=" + std::to_string(is_end_of_turn ? 1 : 0);
+        const auto t0 = std::chrono::steady_clock::now();
+        omni_perf_mark(ctx, "tts.condition", "start", perf_chunk_index, -1.0, condition_detail.c_str());
+        if (!ctx->tts_condition_graph.initialized) {
+            tts_condition_graph_init(ctx);
+        }
+        bool ok = tts_condition_graph_forward(ctx, token_ids.data(), hidden_states.data(),
+                                              (int) token_ids.size(), n_embd,
+                                              merged_embeddings, tts_n_embd);
+        const double condition_ms = std::chrono::duration<double, std::milli>(
+            std::chrono::steady_clock::now() - t0).count();
+        std::string end_detail = condition_detail +
+                                 ",condition_tokens=" + std::to_string(ok ? (int) token_ids.size() : 0) +
+                                 ",tokens=" + std::to_string(ok ? (int) token_ids.size() : 0) +
+                                 ",merged_success=" + std::to_string(ok ? 1 : 0);
+        omni_perf_mark(ctx, "tts.condition", "end", perf_chunk_index, condition_ms, end_detail.c_str());
+        if (ok) {
+            generate_audio_tokens(merged_embeddings, (int) token_ids.size(), tts_n_embd,
+                                  tts_chunk_idx, is_end_of_turn, perf_chunk_index);
+            ++tts_chunk_idx;
+        }
+    }
+}
+
+void OmniDuplexPerfSession::t2w_thread_func() {
+    const int sample_rate = 24000;
+    const int chunk_size = 25;
+    const int pre_lookahead = 3;
+    int wav_idx = 0;
+    std::vector<int32_t> token_buffer = {4218, 4218, 4218};
+    std::string wav_dir = ctx->base_output_dir + "/tts_wav";
+    std::filesystem::create_directories(wav_dir);
+
+    while (running.load() || !t2w_queue.empty()) {
+        std::vector<int32_t> new_tokens;
+        bool is_final = false;
+        bool is_chunk_end = false;
+        int perf_chunk_index = -1;
+        {
+            std::unique_lock<std::mutex> lock(t2w_mtx);
+            t2w_cv.wait(lock, [&] { return !t2w_queue.empty() || !running.load(); });
+            while (!t2w_queue.empty()) {
+                PerfT2WOut * item = t2w_queue.front();
+                t2w_queue.pop();
+                new_tokens.insert(new_tokens.end(), item->audio_tokens.begin(), item->audio_tokens.end());
+                is_final = is_final || item->is_final;
+                is_chunk_end = is_chunk_end || item->is_chunk_end;
+                if (perf_chunk_index < 0) {
+                    perf_chunk_index = item->perf_chunk_index;
+                }
+                delete item;
+            }
+        }
+
+        if (new_tokens.empty() && !is_chunk_end && !is_final) {
+            continue;
+        }
+
+        token_buffer.insert(token_buffer.end(), new_tokens.begin(), new_tokens.end());
+        const bool need_flush = is_final;
+        const size_t window_size = (size_t) (chunk_size + pre_lookahead);
+        while (token_buffer.size() >= window_size || (need_flush && !token_buffer.empty())) {
+            const size_t process_size = std::min(token_buffer.size(), window_size);
+            const bool is_last_window = is_final && token_buffer.size() <= window_size;
+            std::vector<int32_t> window(token_buffer.begin(), token_buffer.begin() + process_size);
+
+            std::string detail = "backend=cpp,window_tokens=" + std::to_string(window.size()) +
+                                 ",is_last=" + std::to_string(is_last_window ? 1 : 0);
+            auto t0 = std::chrono::steady_clock::now();
+            omni_perf_mark(ctx, "t2w.infer", "start", perf_chunk_index, -1.0, detail.c_str());
+            std::vector<float> wav;
+            bool ok = ctx->token2wav_session && ctx->token2wav_session->feed_window(window, is_last_window, wav);
+            const double infer_ms = std::chrono::duration<double, std::milli>(
+                std::chrono::steady_clock::now() - t0).count();
+            omni_perf_mark(ctx, "t2w.infer", "end", perf_chunk_index, infer_ms,
+                           (detail + ",ok=" + std::to_string(ok ? 1 : 0) + ",wav_samples=" + std::to_string(wav.size())).c_str());
+
+            if (ok && !wav.empty()) {
+                const std::string wav_path = wav_dir + "/wav_" + std::to_string(ctx->wav_turn_base + wav_idx) + ".wav";
+                std::string write_detail = "backend=cpp,wav_samples=" + std::to_string(wav.size()) +
+                                           ",path=" + wav_path;
+                auto tw = std::chrono::steady_clock::now();
+                omni_perf_mark(ctx, "t2w.write", "start", perf_chunk_index, -1.0, write_detail.c_str());
+                write_wav_file(wav_path, wav, sample_rate);
+                const double write_ms = std::chrono::duration<double, std::milli>(
+                    std::chrono::steady_clock::now() - tw).count();
+                omni_perf_mark(ctx, "t2w.write", "end", perf_chunk_index, write_ms, write_detail.c_str());
+                ++wav_idx;
+            }
+
+            size_t slide = 0;
+            if (is_last_window) {
+                slide = token_buffer.size();
+            } else if (token_buffer.size() > (size_t) chunk_size) {
+                slide = (size_t) chunk_size;
+            } else if (token_buffer.size() > (size_t) pre_lookahead) {
+                slide = token_buffer.size() - (size_t) pre_lookahead;
+            }
+            if (slide > 0 && slide <= token_buffer.size()) {
+                token_buffer.erase(token_buffer.begin(), token_buffer.begin() + slide);
+            } else if (slide > token_buffer.size()) {
+                token_buffer.clear();
+            }
+            if (is_last_window) {
+                if (is_final) {
+                    token_buffer = {4218, 4218, 4218};
+                }
+                break;
+            }
+        }
+    }
+}
+
+void OmniDuplexPerfSession::llm_thread_func() {
+    while (running.load()) {
+        PrefillPacket * packet = nullptr;
+        {
+            std::unique_lock<std::mutex> lock(llm_mtx);
+            llm_cv.wait(lock, [&] { return !prefill_queue.empty() || !running.load(); });
+            if (!running.load() && prefill_queue.empty()) {
+                break;
+            }
+            packet = prefill_queue.front();
+            prefill_queue.pop();
+        }
+
+        double prefill_ms = 0.0;
+        long long prefill_tokens = 0;
+        bool ok = do_prefill(packet, prefill_ms, prefill_tokens);
+
+        DecodeReq req;
+        req.frame_id = packet->frame_id;
+        req.user_seq = packet->user_seq;
+        req.t_push = packet->t_push;
+        req.t_prefilled = std::chrono::high_resolution_clock::now();
+        delete packet;
+
+        OmniDuplexFrameResult result;
+        result.ms_prefill_submit = elapsed_ms(req.t_push, req.t_prefilled);
+        if (ok) {
+            ok = do_decode(req, result);
+        } else {
+            result.ok = false;
+        }
+        result.ms_total = elapsed_ms(req.t_push, std::chrono::high_resolution_clock::now());
+
+        {
+            std::lock_guard<std::mutex> lock(done_mtx);
+            done_results.push(std::move(result));
+        }
+        done_cv.notify_all();
+        in_flight.fetch_sub(1);
+    }
+}

--- a/tools/omni/test/perf-test/omni_duplex_perf.h
+++ b/tools/omni/test/perf-test/omni_duplex_perf.h
@@ -1,0 +1,122 @@
+#pragma once
+
+#include "omni.h"
+
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+#include <queue>
+#include <string>
+#include <thread>
+
+class OmniDuplexPerfSession {
+public:
+    OmniDuplexPerfSession() = default;
+    ~OmniDuplexPerfSession();
+
+    OmniDuplexPerfSession(const OmniDuplexPerfSession &) = delete;
+    OmniDuplexPerfSession & operator=(const OmniDuplexPerfSession &) = delete;
+
+    bool begin(struct omni_context * ctx_omni,
+               const std::string & voice_audio,
+               const std::string & debug_dir = "./");
+    int64_t push_frame(const OmniDuplexFrame & frame);
+    bool wait_next_frame(OmniDuplexFrameResult * out, int timeout_ms = -1);
+    void end();
+
+private:
+    struct EncodeReq {
+        OmniDuplexFrame frame;
+        int64_t frame_id = -1;
+        std::chrono::high_resolution_clock::time_point t_push;
+    };
+
+    struct PrefillPacket {
+        std::vector<std::vector<float>> vision_embed;
+        std::vector<float> audio_embed;
+        int64_t frame_id = -1;
+        int64_t user_seq = 0;
+        std::chrono::high_resolution_clock::time_point t_push;
+        std::chrono::high_resolution_clock::time_point t_encoded;
+    };
+
+    struct DecodeReq {
+        int64_t frame_id = -1;
+        int64_t user_seq = 0;
+        std::chrono::high_resolution_clock::time_point t_push;
+        std::chrono::high_resolution_clock::time_point t_prefilled;
+    };
+
+    struct PerfLLMOut {
+        std::string text;
+        int n_past = 0;
+        bool llm_finish = false;
+        std::string debug_dir;
+        std::vector<llama_token> token_ids;
+        std::vector<float> hidden_states;
+        int n_embd = 0;
+        bool is_end_of_turn = false;
+        int perf_chunk_index = -1;
+    };
+
+    struct PerfT2WOut {
+        std::vector<int32_t> audio_tokens;
+        bool is_final = false;
+        bool is_chunk_end = false;
+        int round_idx = -1;
+        int perf_chunk_index = -1;
+        std::chrono::steady_clock::time_point enqueue_time = std::chrono::steady_clock::now();
+    };
+
+    void encoder_thread_func();
+    void llm_thread_func();
+    void tts_thread_func();
+    void t2w_thread_func();
+    bool do_prefill(PrefillPacket * packet, double & prefill_ms, long long & prefill_tokens);
+    bool do_decode(const DecodeReq & req, OmniDuplexFrameResult & result);
+    bool generate_audio_tokens(const std::vector<float> & merged_embeddings,
+                               int n_tokens,
+                               int tts_n_embd,
+                               int tts_chunk_idx,
+                               bool is_end_of_turn,
+                               int perf_chunk_index);
+
+    struct omni_context * ctx = nullptr;
+    common_params * params = nullptr;
+    std::string debug_dir;
+    std::atomic<bool> running{false};
+
+    std::queue<EncodeReq *> encode_queue;
+    std::mutex encode_mtx;
+    std::condition_variable encode_cv;
+    static constexpr size_t ENCODE_QUEUE_CAP = 16;
+
+    std::queue<PrefillPacket *> prefill_queue;
+    std::queue<DecodeReq *> decode_queue;
+    std::mutex llm_mtx;
+    std::condition_variable llm_cv;
+    static constexpr size_t PREFILL_QUEUE_CAP = 32;
+
+    std::queue<OmniDuplexFrameResult> done_results;
+    std::mutex done_mtx;
+    std::condition_variable done_cv;
+
+    std::queue<PerfLLMOut *> tts_queue;
+    std::mutex tts_mtx;
+    std::condition_variable tts_cv;
+    static constexpr size_t TTS_QUEUE_CAP = 8;
+
+    std::queue<PerfT2WOut *> t2w_queue;
+    std::mutex t2w_mtx;
+    std::condition_variable t2w_cv;
+    static constexpr size_t T2W_QUEUE_CAP = 32;
+
+    std::atomic<int64_t> frame_id_counter{0};
+    std::atomic<int> in_flight{0};
+
+    std::thread encoder_thread;
+    std::thread llm_thread;
+    std::thread tts_thread;
+    std::thread t2w_thread;
+};

--- a/tools/omni/test/perf-test/omni_perf.cpp
+++ b/tools/omni/test/perf-test/omni_perf.cpp
@@ -1,0 +1,738 @@
+#include "omni_perf.h"
+
+#include "omni.h"
+
+#ifdef GGML_USE_CUDA
+#include "ggml-cuda.h"
+#endif
+
+#include <algorithm>
+#include <cctype>
+#include <condition_variable>
+#include <cstdarg>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <fstream>
+#include <iomanip>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+void print_with_timestamp(const char * format, ...);
+
+namespace {
+
+std::atomic<uint64_t> g_omni_perf_seq{0};
+std::mutex g_omni_gpu_sampler_mutex;
+std::mutex g_omni_gpu_file_mutex;
+OmniPerfState g_omni_perf_state;
+
+bool omni_env_enabled(const char * name) {
+    const char * value = std::getenv(name);
+    if (value == nullptr) {
+        return false;
+    }
+    std::string normalized(value);
+    std::transform(normalized.begin(), normalized.end(), normalized.begin(),
+                   [](unsigned char c) { return (char) std::tolower(c); });
+    return !normalized.empty() && normalized != "0" && normalized != "false" &&
+           normalized != "off" && normalized != "no";
+}
+
+std::string omni_perf_wall_timestamp() {
+    auto now = std::chrono::system_clock::now();
+    auto in_time_t = std::chrono::system_clock::to_time_t(now);
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()) % 1000;
+
+    std::tm buf;
+#ifdef _WIN32
+    localtime_s(&buf, &in_time_t);
+#else
+    localtime_r(&in_time_t, &buf);
+#endif
+
+    std::ostringstream ss;
+    ss << std::put_time(&buf, "%H:%M:%S") << '.'
+       << std::setfill('0') << std::setw(3) << ms.count();
+    return ss.str();
+}
+
+void omni_perf_write_line(const char * kind, const std::string & line) {
+    const bool is_gpu_line = kind != nullptr && std::strcmp(kind, "DUPLEX_GPU") == 0;
+    const char * gpu_file = is_gpu_line ? std::getenv("OMNI_GPU_PROF_FILE") : nullptr;
+    if (!is_gpu_line || gpu_file == nullptr || gpu_file[0] == '\0') {
+        print_with_timestamp("%s", line.c_str());
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(g_omni_gpu_file_mutex);
+    std::ofstream out(gpu_file, std::ios::app);
+    if (out.good()) {
+        out << omni_perf_wall_timestamp() << " " << line;
+        if (line.empty() || line.back() != '\n') {
+            out << "\n";
+        }
+    }
+}
+
+bool omni_gpu_prof_enabled() {
+    return omni_env_enabled("OMNI_GPU_PROF");
+}
+
+double omni_perf_now_ms() {
+    static const auto t0 = std::chrono::steady_clock::now();
+    const auto now = std::chrono::steady_clock::now();
+    return std::chrono::duration<double, std::milli>(now - t0).count();
+}
+
+double omni_perf_rss_mb() {
+#if defined(__linux__)
+    std::ifstream statm("/proc/self/statm");
+    long long total_pages = 0;
+    long long resident_pages = 0;
+    if (!(statm >> total_pages >> resident_pages)) {
+        return -1.0;
+    }
+    const long page_size = sysconf(_SC_PAGESIZE);
+    if (page_size <= 0) {
+        return -1.0;
+    }
+    return (double) resident_pages * (double) page_size / (1024.0 * 1024.0);
+#else
+    return -1.0;
+#endif
+}
+
+bool omni_perf_gpu_memory_mb(double & used_mb, double & total_mb) {
+    used_mb = -1.0;
+    total_mb = -1.0;
+#ifdef GGML_USE_CUDA
+    const int device_count = ggml_backend_cuda_get_device_count();
+    if (device_count <= 0) {
+        return false;
+    }
+    size_t free_bytes_sum = 0;
+    size_t total_bytes_sum = 0;
+    for (int i = 0; i < device_count; ++i) {
+        size_t free_bytes = 0;
+        size_t total_bytes = 0;
+        ggml_backend_cuda_get_device_memory(i, &free_bytes, &total_bytes);
+        free_bytes_sum += free_bytes;
+        total_bytes_sum += total_bytes;
+    }
+    if (total_bytes_sum == 0) {
+        return false;
+    }
+    used_mb = (double) (total_bytes_sum - free_bytes_sum) / (1024.0 * 1024.0);
+    total_mb = (double) total_bytes_sum / (1024.0 * 1024.0);
+    return true;
+#else
+    return false;
+#endif
+}
+
+#if !defined(_WIN32)
+using nvmlReturn_t = int;
+using nvmlDevice_t = void *;
+
+struct nvmlUtilization_t {
+    unsigned int gpu;
+    unsigned int memory;
+};
+
+struct nvmlMemory_t {
+    unsigned long long total;
+    unsigned long long free;
+    unsigned long long used;
+};
+
+constexpr nvmlReturn_t OMNI_NVML_SUCCESS = 0;
+constexpr unsigned int OMNI_NVML_TEMPERATURE_GPU = 0;
+constexpr unsigned int OMNI_NVML_CLOCK_GRAPHICS = 0;
+constexpr unsigned int OMNI_NVML_CLOCK_MEM = 2;
+
+class OmniNvmlLoader {
+public:
+    ~OmniNvmlLoader() {
+        unload();
+    }
+
+    bool load(std::string & reason) {
+        if (loaded) {
+            return true;
+        }
+        handle = dlopen("libnvidia-ml.so.1", RTLD_LAZY | RTLD_LOCAL);
+        if (handle == nullptr) {
+            handle = dlopen("libnvidia-ml.so", RTLD_LAZY | RTLD_LOCAL);
+        }
+        if (handle == nullptr) {
+            reason = "nvml_not_found";
+            return false;
+        }
+        if (!load_symbol(nvmlInit_v2, "nvmlInit_v2") ||
+            !load_symbol(nvmlShutdown, "nvmlShutdown") ||
+            !load_symbol(nvmlDeviceGetCount_v2, "nvmlDeviceGetCount_v2") ||
+            !load_symbol(nvmlDeviceGetHandleByIndex_v2, "nvmlDeviceGetHandleByIndex_v2") ||
+            !load_symbol(nvmlDeviceGetUtilizationRates, "nvmlDeviceGetUtilizationRates") ||
+            !load_symbol(nvmlDeviceGetMemoryInfo, "nvmlDeviceGetMemoryInfo") ||
+            !load_symbol(nvmlDeviceGetPowerUsage, "nvmlDeviceGetPowerUsage") ||
+            !load_symbol(nvmlDeviceGetTemperature, "nvmlDeviceGetTemperature") ||
+            !load_symbol(nvmlDeviceGetClockInfo, "nvmlDeviceGetClockInfo")) {
+            reason = "nvml_symbol_missing";
+            unload();
+            return false;
+        }
+        loaded = true;
+        return true;
+    }
+
+    void unload() {
+        if (handle != nullptr) {
+            dlclose(handle);
+        }
+        handle = nullptr;
+        loaded = false;
+    }
+
+    using nvmlInit_v2_fn = nvmlReturn_t (*)();
+    using nvmlShutdown_fn = nvmlReturn_t (*)();
+    using nvmlDeviceGetCount_v2_fn = nvmlReturn_t (*)(unsigned int *);
+    using nvmlDeviceGetHandleByIndex_v2_fn = nvmlReturn_t (*)(unsigned int, nvmlDevice_t *);
+    using nvmlDeviceGetUtilizationRates_fn = nvmlReturn_t (*)(nvmlDevice_t, nvmlUtilization_t *);
+    using nvmlDeviceGetMemoryInfo_fn = nvmlReturn_t (*)(nvmlDevice_t, nvmlMemory_t *);
+    using nvmlDeviceGetPowerUsage_fn = nvmlReturn_t (*)(nvmlDevice_t, unsigned int *);
+    using nvmlDeviceGetTemperature_fn = nvmlReturn_t (*)(nvmlDevice_t, unsigned int, unsigned int *);
+    using nvmlDeviceGetClockInfo_fn = nvmlReturn_t (*)(nvmlDevice_t, unsigned int, unsigned int *);
+
+    nvmlInit_v2_fn nvmlInit_v2 = nullptr;
+    nvmlShutdown_fn nvmlShutdown = nullptr;
+    nvmlDeviceGetCount_v2_fn nvmlDeviceGetCount_v2 = nullptr;
+    nvmlDeviceGetHandleByIndex_v2_fn nvmlDeviceGetHandleByIndex_v2 = nullptr;
+    nvmlDeviceGetUtilizationRates_fn nvmlDeviceGetUtilizationRates = nullptr;
+    nvmlDeviceGetMemoryInfo_fn nvmlDeviceGetMemoryInfo = nullptr;
+    nvmlDeviceGetPowerUsage_fn nvmlDeviceGetPowerUsage = nullptr;
+    nvmlDeviceGetTemperature_fn nvmlDeviceGetTemperature = nullptr;
+    nvmlDeviceGetClockInfo_fn nvmlDeviceGetClockInfo = nullptr;
+
+private:
+    template <typename T>
+    bool load_symbol(T & fn, const char * name) {
+        fn = reinterpret_cast<T>(dlsym(handle, name));
+        return fn != nullptr;
+    }
+
+    void * handle = nullptr;
+    bool loaded = false;
+};
+#endif
+
+class OmniGpuPerfSampler {
+public:
+    bool start() {
+        if (running.load()) {
+            return true;
+        }
+        if (!omni_gpu_prof_enabled()) {
+            return false;
+        }
+
+        interval_ms = omni_gpu_prof_interval_ms();
+        reset_gpu_log_file();
+
+#if defined(_WIN32)
+        omni_perf_write_line("DUPLEX_GPU", "[DUPLEX_GPU] event=unavailable reason=\"nvml_unsupported_platform\"");
+        return false;
+#else
+        std::string reason;
+        if (nvml.load(reason) &&
+            nvml.nvmlInit_v2() == OMNI_NVML_SUCCESS &&
+            nvml.nvmlDeviceGetCount_v2(&device_count) == OMNI_NVML_SUCCESS &&
+            device_count > 0) {
+            using_nvml = true;
+            sample_devices = resolve_sample_devices(device_count);
+            if (sample_devices.empty()) {
+                omni_perf_write_line("DUPLEX_GPU", "[DUPLEX_GPU] event=unavailable reason=\"no_selected_devices\"");
+                nvml.nvmlShutdown();
+                nvml.unload();
+                using_nvml = false;
+                return false;
+            }
+        } else {
+            if (device_count > 0) {
+                nvml.nvmlShutdown();
+            }
+            nvml.unload();
+            using_nvml = false;
+            device_count = 1;
+            if (!jetson_gpu_sysfs_available()) {
+                const std::string fallback_reason = reason.empty() ? "nvml_unavailable_and_jetson_sysfs_missing" : reason;
+                omni_perf_write_line("DUPLEX_GPU", "[DUPLEX_GPU] event=unavailable reason=\"" + fallback_reason + "\"");
+                return false;
+            }
+            sample_devices = {0};
+        }
+        {
+            std::ostringstream line;
+            line << "[DUPLEX_GPU] event=devices";
+            const bool has_jetson_sysfs = jetson_gpu_sysfs_available();
+            const char * source = "jetson_sysfs";
+            if (using_nvml && has_jetson_sysfs) {
+                source = "nvml+jetson_sysfs";
+            } else if (using_nvml) {
+                source = "nvml";
+            }
+            line << " source=\"" << source << "\"";
+            line << " selected=\"";
+            for (size_t i = 0; i < sample_devices.size(); ++i) {
+                if (i > 0) {
+                    line << ",";
+                }
+                line << sample_devices[i];
+            }
+            line << "\"";
+            omni_perf_write_line("DUPLEX_GPU", line.str());
+        }
+
+        running = true;
+        worker = std::thread(&OmniGpuPerfSampler::run, this);
+        return true;
+#endif
+    }
+
+    void stop() {
+        if (!running.exchange(false)) {
+            return;
+        }
+        cv.notify_all();
+        if (worker.joinable()) {
+            worker.join();
+        }
+#if !defined(_WIN32)
+        if (using_nvml && device_count > 0) {
+            nvml.nvmlShutdown();
+        }
+        nvml.unload();
+        device_count = 0;
+        using_nvml = false;
+        sample_devices.clear();
+#endif
+    }
+
+    ~OmniGpuPerfSampler() {
+        stop();
+    }
+
+private:
+    static void reset_gpu_log_file() {
+        const char * gpu_file = std::getenv("OMNI_GPU_PROF_FILE");
+        if (gpu_file == nullptr || gpu_file[0] == '\0') {
+            return;
+        }
+        std::lock_guard<std::mutex> lock(g_omni_gpu_file_mutex);
+        std::ofstream out(gpu_file, std::ios::trunc);
+        (void) out;
+    }
+
+    static int omni_gpu_prof_interval_ms() {
+        const char * value = std::getenv("OMNI_GPU_PROF_INTERVAL_MS");
+        if (value == nullptr || value[0] == '\0') {
+            return 20;
+        }
+        char * end = nullptr;
+        long parsed = std::strtol(value, &end, 10);
+        if (end == value || parsed <= 0) {
+            return 20;
+        }
+        return (int) std::max<long>(1, std::min<long>(parsed, 1000));
+    }
+
+#if !defined(_WIN32)
+    static std::string fmt_na_or_int(bool ok, unsigned int value) {
+        return ok ? std::to_string(value) : "NA";
+    }
+
+    static std::string fmt_na_or_mb(bool ok, unsigned long long bytes) {
+        if (!ok) {
+            return "NA";
+        }
+        std::ostringstream ss;
+        ss << std::fixed << std::setprecision(2)
+           << (double) bytes / (1024.0 * 1024.0);
+        return ss.str();
+    }
+
+    static std::string fmt_na_or_power(bool ok, unsigned int milliwatts) {
+        if (!ok) {
+            return "NA";
+        }
+        std::ostringstream ss;
+        ss << std::fixed << std::setprecision(2) << (double) milliwatts / 1000.0;
+        return ss.str();
+    }
+
+    static std::string fmt_na_or_double(bool ok, double value, int precision = 2) {
+        if (!ok) {
+            return "NA";
+        }
+        std::ostringstream ss;
+        ss << std::fixed << std::setprecision(precision) << value;
+        return ss.str();
+    }
+
+    static bool read_double_file(const char * path, double & value) {
+        std::ifstream in(path);
+        if (!in.good()) {
+            return false;
+        }
+        double parsed = 0.0;
+        if (!(in >> parsed)) {
+            return false;
+        }
+        value = parsed;
+        return true;
+    }
+
+    static bool read_jetson_gpu_load_pct(double & value) {
+        double raw = 0.0;
+        if (!read_double_file("/sys/devices/platform/17000000.gpu/load", raw)) {
+            return false;
+        }
+        // Jetson exposes GR3D load as either percent or permille depending on BSP.
+        value = raw > 100.0 ? raw / 10.0 : raw;
+        value = std::max(0.0, std::min(100.0, value));
+        return true;
+    }
+
+    static bool read_jetson_gpu_clock_mhz(double & value) {
+        double hz = 0.0;
+        if (!read_double_file("/sys/devices/platform/17000000.gpu/devfreq/17000000.gpu/cur_freq", hz)) {
+            return false;
+        }
+        value = hz / 1000000.0;
+        return true;
+    }
+
+    static bool jetson_gpu_sysfs_available() {
+        double ignored = 0.0;
+        return read_jetson_gpu_load_pct(ignored);
+    }
+
+    static void append_device_if_valid(std::vector<unsigned int> & out,
+                                       long parsed,
+                                       unsigned int device_count) {
+        if (parsed < 0 || parsed >= (long) device_count) {
+            return;
+        }
+        unsigned int device = (unsigned int) parsed;
+        if (std::find(out.begin(), out.end(), device) == out.end()) {
+            out.push_back(device);
+        }
+    }
+
+    static std::vector<unsigned int> parse_device_list(const char * value,
+                                                       unsigned int device_count) {
+        std::vector<unsigned int> devices;
+        if (value == nullptr || value[0] == '\0') {
+            return devices;
+        }
+        const std::string text(value);
+        size_t pos = 0;
+        while (pos < text.size()) {
+            size_t comma = text.find(',', pos);
+            std::string item = text.substr(pos, comma == std::string::npos ? std::string::npos : comma - pos);
+            size_t first = item.find_first_not_of(" \t");
+            size_t last = item.find_last_not_of(" \t");
+            if (first != std::string::npos) {
+                item = item.substr(first, last - first + 1);
+                char * end = nullptr;
+                long parsed = std::strtol(item.c_str(), &end, 10);
+                if (end != item.c_str()) {
+                    append_device_if_valid(devices, parsed, device_count);
+                }
+            }
+            if (comma == std::string::npos) {
+                break;
+            }
+            pos = comma + 1;
+        }
+        return devices;
+    }
+
+    static std::vector<unsigned int> resolve_sample_devices(unsigned int device_count) {
+        // Explicit override: NVML physical indices, e.g. OMNI_GPU_PROF_DEVICES=0 or 0,2.
+        std::vector<unsigned int> devices = parse_device_list(std::getenv("OMNI_GPU_PROF_DEVICES"), device_count);
+        if (!devices.empty()) {
+            return devices;
+        }
+
+        // In common single-GPU runs CUDA_VISIBLE_DEVICES limits the process to one card.
+        // NVML still sees physical indices, so sample the first visible physical id.
+        devices = parse_device_list(std::getenv("CUDA_VISIBLE_DEVICES"), device_count);
+        if (!devices.empty()) {
+            devices.resize(1);
+            return devices;
+        }
+
+        // Avoid sampling every GPU on shared servers by default.
+        return {0};
+    }
+
+    void run() {
+        auto next = std::chrono::steady_clock::now();
+        while (running.load()) {
+            sample_once();
+            next += std::chrono::milliseconds(interval_ms);
+            std::unique_lock<std::mutex> lock(wait_mutex);
+            cv.wait_until(lock, next, [&] { return !running.load(); });
+            if (next < std::chrono::steady_clock::now() - std::chrono::milliseconds(interval_ms)) {
+                next = std::chrono::steady_clock::now();
+            }
+        }
+    }
+
+    void sample_once() {
+        for (unsigned int device : sample_devices) {
+            if (device >= device_count) {
+                continue;
+            }
+            nvmlDevice_t handle = nullptr;
+            if (using_nvml && nvml.nvmlDeviceGetHandleByIndex_v2(device, &handle) != OMNI_NVML_SUCCESS) {
+                continue;
+            }
+
+            nvmlUtilization_t util{};
+            nvmlMemory_t mem{};
+            unsigned int power_mw = 0;
+            unsigned int temp_c = 0;
+            unsigned int graphics_clock = 0;
+            unsigned int mem_clock = 0;
+
+            const bool has_util = using_nvml && nvml.nvmlDeviceGetUtilizationRates(handle, &util) == OMNI_NVML_SUCCESS;
+            const bool has_mem = using_nvml && nvml.nvmlDeviceGetMemoryInfo(handle, &mem) == OMNI_NVML_SUCCESS;
+            const bool has_power = using_nvml && nvml.nvmlDeviceGetPowerUsage(handle, &power_mw) == OMNI_NVML_SUCCESS;
+            const bool has_temp = using_nvml && nvml.nvmlDeviceGetTemperature(handle, OMNI_NVML_TEMPERATURE_GPU, &temp_c) == OMNI_NVML_SUCCESS;
+            const bool has_graphics_clock = using_nvml && nvml.nvmlDeviceGetClockInfo(handle, OMNI_NVML_CLOCK_GRAPHICS, &graphics_clock) == OMNI_NVML_SUCCESS;
+            const bool has_mem_clock = using_nvml && nvml.nvmlDeviceGetClockInfo(handle, OMNI_NVML_CLOCK_MEM, &mem_clock) == OMNI_NVML_SUCCESS;
+
+            double jetson_load_pct = 0.0;
+            const bool has_jetson_load = !has_util && read_jetson_gpu_load_pct(jetson_load_pct);
+            double jetson_clock_mhz = 0.0;
+            const bool has_jetson_clock = !has_graphics_clock && read_jetson_gpu_clock_mhz(jetson_clock_mhz);
+            double cuda_used_mb = -1.0;
+            double cuda_total_mb = -1.0;
+            const bool has_cuda_mem = !has_mem && omni_perf_gpu_memory_mb(cuda_used_mb, cuda_total_mb);
+
+            const uint64_t sample_id = next_sample_id++;
+            std::ostringstream line;
+            line << "[DUPLEX_GPU] sample_id=" << sample_id
+                 << " t_ms=" << std::fixed << std::setprecision(3) << omni_perf_now_ms()
+                 << " device=" << device
+                 << " sm_util_pct=" << (has_util ? fmt_na_or_int(true, util.gpu) : fmt_na_or_double(has_jetson_load, jetson_load_pct, 1))
+                 << " mem_util_pct=" << fmt_na_or_int(has_util, util.memory)
+                 << " gpu_used_mb=" << (has_mem ? fmt_na_or_mb(true, mem.used) : fmt_na_or_double(has_cuda_mem, cuda_used_mb))
+                 << " gpu_total_mb=" << (has_mem ? fmt_na_or_mb(true, mem.total) : fmt_na_or_double(has_cuda_mem, cuda_total_mb))
+                 << " power_w=" << fmt_na_or_power(has_power, power_mw)
+                 << " temp_c=" << fmt_na_or_int(has_temp, temp_c)
+                 << " graphics_clock_mhz=" << (has_graphics_clock ? fmt_na_or_int(true, graphics_clock) : fmt_na_or_double(has_jetson_clock, jetson_clock_mhz, 1))
+                 << " mem_clock_mhz=" << fmt_na_or_int(has_mem_clock, mem_clock);
+            omni_perf_write_line("DUPLEX_GPU", line.str());
+        }
+    }
+
+    OmniNvmlLoader nvml;
+    unsigned int device_count = 0;
+    std::vector<unsigned int> sample_devices;
+    bool using_nvml = false;
+#endif
+
+    std::atomic<bool> running{false};
+    std::thread worker;
+    std::mutex wait_mutex;
+    std::condition_variable cv;
+    int interval_ms = 20;
+    uint64_t next_sample_id = 0;
+};
+
+std::unique_ptr<OmniGpuPerfSampler> g_omni_gpu_sampler;
+
+double omni_perf_tokens_per_s(long long tokens, double duration_ms) {
+    if (tokens <= 0 || duration_ms <= 0.0) {
+        return 0.0;
+    }
+    return (double) tokens * 1000.0 / duration_ms;
+}
+
+OmniPerfTokenStats * omni_perf_stage_stats(const char * stage) {
+    if (stage == nullptr) {
+        return nullptr;
+    }
+    if (std::strcmp(stage, "duplex.llm.prefill") == 0) {
+        return &g_omni_perf_state.llm_prefill;
+    }
+    if (std::strcmp(stage, "duplex.llm.decode") == 0) {
+        return &g_omni_perf_state.llm_decode;
+    }
+    if (std::strcmp(stage, "tts.prefill") == 0) {
+        return &g_omni_perf_state.tts_prefill;
+    }
+    if (std::strcmp(stage, "tts.decode") == 0) {
+        return &g_omni_perf_state.tts_decode;
+    }
+    return nullptr;
+}
+
+} // namespace
+
+std::string omni_perf_speed_detail(long long tokens, double duration_ms) {
+    std::ostringstream oss;
+    oss << ",tokens_per_s=" << std::fixed << std::setprecision(2)
+        << omni_perf_tokens_per_s(tokens, duration_ms);
+    if (tokens > 0 && duration_ms > 0.0) {
+        oss << ",ms_per_token=" << std::setprecision(4)
+            << (duration_ms / (double) tokens);
+    } else {
+        oss << ",ms_per_token=0.0000";
+    }
+    return oss.str();
+}
+
+bool omni_tts_debug_dump_enabled() {
+    return omni_env_enabled("OMNI_TTS_DEBUG_DUMP");
+}
+
+void omni_gpu_perf_sampler_start() {
+    if (!omni_gpu_prof_enabled()) {
+        return;
+    }
+    std::lock_guard<std::mutex> lock(g_omni_gpu_sampler_mutex);
+    if (!g_omni_gpu_sampler) {
+        g_omni_gpu_sampler = std::make_unique<OmniGpuPerfSampler>();
+        if (!g_omni_gpu_sampler->start()) {
+            g_omni_gpu_sampler.reset();
+        }
+    }
+}
+
+void omni_gpu_perf_sampler_stop() {
+    std::lock_guard<std::mutex> lock(g_omni_gpu_sampler_mutex);
+    if (g_omni_gpu_sampler) {
+        g_omni_gpu_sampler->stop();
+        g_omni_gpu_sampler.reset();
+    }
+}
+
+void omni_perf_record_tokens(struct omni_context * ctx_omni, const char * stage, long long tokens, double duration_ms) {
+    if (tokens <= 0 || duration_ms < 0.0) {
+        return;
+    }
+    (void) ctx_omni;
+    OmniPerfTokenStats * stats = omni_perf_stage_stats(stage);
+    if (stats == nullptr) {
+        return;
+    }
+    std::lock_guard<std::mutex> lock(g_omni_perf_state.token_stats_mtx);
+    stats->calls += 1;
+    stats->tokens += tokens;
+    stats->duration_ms += duration_ms;
+}
+
+void omni_perf_print_token_stats(struct omni_context * ctx_omni) {
+    (void) ctx_omni;
+    std::lock_guard<std::mutex> lock(g_omni_perf_state.token_stats_mtx);
+    const auto print_one = [](const char * stage, const OmniPerfTokenStats & stats) {
+        if (stats.calls <= 0) {
+            return;
+        }
+        const double tokens_per_s = omni_perf_tokens_per_s(stats.tokens, stats.duration_ms);
+        const double ms_per_token = stats.tokens > 0 ? stats.duration_ms / (double) stats.tokens : 0.0;
+        print_with_timestamp("[DUPLEX_PERF_SUMMARY] stage=%s calls=%lld tokens=%lld total_ms=%.3f avg_tokens_per_s=%.2f avg_ms_per_token=%.4f\n",
+                             stage, stats.calls, stats.tokens, stats.duration_ms, tokens_per_s, ms_per_token);
+    };
+    print_one("duplex.llm.prefill", g_omni_perf_state.llm_prefill);
+    print_one("duplex.llm.decode", g_omni_perf_state.llm_decode);
+    print_one("tts.prefill", g_omni_perf_state.tts_prefill);
+    print_one("tts.decode", g_omni_perf_state.tts_decode);
+}
+
+void omni_perf_mark(struct omni_context * ctx_omni,
+                    const char * stage,
+                    const char * event,
+                    int chunk_index,
+                    double duration_ms,
+                    const char * detail) {
+    double gpu_used_mb = -1.0;
+    double gpu_total_mb = -1.0;
+    const bool has_gpu = omni_perf_gpu_memory_mb(gpu_used_mb, gpu_total_mb);
+    const double rss_mb = omni_perf_rss_mb();
+    const int n_past = ctx_omni ? ctx_omni->n_past : -1;
+    const char * safe_stage = stage ? stage : "unknown";
+    const char * safe_event = event ? event : "mark";
+    const char * safe_detail = detail ? detail : "";
+    const uint64_t seq = g_omni_perf_seq++;
+
+    std::ostringstream line;
+    if (has_gpu) {
+        line << "[DUPLEX_PERF] seq=" << seq
+             << " stage=" << safe_stage
+             << " event=" << safe_event
+             << " chunk=" << chunk_index
+             << " t_ms=" << std::fixed << std::setprecision(3) << omni_perf_now_ms()
+             << " dur_ms=" << duration_ms
+             << " rss_mb=" << std::setprecision(2) << rss_mb
+             << " gpu_used_mb=" << gpu_used_mb
+             << " gpu_total_mb=" << gpu_total_mb
+             << " n_past=" << n_past
+             << " detail=\"" << safe_detail << "\"";
+    } else {
+        line << "[DUPLEX_PERF] seq=" << seq
+             << " stage=" << safe_stage
+             << " event=" << safe_event
+             << " chunk=" << chunk_index
+             << " t_ms=" << std::fixed << std::setprecision(3) << omni_perf_now_ms()
+             << " dur_ms=" << duration_ms
+             << " rss_mb=" << std::setprecision(2) << rss_mb
+             << " gpu_used_mb=NA gpu_total_mb=NA"
+             << " n_past=" << n_past
+             << " detail=\"" << safe_detail << "\"";
+    }
+    omni_perf_write_line("DUPLEX_PERF", line.str());
+}
+
+OmniPerfScope::OmniPerfScope(struct omni_context * ctx_, const char * stage_, int chunk_index_, const std::string & detail_)
+    : ctx(ctx_), stage(stage_), chunk_index(chunk_index_), detail(detail_),
+      start(std::chrono::steady_clock::now()) {
+    omni_perf_mark(ctx, stage, "start", chunk_index, -1.0, detail.c_str());
+}
+
+OmniPerfScope::~OmniPerfScope() {
+    const auto end = std::chrono::steady_clock::now();
+    const double duration_ms = std::chrono::duration<double, std::milli>(end - start).count();
+    std::string final_detail = detail;
+    if (has_tokens) {
+        final_detail += omni_perf_speed_detail(tokens, duration_ms);
+        omni_perf_record_tokens(ctx, stage, tokens, duration_ms);
+    }
+    omni_perf_mark(ctx, stage, "end", chunk_index, duration_ms, final_detail.c_str());
+}
+
+void OmniPerfScope::set_detail(const std::string & detail_) {
+    detail = detail_;
+}
+
+void OmniPerfScope::set_tokens(long long tokens_) {
+    tokens = tokens_;
+    has_tokens = true;
+}

--- a/tools/omni/test/perf-test/omni_perf.h
+++ b/tools/omni/test/perf-test/omni_perf.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <mutex>
+#include <string>
+
+struct omni_context;
+
+struct OmniPerfTokenStats {
+    long long calls = 0;
+    long long tokens = 0;
+    double duration_ms = 0.0;
+};
+
+struct OmniPerfState {
+    std::atomic<int> current_chunk_index{-1};
+    std::mutex token_stats_mtx;
+    OmniPerfTokenStats llm_prefill;
+    OmniPerfTokenStats llm_decode;
+    OmniPerfTokenStats tts_prefill;
+    OmniPerfTokenStats tts_decode;
+};
+
+bool omni_tts_debug_dump_enabled();
+
+void omni_gpu_perf_sampler_start();
+void omni_gpu_perf_sampler_stop();
+
+void omni_perf_print_token_stats(struct omni_context * ctx_omni);
+void omni_perf_record_tokens(struct omni_context * ctx_omni, const char * stage, long long tokens, double duration_ms);
+std::string omni_perf_speed_detail(long long tokens, double duration_ms);
+
+void omni_perf_mark(struct omni_context * ctx_omni,
+                    const char * stage,
+                    const char * event,
+                    int chunk_index = -1,
+                    double duration_ms = -1.0,
+                    const char * detail = nullptr);
+
+class OmniPerfScope {
+public:
+    OmniPerfScope(struct omni_context * ctx, const char * stage, int chunk_index, const std::string & detail);
+    ~OmniPerfScope();
+
+    void set_detail(const std::string & detail);
+    void set_tokens(long long tokens);
+
+private:
+    struct omni_context * ctx;
+    const char * stage;
+    int chunk_index;
+    std::string detail;
+    long long tokens = 0;
+    bool has_tokens = false;
+    std::chrono::steady_clock::time_point start;
+};

--- a/tools/omni/test/perf-test/test-duplex-perf.cpp
+++ b/tools/omni/test/perf-test/test-duplex-perf.cpp
@@ -1,0 +1,392 @@
+/**
+ * 双工 (Duplex) Omni 模式测试
+ *
+ * 这份测试脚本的职责仅有：
+ *   1. 解析命令行 / 模型路径，调 omni_init
+ *   2. 调用 omni_duplex_session_begin / push_frame / wait_next_frame / session_end
+ *   3. 打印每帧结果与汇总统计
+ *
+ * 所有线程调度（VPM/APM 编码、LLM prefill/decode 流水线、TTS/T2W 落盘）
+ * 都封装在 omni 内部。同一组 API 可被 server / cli 复用。
+ */
+
+#include "omni_duplex_perf.h"
+
+#include "common.h"
+#include "llama.h"
+#include "ggml.h"
+
+#include <chrono>
+#include <vector>
+#include <string>
+#include <cstdio>
+#include <cstdlib>
+#include <thread>
+
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+#include <signal.h>
+#include <sys/stat.h>
+#elif defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#include <signal.h>
+#endif
+
+namespace {
+
+volatile bool g_is_interrupted = false;
+
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__)) || defined(_WIN32)
+void sigint_handler(int signo) {
+    if (signo == SIGINT) {
+        if (g_is_interrupted) {
+            std::_Exit(1);
+        }
+        g_is_interrupted = true;
+    }
+}
+#endif
+
+// ==================== 模型路径解析（复用 cli 逻辑） ====================
+
+struct TestModelPaths {
+    std::string llm;
+    std::string vision;
+    std::string audio;
+    std::string tts;
+    std::string projector;
+    std::string vision_coreml;  // CoreML/ANE mlmodelc 路径，可选
+    std::string base_dir;
+};
+
+std::string get_parent_dir(const std::string & path) {
+    size_t last_slash = path.find_last_of("/\\");
+    if (last_slash != std::string::npos) {
+        return path.substr(0, last_slash);
+    }
+    return ".";
+}
+
+bool file_exists(const std::string & path) {
+    FILE * f = fopen(path.c_str(), "rb");
+    if (f) {
+        fclose(f);
+        return true;
+    }
+    return false;
+}
+
+TestModelPaths resolve_model_paths(const std::string & llm_path) {
+    TestModelPaths paths;
+    paths.llm = llm_path;
+    paths.base_dir = get_parent_dir(llm_path);
+    paths.vision = paths.base_dir + "/vision/MiniCPM-o-4_5-vision-F16.gguf";
+    paths.audio = paths.base_dir + "/audio/MiniCPM-o-4_5-audio-F16.gguf";
+    paths.tts = paths.base_dir + "/tts/MiniCPM-o-4_5-tts-F16.gguf";
+    paths.projector = paths.base_dir + "/tts/MiniCPM-o-4_5-projector-F16.gguf";
+    paths.vision_coreml = paths.base_dir + "/vision/coreml_minicpmo45_vit_all_f16.mlmodelc";
+    return paths;
+}
+
+// ==================== 双工测试核心 ====================
+
+void duplex_test_case(struct omni_context * ctx_omni,
+                      const std::string & data_path_prefix,
+                      int cnt,
+                      int stream_interval_ms) {
+    printf("\n=== Duplex test: %d chunks, interval=%dms ===\n", cnt, stream_interval_ms);
+
+    // 准备 N 个 chunk 的 (audio, image) 文件路径
+    std::vector<OmniDuplexFrame> frames(cnt);
+    for (int il = 0; il < cnt; ++il) {
+        char idx[16];
+        snprintf(idx, sizeof(idx), "%04d", il);
+        frames[il].aud_fname = data_path_prefix + idx + ".wav";
+        std::string img = data_path_prefix + idx + ".jpg";
+        if (file_exists(img)) {
+            frames[il].img_fname = img;
+        }
+        frames[il].user_seq = il + 1;
+        if (!file_exists(frames[il].aud_fname)) {
+            fprintf(stderr, "[错误] 音频不存在: %s\n", frames[il].aud_fname.c_str());
+            return;
+        }
+    }
+
+    OmniDuplexPerfSession session;
+    if (!session.begin(ctx_omni, /*voice_audio=*/"", /*debug_dir=*/"./")) {
+        fprintf(stderr, "[错误] OmniDuplexPerfSession begin failed\n");
+        return;
+    }
+
+    auto total_t0 = std::chrono::high_resolution_clock::now();
+
+    // push 节奏 = stream_interval_ms。push 本身非阻塞（除非内部队列满），
+    // 因此即便 LLM 处理慢于 push 间隔，pipeline 仍能把后续帧排队等候。
+    std::thread producer([&]() {
+        auto t_start = std::chrono::high_resolution_clock::now();
+        for (int il = 0; il < cnt && !g_is_interrupted; ++il) {
+            if (stream_interval_ms > 0) {
+                std::this_thread::sleep_until(
+                    t_start + std::chrono::milliseconds((int64_t)il * stream_interval_ms));
+            }
+            if (session.push_frame(frames[il]) < 0) {
+                fprintf(stderr, "[push] frame %d 提交失败\n", il + 1);
+                break;
+            }
+        }
+    });
+
+    int speak = 0;
+    int listen = 0;
+    int completed = 0;
+    double sum_prefill = 0;
+    double sum_decode = 0;
+    double sum_e2e = 0;
+
+    for (int il = 0; il < cnt && !g_is_interrupted; ++il) {
+        OmniDuplexFrameResult r;
+        if (!session.wait_next_frame(&r, /*timeout_ms=*/30000) || !r.ok) {
+            fprintf(stderr, "[错误] frame %d 处理失败/超时\n", il + 1);
+            break;
+        }
+        (r.is_speak ? speak : listen)++;
+        sum_prefill += r.ms_prefill_submit;
+        sum_decode += r.ms_decode;
+        sum_e2e    += r.ms_total;
+        completed++;
+
+        printf("--- Chunk %lld/%d --- prefill %.1fms | decode %.1fms | e2e %.1fms | n_past %d | %s\n",
+               (long long)r.user_seq, cnt, r.ms_prefill_submit, r.ms_decode, r.ms_total, r.n_past_after,
+               r.is_speak ? ("<|speak|> \"" + (r.text.size() > 60 ? r.text.substr(0,60)+"..." : r.text) + "\"").c_str()
+                          : "<|listen|>");
+    }
+
+    if (producer.joinable()) {
+        producer.join();
+    }
+    session.end();
+
+    double total_s = std::chrono::duration<double>(
+        std::chrono::high_resolution_clock::now() - total_t0).count();
+    printf("\n=== Summary: %d/%d chunks, %.3fs | avg prefill %.1fms | avg decode %.1fms | avg e2e %.1fms | speak %d listen %d ===\n",
+           completed, cnt, total_s,
+           completed ? sum_prefill / completed : 0,
+           completed ? sum_decode / completed : 0,
+           completed ? sum_e2e    / completed : 0,
+           speak, listen);
+}
+
+// ==================== 帮助信息 ====================
+
+void show_usage(const char * prog_name) {
+    printf(
+        "MiniCPM-o Duplex Mode Test\n\n"
+        "Usage: %s -m <llm_model_path> [options]\n\n"
+        "Required:\n"
+        "  -m <path>           LLM 模型路径\n\n"
+        "Options:\n"
+        "  --vision <path>     覆盖 vision 模型路径\n"
+        "  --audio <path>      覆盖 audio 模型路径\n"
+        "  --tts <path>        覆盖 TTS 模型路径\n"
+        "  --projector <path>  覆盖 projector 模型路径\n"
+        "  --ref-audio <path>  参考音频路径 (默认: tools/omni/assets/default_ref_audio/default_ref_audio.wav)\n"
+        "  -c, --ctx-size <n>  上下文大小 (默认: 4096)\n"
+        "  -ngl <n>            GPU 层数 (默认: 99)\n"
+        "  --no-tts            禁用 TTS\n"
+        "  --omni              启用 omni 模式 (audio+vision, media_type=2)\n"
+        "  --vision-backend <m>  Vision compute backend: 'metal'(默认) 或 'coreml'(ANE)\n"
+        "  --vision-coreml <p>   CoreML/ANE 模型路径 (.mlmodelc)；--vision-backend=coreml 时\n"
+        "                        若未指定则默认 <llm 同级目录>/vision/coreml_minicpmo45_vit_all_f16.mlmodelc\n"
+        "  --test <prefix> <n> 指定测试数据前缀和 chunk 数量\n"
+        "  --stream-interval <ms>  push frame 的最小间隔 (默认 0=背靠背压测；\n"
+        "                          设为 1000 模拟真实 MiniCPM-o 流式输入)\n"
+        "  -o <dir>            输出目录 (默认: ./tools/omni/output)\n"
+        "  -h, --help          显示帮助\n\n"
+        "Example:\n"
+        "  %s -m ./models/MiniCPM-o-4_5-gguf/MiniCPM-o-4_5-Q4_K_M.gguf \\\n"
+        "     --omni --test tools/omni/assets/test_case/omni_test_case/omni_test_case_ 9\n",
+        prog_name, prog_name
+    );
+}
+
+} // namespace
+
+// ==================== Main ====================
+
+int main(int argc, char ** argv) {
+    ggml_time_init();
+
+    std::string llm_path;
+    std::string vision_path_override;
+    std::string audio_path_override;
+    std::string tts_path_override;
+    std::string projector_path_override;
+    std::string ref_audio_path = "tools/omni/assets/default_ref_audio/default_ref_audio.wav";
+    std::string output_dir = "./tools/omni/output";
+    std::string vision_backend = "metal";  // 'metal' or 'coreml'
+    std::string vision_coreml_model_path;  // 可选；若为空且 backend=coreml 则用默认推断路径
+    int n_ctx = 4096;
+    int n_gpu_layers = 99;
+    int media_type = 1;     // 1=audio only, 2=omni (audio+vision)
+    bool use_tts = true;
+    bool run_test = false;
+    int  stream_interval_ms = 0;  // 0 = 背靠背（压测）；真实流式建议 1000
+    std::string test_prefix;
+    int test_count = 0;
+    std::string token2wav_device = "gpu";
+    if (const char * v = std::getenv("OMNI_T2W_DEVICE")) {
+        if (*v) {
+            token2wav_device = v;
+        }
+    }
+
+    for (int i = 1; i < argc; i++) {
+        std::string arg = argv[i];
+        if (arg == "-h" || arg == "--help") {
+            show_usage(argv[0]);
+            return 0;
+        }
+        if (arg == "-m" && i + 1 < argc) { llm_path = argv[++i]; }
+        else if (arg == "--vision" && i + 1 < argc) { vision_path_override = argv[++i]; }
+        else if (arg == "--audio" && i + 1 < argc) { audio_path_override = argv[++i]; }
+        else if (arg == "--tts" && i + 1 < argc) { tts_path_override = argv[++i]; }
+        else if (arg == "--projector" && i + 1 < argc) { projector_path_override = argv[++i]; }
+        else if (arg == "--ref-audio" && i + 1 < argc) { ref_audio_path = argv[++i]; }
+        else if ((arg == "-c" || arg == "--ctx-size") && i + 1 < argc) { n_ctx = std::atoi(argv[++i]); }
+        else if (arg == "-ngl" && i + 1 < argc) { n_gpu_layers = std::atoi(argv[++i]); }
+        else if (arg == "--no-tts") { use_tts = false; }
+        else if (arg == "--omni") { media_type = 2; }
+        else if (arg == "--vision-backend" && i + 1 < argc) {
+            vision_backend = argv[++i];
+            if (vision_backend != "metal" && vision_backend != "coreml") {
+                fprintf(stderr, "Error: --vision-backend must be 'metal' or 'coreml', got '%s'\n", vision_backend.c_str());
+                return 1;
+            }
+        }
+        else if (arg == "--vision-coreml" && i + 1 < argc) {
+            vision_coreml_model_path = argv[++i];
+            // 显式指定路径时自动开 coreml 后端
+            vision_backend = "coreml";
+        }
+        else if (arg == "-o" && i + 1 < argc) { output_dir = argv[++i]; }
+        else if (arg == "--test" && i + 2 < argc) {
+            run_test = true;
+            test_prefix = argv[++i];
+            test_count = std::atoi(argv[++i]);
+        }
+        else if (arg == "--stream-interval" && i + 1 < argc) {
+            stream_interval_ms = std::atoi(argv[++i]);
+        }
+        else {
+            fprintf(stderr, "Unknown argument: %s\n", arg.c_str());
+            show_usage(argv[0]);
+            return 1;
+        }
+    }
+
+    if (llm_path.empty()) {
+        fprintf(stderr, "Error: -m <llm_model_path> is required\n\n");
+        show_usage(argv[0]);
+        return 1;
+    }
+
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__)) || defined(_WIN32)
+    struct sigaction sigint_action;
+    sigint_action.sa_handler = sigint_handler;
+    sigemptyset(&sigint_action.sa_mask);
+    sigint_action.sa_flags = 0;
+    sigaction(SIGINT, &sigint_action, NULL);
+#endif
+
+    // 解析模型路径
+    TestModelPaths paths = resolve_model_paths(llm_path);
+    if (!vision_path_override.empty()) {
+        paths.vision = vision_path_override;
+    }
+    if (!audio_path_override.empty()) {
+        paths.audio = audio_path_override;
+    }
+    if (!tts_path_override.empty()) {
+        paths.tts = tts_path_override;
+    }
+    if (!projector_path_override.empty()) {
+        paths.projector = projector_path_override;
+    }
+    // CoreML 路径：用户显式指定 > resolve_model_paths 默认推断
+    if (!vision_coreml_model_path.empty()) {
+        paths.vision_coreml = vision_coreml_model_path;
+    }
+
+    printf("=== Duplex Test ===\n");
+    printf("  LLM:    %s\n", paths.llm.c_str());
+    printf("  Vision: %s (backend=%s)\n", paths.vision.c_str(), vision_backend.c_str());
+    printf("  Audio:  %s\n", paths.audio.c_str());
+    printf("  TTS:    %s (use_tts=%d)\n", paths.tts.c_str(), use_tts ? 1 : 0);
+    if (vision_backend == "coreml") {
+        struct stat st;
+        bool ok = (stat(paths.vision_coreml.c_str(), &st) == 0);
+        printf("  CoreML: %s %s\n", paths.vision_coreml.c_str(), ok ? "[OK]" : "[NOT FOUND]");
+    }
+
+    if (!file_exists(paths.llm))   { fprintf(stderr, "Error: LLM not found\n");   return 1; }
+    if (!file_exists(paths.audio)) { fprintf(stderr, "Error: Audio not found\n"); return 1; }
+    if (use_tts && !file_exists(paths.tts)) {
+        fprintf(stderr, "Warning: TTS not found, disabling TTS\n");
+        use_tts = false;
+    }
+
+    // 设置参数
+    common_params params;
+    params.model.path = paths.llm;
+    params.vpm_model = paths.vision;
+    params.apm_model = paths.audio;
+    params.tts_model = paths.tts;
+    params.n_ctx = n_ctx;
+    params.n_gpu_layers = n_gpu_layers;
+    if (vision_backend == "coreml") {
+        params.vision_coreml_model_path = paths.vision_coreml;
+    }
+
+    // 🔧 [bit-exact A/B] 固定 LLM / TTS 采样种子，配合 token2wav 中已有的 mt19937(42)
+    // 让两次独立进程产生完全相同的输出（A/B 对比可用 md5 验证）
+    {
+        const char * seed_env = std::getenv("OMNI_SAMPLER_SEED");
+        uint32_t     seed     = seed_env ? (uint32_t) std::strtoul(seed_env, nullptr, 10) : 42u;
+        params.sampling.seed  = seed;
+        printf("  Sampler seed: %u (env OMNI_SAMPLER_SEED to override)\n", seed);
+    }
+
+    std::string tts_bin_dir = get_parent_dir(paths.tts);
+
+    common_init();
+
+    auto * ctx_omni = omni_init(&params, media_type, use_tts, tts_bin_dir,
+                                /*tts_gpu_layers=*/-1, /*token2wav_device=*/token2wav_device,
+                                /*duplex_mode=*/true,
+                                /*existing_model=*/nullptr, /*existing_ctx=*/nullptr,
+                                /*base_output_dir=*/output_dir);
+    if (ctx_omni == nullptr) {
+        fprintf(stderr, "Error: Failed to initialize omni context\n");
+        return 1;
+    }
+    ctx_omni->async = true;
+    ctx_omni->ref_audio_path = ref_audio_path;
+
+    const std::string default_prefix = "tools/omni/assets/test_case/audio_test_case/audio_test_case_";
+    duplex_test_case(ctx_omni,
+                     run_test ? test_prefix : default_prefix,
+                     run_test ? test_count  : 2,
+                     stream_interval_ms);
+
+    // 等所有 speak 帧的 audio 文件落盘后再销毁；omni_free 会处理后续所有线程 join。
+    omni_duplex_drain_tts_audio(ctx_omni);
+    llama_perf_context_print(ctx_omni->ctx_llama);
+    omni_free(ctx_omni);
+
+    printf("\n=== Duplex test finished ===\n");
+    return 0;
+}

--- a/tools/omni/vision.cpp
+++ b/tools/omni/vision.cpp
@@ -207,6 +207,11 @@ struct vision_ctx {
     // 🔧 [高清模式] 运行时覆盖 max_slice_nums，-1 表示使用模型默认值
     int max_slice_nums_override = -1;
 
+    // 🔧 [batch encode 开关] 是否对多个尺寸相同的 slice 启用批量编码优化。
+    // 默认 false（关闭）—— 该优化只在大图/高清高刷等 slice 数较多时收益明显，
+    // 并非通用场景，因此需要显式开启。
+    bool batch_encode = false;
+
     // CoreML / ANE model path
     std::string coreml_model_path;
 
@@ -275,8 +280,8 @@ struct vision_graph {
     const vision_model & model;
     const vision_hparams & hparams;
 
-    // we only support single image per batch
-    const vision_image_f32 & img;
+    const vision_image_f32 & img; // reference image (all batched images must share dimensions)
+    const int batch_size;
 
     const int patch_size;
     const int n_patches_x;
@@ -293,11 +298,12 @@ struct vision_graph {
     ggml_context * ctx0;
     ggml_cgraph * gf;
 
-    vision_graph(vision_ctx * ctx, const vision_image_f32 & img) :
+    vision_graph(vision_ctx * ctx, const vision_image_f32 & img, int batch_size = 1) :
             ctx(ctx),
             model(ctx->model),
             hparams(model.hparams),
             img(img),
+            batch_size(batch_size),
             patch_size(hparams.patch_size),
             n_patches_x(img.nx / patch_size),
             n_patches_y(img.ny / patch_size),
@@ -319,13 +325,12 @@ struct vision_graph {
     }
 
     ggml_cgraph * build_minicpmv() {
-        const int batch_size = 1;
-
         const int n_pos = n_patches;
 
         // position embeddings for the projector (not for ViT)
+        // keep as [n_output_dim, n_pos, 1] even for batch>1, ggml_add broadcasts
         int n_output_dim = vision_n_mmproj_embd(ctx);
-        ggml_tensor * pos_embed = ggml_new_tensor_3d(ctx0, GGML_TYPE_F32, n_output_dim, n_pos, batch_size);
+        ggml_tensor * pos_embed = ggml_new_tensor_3d(ctx0, GGML_TYPE_F32, n_output_dim, n_pos, 1);
         ggml_set_name(pos_embed, "pos_embed");
         ggml_set_input(pos_embed);
 
@@ -343,6 +348,7 @@ struct vision_graph {
                                 hparams.ffn_op,
                                 learned_pos_embd,
                                 nullptr);
+        // embeddings shape: [n_embd, n_patches] (batch=1) or [n_embd, n_patches, batch_size] (batch>1)
 
         // resampler projector (it is just another transformer)
 
@@ -353,7 +359,7 @@ struct vision_graph {
         q = build_norm(q, model.mm_model_ln_q_w, model.mm_model_ln_q_b, NORM_TYPE_NORMAL, eps, -1);
         v = build_norm(v, model.mm_model_ln_kv_w, model.mm_model_ln_kv_b, NORM_TYPE_NORMAL, eps, -1);
 
-        // k = v + pos_embed
+        // k = v + pos_embed (pos_embed broadcasts over batch dim)
         ggml_tensor * k = ggml_add(ctx0, v, pos_embed);
 
         // attention
@@ -361,7 +367,6 @@ struct vision_graph {
             int n_embd = vision_n_mmproj_embd(ctx);
             const int d_head = 128;
             int n_head = n_embd/d_head;
-            // Use actual config value if available, otherwise fall back to hardcoded values
             int num_query = ctx->model.hparams.minicpmv_query_num;
             ggml_tensor * Q = ggml_add(ctx0,
                 ggml_mul_mat(ctx0, model.mm_model_attn_q_w, q),
@@ -374,8 +379,16 @@ struct vision_graph {
                 model.mm_model_attn_v_b);
 
             Q = ggml_reshape_3d(ctx0, Q, d_head, n_head, num_query);
-            K = ggml_reshape_3d(ctx0, K, d_head, n_head, n_pos);
-            V = ggml_reshape_3d(ctx0, V, d_head, n_head, n_pos);
+            if (batch_size > 1) {
+                K = ggml_reshape_4d(ctx0, K, d_head, n_head, n_pos, batch_size);
+                V = ggml_reshape_4d(ctx0, V, d_head, n_head, n_pos, batch_size);
+                // Q has no batch dim (shared query), expand via repeat for mul_mat broadcast compatibility
+                ggml_tensor * Q_target = ggml_new_tensor_4d(ctx0, Q->type, d_head, n_head, num_query, batch_size);
+                Q = ggml_repeat(ctx0, Q, Q_target);
+            } else {
+                K = ggml_reshape_3d(ctx0, K, d_head, n_head, n_pos);
+                V = ggml_reshape_3d(ctx0, V, d_head, n_head, n_pos);
+            }
 
             cb(Q, "resampler_Q", -1);
             cb(K, "resampler_K", -1);
@@ -775,9 +788,15 @@ private:
                     cb(Kcur, "Kcur_norm", il);
                 }
 
-                Qcur = ggml_reshape_3d(ctx0, Qcur, d_head, n_head, n_pos);
-                Kcur = ggml_reshape_3d(ctx0, Kcur, d_head, n_head, n_pos);
-                Vcur = ggml_reshape_3d(ctx0, Vcur, d_head, n_head, n_pos);
+                if (batch_size > 1) {
+                    Qcur = ggml_reshape_4d(ctx0, Qcur, d_head, n_head, n_pos, batch_size);
+                    Kcur = ggml_reshape_4d(ctx0, Kcur, d_head, n_head, n_pos, batch_size);
+                    Vcur = ggml_reshape_4d(ctx0, Vcur, d_head, n_head, n_pos, batch_size);
+                } else {
+                    Qcur = ggml_reshape_3d(ctx0, Qcur, d_head, n_head, n_pos);
+                    Kcur = ggml_reshape_3d(ctx0, Kcur, d_head, n_head, n_pos);
+                    Vcur = ggml_reshape_3d(ctx0, Vcur, d_head, n_head, n_pos);
+                }
 
                 cb(Qcur, "Qcur", il);
                 cb(Kcur, "Kcur", il);
@@ -840,11 +859,15 @@ private:
     }
 
     // build the input after conv2d (inp_raw --> patches)
-    // returns tensor with shape [n_embd, n_patches]
+    // returns tensor with shape [n_embd, n_patches] (batch=1) or [n_embd, n_patches, batch_size] (batch>1)
     ggml_tensor * build_inp() {
         ggml_tensor * inp_raw = build_inp_raw();
         ggml_tensor * inp = ggml_conv_2d(ctx0, model.patch_embeddings, inp_raw, patch_size, patch_size, 0, 0, 1, 1);
-        inp = ggml_reshape_2d(ctx0, inp, n_patches, n_embd);
+        if (batch_size > 1) {
+            inp = ggml_reshape_3d(ctx0, inp, n_patches, n_embd, batch_size);
+        } else {
+            inp = ggml_reshape_2d(ctx0, inp, n_patches, n_embd);
+        }
         inp = ggml_cont(ctx0, ggml_transpose(ctx0, inp));
         if (model.patch_bias) {
             inp = ggml_add(ctx0, inp, model.patch_bias);
@@ -854,7 +877,12 @@ private:
     }
 
     ggml_tensor * build_inp_raw(int channels = 3) {
-        ggml_tensor * inp_raw = ggml_new_tensor_3d(ctx0, GGML_TYPE_F32, img.nx, img.ny, channels);
+        ggml_tensor * inp_raw;
+        if (batch_size > 1) {
+            inp_raw = ggml_new_tensor_4d(ctx0, GGML_TYPE_F32, img.nx, img.ny, channels, batch_size);
+        } else {
+            inp_raw = ggml_new_tensor_3d(ctx0, GGML_TYPE_F32, img.nx, img.ny, channels);
+        }
         ggml_set_name(inp_raw, "inp_raw");
         ggml_set_input(inp_raw);
         return inp_raw;
@@ -1003,6 +1031,7 @@ private:
         {
             const auto n_tokens = q->ne[1];
             const auto n_head   = q->ne[2];
+            const auto n_batch  = q->ne[3];
             // const auto n_kv     = k->ne[1]; // for flash attention
 
             ggml_tensor * kq = ggml_mul_mat(ctx0, k, q);
@@ -1013,7 +1042,12 @@ private:
 
             ggml_tensor * kqv = ggml_mul_mat(ctx0, v, kq);
             cur = ggml_permute(ctx0, kqv, 0, 2, 1, 3);
-            cur = ggml_cont_2d(ctx0, cur, cur->ne[0]*n_head, n_tokens);
+            if (n_batch > 1) {
+                cur = ggml_cont(ctx0, cur);
+                cur = ggml_reshape_3d(ctx0, cur, cur->ne[0]*n_head, n_tokens, n_batch);
+            } else {
+                cur = ggml_cont_2d(ctx0, cur, cur->ne[0]*n_head, n_tokens);
+            }
         }
 
         cb(cur, "kqv_out", il);
@@ -1032,8 +1066,9 @@ private:
 };
 
 static ggml_cgraph * vision_image_build_graph(vision_ctx * ctx, const vision_image_f32_batch & imgs) {
-    GGML_ASSERT(imgs.entries.size() == 1 && "n_batch > 1 is not supported");
-    vision_graph graph(ctx, *imgs.entries[0]);
+    const int n_batch = (int)imgs.entries.size();
+    GGML_ASSERT(n_batch >= 1);
+    vision_graph graph(ctx, *imgs.entries[0], n_batch);
 
     ggml_cgraph * res;
 
@@ -2257,10 +2292,22 @@ bool vision_image_batch_encode(vision_ctx * ctx, const int n_threads, const visi
     const vision_image_f32_batch & imgs = *imgs_c_ptr;
     int batch_size = imgs.entries.size();
 
-    // TODO @ngxson : implement batch size > 1 as a loop
-    //                we don't need true batching support because the cgraph will gonna be big anyway
-    if (batch_size != 1) {
-        return false; // only support batch size of 1
+    if (batch_size < 1) {
+        return false;
+    }
+
+    // verify all images in batch have the same dimensions
+    if (batch_size > 1) {
+        const int ref_nx = imgs.entries[0]->nx;
+        const int ref_ny = imgs.entries[0]->ny;
+        for (int b = 1; b < batch_size; b++) {
+            if (imgs.entries[b]->nx != ref_nx || imgs.entries[b]->ny != ref_ny) {
+                LOG_ERR("%s: batch image %d has size %dx%d, expected %dx%d\n",
+                        __func__, b, imgs.entries[b]->nx, imgs.entries[b]->ny, ref_nx, ref_ny);
+                return false;
+            }
+        }
+        LOG_INF("%s: batched encoding %d images of size %dx%d\n", __func__, batch_size, ref_nx, ref_ny);
     }
 
     // build the inference graph
@@ -2307,40 +2354,22 @@ bool vision_image_batch_encode(vision_ctx * ctx, const int n_threads, const visi
         ggml_backend_tensor_set(cur, values.data(), 0, ggml_nbytes(cur));
     };
 
-    // set input pixel values
+    // set input pixel values for all images in the batch
     {
-        size_t nelem = 0;
-        for (const auto & img : imgs.entries) {
-            nelem += img->nx * img->ny * 3;
-        }
-        std::vector<float> inp_raw(nelem);
+        const int nx = imgs.entries[0]->nx;
+        const int ny = imgs.entries[0]->ny;
+        const int n = nx * ny;
+        std::vector<float> inp_raw(3 * n * batch_size);
 
-        // layout of data (note: the channel dim is unrolled to better visualize the layout):
-        //
-        // ┌──W──┐
-        // │     H │  channel = R
-        // ├─────┤ │
-        // │     H │  channel = G
-        // ├─────┤ │
-        // │     H │  channel = B
-        // └─────┘ │
-        //   ──────┘ x B
-
-        for (size_t i = 0; i < imgs.entries.size(); i++) {
-            const int nx = imgs.entries[i]->nx;
-            const int ny = imgs.entries[i]->ny;
-            const int n = nx * ny;
-
-            for (int b = 0; b < batch_size; b++) {
-                float * batch_entry = inp_raw.data() + b * (3*n);
-                for (int y = 0; y < ny; y++) {
-                    for (int x = 0; x < nx; x++) {
-                        size_t base_src = 3*(y * nx + x); // idx of the first channel
-                        size_t base_dst =    y * nx + x;  // idx of the first channel
-                        batch_entry[      base_dst] = imgs.entries[b]->buf[base_src    ];
-                        batch_entry[1*n + base_dst] = imgs.entries[b]->buf[base_src + 1];
-                        batch_entry[2*n + base_dst] = imgs.entries[b]->buf[base_src + 2];
-                    }
+        for (int b = 0; b < batch_size; b++) {
+            float * batch_entry = inp_raw.data() + b * (3 * n);
+            for (int y = 0; y < ny; y++) {
+                for (int x = 0; x < nx; x++) {
+                    size_t base_src = 3 * (y * nx + x);
+                    size_t base_dst =      y * nx + x;
+                    batch_entry[          base_dst] = imgs.entries[b]->buf[base_src    ];
+                    batch_entry[1 * n + base_dst]   = imgs.entries[b]->buf[base_src + 1];
+                    batch_entry[2 * n + base_dst]   = imgs.entries[b]->buf[base_src + 2];
                 }
             }
         }
@@ -2351,9 +2380,6 @@ bool vision_image_batch_encode(vision_ctx * ctx, const int n_threads, const visi
     switch (ctx->model.model_type) {
         case MiniCPM_o:
             {
-                // inspired from siglip:
-                //    -> https://huggingface.co/HuggingFaceM4/siglip-so400m-14-980-flash-attn2-navit
-                //    -> https://huggingface.co/HuggingFaceM4/siglip-so400m-14-980-flash-attn2-navit/blob/d66538faeba44480d0bfaa42145eef26f9423199/modeling_siglip.py#L316
                 std::vector<int32_t> positions(pos_h * pos_w);
                 int bucket_coords_h[1024];
                 int bucket_coords_w[1024];
@@ -2370,14 +2396,11 @@ bool vision_image_batch_encode(vision_ctx * ctx, const int n_threads, const visi
                 }
                 set_input_i32("positions", positions);
 
-                // inspired from resampler of Qwen-VL:
-                //    -> https://huggingface.co/Qwen/Qwen-VL/tree/main
-                //    -> https://huggingface.co/Qwen/Qwen-VL/blob/0547ed36a86561e2e42fecec8fd0c4f6953e33c4/visual.py#L23
                 int embed_dim = vision_n_mmproj_embd(ctx);
 
-                // TODO @ngxson : this is very inefficient, can we do this using ggml_sin and ggml_cos?
                 auto pos_embed_t = get_2d_sincos_pos_embed(embed_dim, std::make_pair(pos_w, pos_h));
 
+                // pos_embed is [embed_dim, n_pos, 1] — same for all batch elements (broadcast)
                 std::vector<float> pos_embed(embed_dim * pos_w * pos_h);
                 for(int i = 0; i < pos_w * pos_h; ++i){
                     for(int j = 0; j < embed_dim; ++j){
@@ -2494,15 +2517,13 @@ bool vision_image_batch_encode(vision_ctx * ctx, const int n_threads, const visi
         for (ggml_tensor * t : ctx->debug_print_tensors) {
             std::vector<uint8_t> data(ggml_nbytes(t));
             ggml_backend_tensor_get(t, data.data(), 0, ggml_nbytes(t));
-            // print_tensor_shape(t);
-            // print_tensor_data(t, data.data(), 3);
         }
     }
 
     // the last node is the embedding tensor
     ggml_tensor * embeddings = ggml_graph_node(gf, -1);
 
-    // sanity check (only support batch size of 1 for now)
+    // sanity check: output shape should be [embd_dim, n_tokens, batch_size]
     const int n_tokens_out = embeddings->ne[1];
     const int expected_n_tokens_out = vision_n_output_tokens_for_image(ctx, imgs.entries[0].get());
     if (n_tokens_out != expected_n_tokens_out) {
@@ -2511,6 +2532,7 @@ bool vision_image_batch_encode(vision_ctx * ctx, const int n_threads, const visi
     }
 
     // copy the embeddings to the location passed by the user
+    // for batch>1, output is contiguous: [embd * n_tokens * batch_size]
     ggml_backend_tensor_get(embeddings, vec, 0, ggml_nbytes(embeddings));
 
     return true;
@@ -2537,6 +2559,18 @@ void vision_set_max_slice_nums(struct vision_ctx * ctx, int max_slice_nums) {
         ctx->max_slice_nums_override = max_slice_nums;
         LOG_INF("%s: max_slice_nums_override set to %d\n", __func__, max_slice_nums);
     }
+}
+
+// 🔧 [batch encode 开关] 设置/读取多 slice 批量编码优化
+void vision_set_batch_encode(struct vision_ctx * ctx, bool enable) {
+    if (ctx) {
+        ctx->batch_encode = enable;
+        LOG_INF("%s: vision batch encode %s\n", __func__, enable ? "enabled" : "disabled");
+    }
+}
+
+bool vision_get_batch_encode(const struct vision_ctx * ctx) {
+    return ctx ? ctx->batch_encode : false;
 }
 
 //

--- a/tools/omni/vision.h
+++ b/tools/omni/vision.h
@@ -93,6 +93,9 @@ struct vision_image_u8        * vision_image_u8_init (void);
 struct vision_image_f32       * vision_image_f32_init(void);
 struct vision_image_f32_batch * vision_image_f32_batch_init(void);
 
+// decode an encoded image (PNG/JPEG/...) from memory into a vision_image_u8
+bool vision_image_load_from_bytes(const unsigned char * bytes, size_t bytes_length, struct vision_image_u8 * img);
+
 // vision query
 int vision_n_output_tokens(const struct vision_ctx * ctx);
 int vision_n_mmproj_embd(const struct vision_ctx * ctx);
@@ -103,6 +106,11 @@ bool vision_image_preprocess(struct vision_ctx * ctx, const struct vision_image_
 // vision forward
 bool vision_image_encode      (struct vision_ctx * ctx, int n_threads, struct vision_image_f32 * img, float * vec);
 bool vision_image_batch_encode(struct vision_ctx * ctx, int n_threads, const struct vision_image_f32_batch * imgs, float * vec);
+
+// batch encode 开关：是否对多个尺寸相同的 slice 启用批量编码优化
+// 默认关闭；只有大图/高清高刷等 slice 数较多的场景才建议开启
+void vision_set_batch_encode(struct vision_ctx * ctx, bool enable);
+bool vision_get_batch_encode(const struct vision_ctx * ctx);
 
 // CoreML / ANE support
 void vision_set_coreml_model_path(struct vision_ctx * ctx, const char * coreml_model_path);

--- a/tools/server/server-omni.cpp
+++ b/tools/server/server-omni.cpp
@@ -64,6 +64,14 @@ int main(int argc, char ** argv) {
         return 1;
     }
 
+    // omni HTTP server is single-session (1:1 duplex), so 1 sequence is enough.
+    // common_params defaults n_parallel to -1 ("auto"); each example resolves it
+    // itself (see tools/server/server.cpp). Without this, n_seq_max overflows
+    // uint32 and trips LLAMA_MAX_SEQ(256) inside llama_context.
+    if (params.n_parallel < 0) {
+        params.n_parallel = 1;
+    }
+
     llama_backend_init();
     llama_numa_init(params.numa);
 
@@ -126,6 +134,26 @@ int main(int argc, char ** argv) {
             }
             return true;
         };
+
+        // Resolve omni model paths from `model_dir` (parity with old feat/web-demo
+        // server.cpp). common_params has no CLI parser for vpm/apm/tts paths,
+        // so they must be filled in here; otherwise omni_init() inside hits
+        // `apm_model.empty()` and returns NULL.
+        std::string model_dir_norm = model_dir;
+        if (!model_dir_norm.empty() &&
+            model_dir_norm.back() != '/' && model_dir_norm.back() != '\\') {
+            model_dir_norm += '/';
+        }
+        params.vpm_model = model_dir_norm + "vision/MiniCPM-o-4_5-vision-F16.gguf";
+        params.apm_model = model_dir_norm + "audio/MiniCPM-o-4_5-audio-F16.gguf";
+        params.tts_model = model_dir_norm + "tts/MiniCPM-o-4_5-tts-F16.gguf";
+
+        if (!check_file("LLM",    params.model.path) ||
+            !check_file("vision", params.vpm_model)  ||
+            !check_file("audio",  params.apm_model)  ||
+            (use_tts && !check_file("tts", params.tts_model))) {
+            return;
+        }
 
         {
             std::lock_guard<std::mutex> lock(state.octx_mutex);


### PR DESCRIPTION
# 优化 Duplex Profiling 统计口径

## 背景

本 PR 优化 duplex 测试的 profiling 统计口径，使其更贴近真实数据处理耗时。聚焦底层流水线中的实际处理阶段，用于判断 SPEAK 音频输出是否满足 1 秒内完成的双工需求。

## 主要改动

### 1. 收敛 profiling 阶段

当前仅保留 duplex 路径中的核心处理阶段：

* `duplex.encode`
* `duplex.llm.prefill`
* `duplex.llm.decode`
* `tts.condition`
* `tts.prefill`
* `tts.decode`
* `t2w.infer`
* `t2w.write`

### 2. 明确 frame 数据流传递

补齐 duplex decode 到 TTS/T2W 后续阶段的 `perf_chunk_index` 传递，使同一个输入 frame 在 encode、LLM、TTS 和 T2W 等阶段保持一致的 frame 标识，便于报告按 frame 维度汇总和展示各阶段耗时。

### 3. 简化分析脚本输出

更新 duplex profiling 分析脚本，使默认报告只围绕核心阶段展开。

默认输出包括：

* duplex 性能报告
* duplex pipeline 图
* GPU 利用率图

不再默认生成长 CSV、SLA 细表、多余 stage timing 文件和额外调试图。

### 4. 调整 SLA 统计口径

新的 SLA 统计只关注 `SPEAK` frame：

* 起点为该 frame 的 `duplex.encode.start`
* 终点为该 frame 最后一次 `t2w.write.end`
* `LISTEN` frame 不要求包含 TTS/T2W 阶段
* 初始化阶段不纳入 SLA 统计

### 5. 保留 token 速度统计

报告中继续保留关键模型阶段的 token 数和推理速度统计，包括：

* `duplex.llm.prefill`
* `duplex.llm.decode`
* `tts.prefill`
* `tts.decode`

便于分析 LLM 和 TTS 两部分的实际推理效率。

## 验证

已通过 GPU duplex 测试和 profiling 分析脚本验证，能够生成简化后的性能报告、pipeline 图和 GPU 利用率图。



