### PR TITLE
feat: add use_tts flag to session.init for per-session TTS toggle

### DIFF
--- a/tools/server/protocol.cpp
+++ b/tools/server/protocol.cpp
@@ -278,6 +278,9 @@ ParsedSessionInit parse_session_init(const json & msg) {
     }
     out.mode = mode;
 
+    // use_tts — session-level TTS toggle (same name as server init /omni_init)
+    out.use_tts = json_bool(p, "use_tts", true);
+
     // voice (reference audio)
     if (p.contains("voice") && p.at("voice").is_object()) {
         const json & v = p.at("voice");

--- a/tools/server/protocol.h
+++ b/tools/server/protocol.h
@@ -83,6 +83,9 @@ struct ParsedSessionInit {
 
     std::string mode; // "full_duplex" or "turn_based"
 
+    // TTS enabled flag — defaults to true for backward compatibility
+    bool use_tts = true;
+
     // voice reference audio (base64 float32 PCM)
     std::string ref_audio_b64;
     std::string tts_ref_audio_b64;

--- a/tools/server/ws_handler.cpp
+++ b/tools/server/ws_handler.cpp
@@ -523,9 +523,7 @@ static omni_context * create_session_octx(common_params & params, const ParsedSe
                                           const std::string & output_dir) {
     int media_type = 2; // omni
     bool duplex_mode = (init.mode == "full_duplex");
-    // Turn-based sessions may request TTS per input.append. Load the TTS-capable
-    // context up front, then toggle octx->use_tts per request.
-    bool use_tts = true;
+    bool use_tts = init.use_tts;
 
     // Build params for omni_init
     auto & p = params;


### PR DESCRIPTION
## Summary
- Add `use_tts` field to `ParsedSessionInit` (defaults to `true` for backward compatibility)
- Parse `use_tts` from `session.init` payload in `parse_session_init()`
- Use `init.use_tts` instead of hardcoded `true` in `create_session_octx()`

## Usage
Frontend sends `"use_tts": true/false` in `session.init` payload to control TTS per session.