### PR TITLE
fix: swap cert/key args to match SSLServer(cert, key) constructor order

### DIFF
--- a/tools/server/server-omni.cpp
+++ b/tools/server/server-omni.cpp
@@ -115,7 +115,7 @@ int main(int argc, char ** argv) {
 
     // HTTP server setup
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-    httplib::SSLServer svr(params.ssl_file_key.c_str(), params.ssl_file_cert.c_str());
+    httplib::SSLServer svr(params.ssl_file_cert.c_str(), params.ssl_file_key.c_str());
 #else
     httplib::Server svr;
 #endif

--- a/tools/server/server-voxcpm2.cpp
+++ b/tools/server/server-voxcpm2.cpp
@@ -207,7 +207,7 @@ int main(int argc, char ** argv) {
 
     // HTTP server setup
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-    httplib::SSLServer svr(params.ssl_file_key.c_str(), params.ssl_file_cert.c_str());
+    httplib::SSLServer svr(params.ssl_file_cert.c_str(), params.ssl_file_key.c_str());
 #else
     httplib::Server svr;
 #endif


### PR DESCRIPTION
cpp-httplib SSLServer constructor is `SSLServer(cert_path, private_key_path, ...)`, but server-omni and server-voxcpm2 passed (key, cert) — the opposite order. This caused TLS init to fail silently, making `svr.listen()` return immediately and the server exit with code 0, without binding or printing any error.

Fix: swap to `SSLServer(cert, key)` in both files.

Closes #77