### PR TITLE
fix: handle F32 tensors in ggml_tensor_to_f32 to avoid null to_float segfault

### DIFF
--- a/tools/omni/omni.cpp
+++ b/tools/omni/omni.cpp
@@ -1613,7 +1613,16 @@ std::vector<float> projector_forward(projector_model & model, const float * inpu
 bool load_tts_weights_from_gguf(struct omni_context * ctx_omni, const char * tts_model_path) {
 
     auto ggml_tensor_to_f32 = [](const ggml_tensor * t, float * dst, int64_t n) {
-        ggml_get_type_traits(t->type)->to_float(t->data, dst, n);
+        if (t->type == GGML_TYPE_F32) {
+            memcpy(dst, t->data, (size_t)n * sizeof(float));
+            return;
+        }
+        const auto * traits = ggml_get_type_traits(t->type);
+        if (traits && traits->to_float) {
+            traits->to_float(t->data, dst, n);
+        } else {
+            LOG_ERR("TTS: no to_float converter for ggml type %d\n", (int)t->type);
+        }
     };
 
     // Initialize GGUF context


### PR DESCRIPTION
ggml_tensor_to_f32 in load_tts_weights_from_gguf called ggml_get_type_traits(t->type)->to_float() unconditionally, but for GGML_TYPE_F32 the to_float pointer is NULL. Loading F32 TTS weights (default in MiniCPM-o 4.5 GGUF) triggers jump to 0x0 segfault.

Fix:
- F32 fast path: direct memcpy when tensor type is GGML_TYPE_F32
- Defensive guard: null-check traits and traits->to_float, log error if no converter

Closes #76