### PR TITLE
fix: prevent full-duplex SPEAK tail cut on LISTEN switch and mid-turn TTS finalization

### DIFF
--- a/tools/omni/omni.cpp
+++ b/tools/omni/omni.cpp
@@ -6678,17 +6678,13 @@ void tts_thread_func_duplex(struct omni_context * ctx_omni, common_params *param
             llm_text.clear();
             response.clear();
             
-            // Handle final chunk
             if (llm_finish) {
-                tts_finish = true;
-                ctx_omni->speek_done = true;
-                ctx_omni->warmup_done = true;
-                speek_cv.notify_all();
-                
-                merge_wav_files(tts_wav_output_dir, chunk_idx + 1);
-                
-                if (ctx_omni->duplex_mode && !accumulated_is_end_of_turn) {
-                    // LISTEN/CHUNK_EOS: 保持 TTS 状态
+                const bool duplex_mid_chunk =
+                    ctx_omni->duplex_mode && !accumulated_is_end_of_turn;
+
+                if (duplex_mid_chunk) {
+                    ctx_omni->speek_done = false;
+                    ctx_omni->warmup_done = true;
                     if (ctx_omni->t2w_thread_info) {
                         T2WOut *t2w_out = new T2WOut();
                         t2w_out->audio_tokens.clear();
@@ -6705,6 +6701,13 @@ void tts_thread_func_duplex(struct omni_context * ctx_omni, common_params *param
                     tts_finish = false;
                 } else {
                     // 真正的轮次结束
+                    tts_finish = true;
+                    ctx_omni->speek_done = true;
+                    ctx_omni->warmup_done = true;
+                    speek_cv.notify_all();
+
+                    merge_wav_files(tts_wav_output_dir, chunk_idx + 1);
+
                     if (ctx_omni->t2w_thread_info && !turn_eos_flushed) {
                         T2WOut *t2w_out = new T2WOut();
                         t2w_out->audio_tokens.clear();
@@ -6724,6 +6727,7 @@ void tts_thread_func_duplex(struct omni_context * ctx_omni, common_params *param
                     ctx_omni->tts_n_past_accumulated = 0;
                     ctx_omni->tts_all_generated_tokens.clear();
                     ctx_omni->tts_condition_saved = false;
+                    chunk_idx = 0;
                     tts_n_past = 0;
                     audio_tokens.clear();
                     all_audio_tokens.clear();
@@ -6778,6 +6782,7 @@ void tts_thread_func_duplex(struct omni_context * ctx_omni, common_params *param
             ctx_omni->tts_n_past_accumulated = 0;
             ctx_omni->tts_all_generated_tokens.clear();
             ctx_omni->tts_condition_saved = false;
+            chunk_idx = 0;
             tts_n_past = 0;
             audio_tokens.clear();
             all_audio_tokens.clear();

--- a/tools/server/ws_handler.cpp
+++ b/tools/server/ws_handler.cpp
@@ -523,7 +523,7 @@ static omni_context * create_session_octx(common_params & params, const ParsedSe
                                           const std::string & output_dir) {
     int media_type = 2; // omni
     bool duplex_mode = (init.mode == "full_duplex");
-    bool use_tts = init.use_tts;
+    bool use_tts = duplex_mode ? init.use_tts : true;
 
     // Build params for omni_init
     auto & p = params;
@@ -713,13 +713,16 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
         bool accumulate = false;
         std::vector<float> accum;
         bool emitted_audio = false;
+        bool has_stream_audio = false;
+        double streamed_audio_ms = 0.0;
+        std::chrono::steady_clock::time_point first_stream_audio_sent;
     };
     auto audio_state = std::make_shared<AudioCbState>();
     audio_state->session_id = session_id;
     audio_state->ws = &ws;
     audio_state->octx = octx;
 
-    octx->audio_output_cb = [audio_state](const float * samples, int n_samples, int /*sample_rate*/, bool /*is_final*/) {
+    octx->audio_output_cb = [audio_state](const float * samples, int n_samples, int sample_rate, bool /*is_final*/) {
         {
             // Non-streaming: buffer the PCM so it can be returned in
             // response.done.audio rather than emitted as audio deltas.
@@ -740,6 +743,15 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
                 response_id = audio_state->response_id;
                 response_start = audio_state->response_start;
                 audio_state->emitted_audio = true;
+                if (samples && n_samples > 0) {
+                    if (!audio_state->has_stream_audio) {
+                        audio_state->has_stream_audio = true;
+                        audio_state->first_stream_audio_sent = std::chrono::steady_clock::now();
+                    }
+                    const int sr = sample_rate > 0 ? sample_rate : 24000;
+                    audio_state->streamed_audio_ms +=
+                        1000.0 * static_cast<double>(n_samples) / static_cast<double>(sr);
+                }
             }
             std::string b64 = float32_pcm_to_b64(samples, n_samples);
             ProtocolMetrics metrics = make_runtime_metrics(
@@ -797,6 +809,8 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
             audio_state->response_id = response_id; // update for audio callback
             audio_state->response_start = t_request_start;
             audio_state->emitted_audio = false;
+            audio_state->has_stream_audio = false;
+            audio_state->streamed_audio_ms = 0.0;
         }
 
         // Branch: full_duplex vs turn_based. The input shape MUST match the
@@ -1147,6 +1161,7 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
             // Collect full text for response.done
             std::string full_text;
             std::string utf8_pending;
+            bool pending_listen = false;
 
             // Poll text_queue
             while (true) {
@@ -1169,14 +1184,7 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
 
                 if (!frag.empty()) {
                     if (frag == "__IS_LISTEN__") {
-                        // Model switched to listen
-                        send_event(make_listen_delta(
-                            session_id, response_id,
-                            make_runtime_metrics(octx, prefill_ms,
-                                                 elapsed_ms(t_generate_start),
-                                                 elapsed_ms(t_request_start), 0,
-                                                 turn_vision_slices)));
-                        break; // Done for this input
+                        pending_listen = true;
                     } else if (frag == "__END_OF_TURN__") {
                         // Turn ended — will be handled by response.done
                     } else {
@@ -1220,6 +1228,41 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
                                              elapsed_ms(t_request_start), 0,
                                              turn_vision_slices)));
                 }
+            }
+            if (pending_listen) {
+                const bool has_tts_tail =
+                    octx->use_tts &&
+                    (!full_text.empty() ||
+                     !omni_tts_queues_empty(octx));
+                if (has_tts_tail) {
+                    if (!omni_duplex_drain_tts_audio(octx, /*max_wait_ms*/3000, /*idle_ms*/100)) {
+                        LOG_WRN("WS /backend: timed out waiting for full-duplex TTS drain before listen for session %s\n",
+                                session_id.c_str());
+                    }
+                }
+                int playback_tail_wait_ms = 0;
+                {
+                    std::lock_guard<std::mutex> lk(audio_state->mtx);
+                    if (audio_state->has_stream_audio) {
+                        const int audio_ms = static_cast<int>(audio_state->streamed_audio_ms + 0.5);
+                        const int client_delay_ms = 250;
+                        const int safety_ms = 250;
+                        const auto playback_done_at =
+                            audio_state->first_stream_audio_sent +
+                            std::chrono::milliseconds(audio_ms + client_delay_ms + safety_ms);
+                        playback_tail_wait_ms = static_cast<int>(
+                            std::chrono::duration_cast<std::chrono::milliseconds>(
+                                playback_done_at - std::chrono::steady_clock::now()).count());
+                    }
+                }
+                if (playback_tail_wait_ms > 0) {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(playback_tail_wait_ms));
+                }
+                send_event(make_listen_delta(
+                    session_id, response_id,
+                    make_runtime_metrics(octx, prefill_ms, generate_ms,
+                                         elapsed_ms(t_request_start), 0,
+                                         turn_vision_slices)));
             }
             bool emitted_audio = false;
             {


### PR DESCRIPTION
… TTS finalization

## Overview

<!-- Describe what this PR does and why. Be concise but complete -->
1、对于长回答尾音被吞：模型从"说"切到"听"（LISTEN）时，会立即切换，把还没生成完/还没播完的语音尾巴掐掉。现在改为——切 LISTEN 前先等 TTS 把剩余音频生成完、并等已发送的音频在前端播放完，再进入 LISTEN，保证整句话说完整。

2、对于中间 chunk 被误判为整轮结束：一轮语音中途的分段（chunk）会被当成"整轮说完"来处理，提前重置 TTS 状态、合并音频，导致断字/语音不连续。现在改为——只有真正轮次结束才做收尾（合并音频、清理状态、复位 chunk 计数），中途分段保持"还在说"的状态继续。

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
