### PR TITLE
CANN: fix Token2Wav streaming crashes and disable Flash Attention in AUTO mode

### DIFF
--- a/ggml/src/ggml-cann/ggml-cann.cpp
+++ b/ggml/src/ggml-cann/ggml-cann.cpp
@@ -1701,6 +1701,13 @@ static void * ggml_cann_host_malloc(size_t size) {
     }
 
     void *   hostPtr = nullptr;
+    // aclrtMallocHost requires a thread-local ACL context; threads that have
+    // not touched a device yet (e.g. the token2wav worker thread) would fail
+    // here and silently lose pinned memory. Bind the primary device first.
+    int32_t current_device = -1;
+    if (aclrtGetDevice(&current_device) != ACL_SUCCESS) {
+        ggml_cann_set_device(0);
+    }
     aclError err     = aclrtMallocHost((void **) &hostPtr, size);
     if (err != ACL_SUCCESS) {
         GGML_LOG_WARN("%s: failed to allocate %.2f MiB of pinned memory: %s\n", __func__, size / 1024.0 / 1024.0,
@@ -1922,7 +1929,10 @@ static bool ggml_cann_compute_forward(ggml_backend_cann_context & ctx, struct gg
             ggml_cann_scale(ctx, dst);
             break;
         case GGML_OP_SQR:
-            GGML_ASSERT(dst->src[1] == nullptr);
+            // SQR is emulated as MUL(x, x) by pointing src[1] at src[0].
+            // The node mutation persists in the graph, so allow re-evaluated
+            // graphs (e.g. streaming token2wav) where src[1] was already set.
+            GGML_ASSERT(dst->src[1] == nullptr || dst->src[1] == dst->src[0]);
             dst->src[1] = dst->src[0];
             ggml_cann_binary_op<aclnn_mul>(ctx, dst);
             break;
@@ -2084,6 +2094,10 @@ static void ggml_backend_cann_set_tensor_async(ggml_backend_t backend,
     GGML_ASSERT(buf->buft == ggml_backend_cann_buffer_type(cann_ctx->device) && "unsupported buffer type");
     GGML_ASSERT(!ggml_is_quantized(tensor->type));
 
+    // Bind the calling thread to the device: worker threads (e.g. the
+    // token2wav thread) may reach here as their first CANN call, and
+    // aclrtMemcpyAsync requires a thread-local ACL context.
+    ggml_cann_set_device(cann_ctx->device);
     ACL_CHECK(aclrtMemcpyAsync((char *) tensor->data + offset, size, data, size, ACL_MEMCPY_HOST_TO_DEVICE,
                                cann_ctx->stream()));
 }
@@ -2110,6 +2124,8 @@ static void ggml_backend_cann_get_tensor_async(ggml_backend_t      backend,
     GGML_ASSERT(buf->buft == ggml_backend_cann_buffer_type(cann_ctx->device) && "unsupported buffer type");
     GGML_ASSERT(!ggml_is_quantized(tensor->type));
 
+    // Same as set_tensor_async: ensure this thread has an ACL context.
+    ggml_cann_set_device(cann_ctx->device);
     ACL_CHECK(aclrtMemcpyAsync(data, size, (char *) tensor->data + offset, size, ACL_MEMCPY_DEVICE_TO_HOST,
                                cann_ctx->stream()));
 }

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -3394,6 +3394,19 @@ llama_context * llama_init_from_model(
         params.flash_attn_type = LLAMA_FLASH_ATTN_TYPE_DISABLED;
     }
 
+    // CANN (Ascend NPU): the fused attention operator is numerically unstable
+    // on some SOCs under long / multi-image shapes. Force-disable FA on CANN in
+    // AUTO mode; pass --flash-attn on to opt back in.
+    if (params.flash_attn_type == LLAMA_FLASH_ATTN_TYPE_AUTO) {
+        for (const auto & dev : model->devices) {
+            if (dev.dev && strncmp(ggml_backend_dev_name(dev.dev), "CANN", 4) == 0) {
+                LLAMA_LOG_WARN("%s: flash_attn is not compatible with CANN - forcing off\n", __func__);
+                params.flash_attn_type = LLAMA_FLASH_ATTN_TYPE_DISABLED;
+                break;
+            }
+        }
+    }
+
     if (model->split_mode() == LLAMA_SPLIT_MODE_TENSOR) {
         if (params.flash_attn_type == LLAMA_FLASH_ATTN_TYPE_AUTO) {
             LLAMA_LOG_INFO("%s: enabling flash_attn since it is required for SPLIT_MODE_TENSOR\n", __func__);

--- a/tools/omni/token2wav/token2wav-impl.cpp
+++ b/tools/omni/token2wav/token2wav-impl.cpp
@@ -9655,7 +9655,20 @@ bool Token2Wav::load_models(const std::string & encoder_gguf,
                             const std::string & coreml_model_path) {
     reset_stream();
 
-    constexpr int kDefaultThreads = 8;
+    // CPU thread count for token2mel / vocoder. Overridable via env
+    // OMNI_T2W_THREADS: on many-core servers the vocoder-on-CPU path
+    // benefits from far more than 8 threads. Only affects CPU backends.
+    int kDefaultThreads = 8;
+    {
+        const char * th = getenv("OMNI_T2W_THREADS");
+        if (th && th[0]) {
+            int v = atoi(th);
+            if (v > 0) {
+                kDefaultThreads = v;
+            }
+        }
+    }
+    std::fprintf(stderr, "Token2Wav.load_models: using %d CPU threads (token2mel+vocoder)\n", kDefaultThreads);
     if (!t2m_.load_model(encoder_gguf, flow_matching_gguf, flow_extra_gguf, device_token2mel, kDefaultThreads,
                          coreml_model_path)) {
         LOG_ERROR( "Token2Wav.load_models: Token2Mel.load_model failed\n");


### PR DESCRIPTION
## Summary

- Fix two ggml-cann crashes that prevented Token2Wav from running on NPU, forcing vocoder fallback to CPU with nearly zero audio output
- Disable Flash Attention by default on CANN in AUTO mode due to numerical instability on certain SOCs
- Add env-based configuration for thread count (`OMNI_T2W_THREADS`)

## Details

### Commit 1: Fix Token2Wav streaming crashes

Two ggml-cann issues triggered on the token2wav worker thread:
1. `set/get_tensor_async` did not bind a thread-local ACL context → `aclrtMemcpyAsync` aborted with "ctx is NULL"
2. `GGML_OP_SQR` (emulated as `MUL(x,x)`) mutates `src[1]` in place; re-evaluating the same graph in streaming mode tripped `GGML_ASSERT(dst->src[1]==nullptr)`

Fixes:
- Bind the device via `ggml_cann_set_device` in `set/get_tensor_async`
- Relax the SQR assert to allow `src[1]==src[0]` (idempotent re-eval)
- `ggml_cann_host_malloc` binds the device when no context is set

New env hook: `OMNI_T2W_THREADS` (token2mel/vocoder CPU threads, default 8)

### Commit 2: Disable Flash Attention in AUTO mode

The fused attention operator (`FusedInferAttentionScoreV2`) is numerically unstable on some CANN SOCs under long/multi-image shapes, producing degraded logits (repeated-token / '?' floods). Force-disable FA on CANN in AUTO mode, matching the existing Grok override pattern. Pass `--flash-attn on` to opt back in.

## Test plan

- [x] Verified on Ascend 910B4: TTFPA reduced from ~29s to ~1.3s, full audio pipeline runs on NPU without CPU fallback
- [ ] Confirm no regression on CUDA/Metal backends (Flash Attention behavior unchanged)