### PR TITLE
CANN: fix Token2Wav streaming crashes and disable Flash Attention in AUTO mode

### DIFF
--- a/ggml/src/ggml-cann/ggml-cann.cpp
+++ b/ggml/src/ggml-cann/ggml-cann.cpp
@@ -1701,6 +1701,13 @@ static void * ggml_cann_host_malloc(size_t size) {
     }
 
     void *   hostPtr = nullptr;
+    // aclrtMallocHost requires a thread-local ACL context; threads that have
+    // not touched a device yet (e.g. the token2wav worker thread) would fail
+    // here and silently lose pinned memory. Bind the primary device first.
+    int32_t current_device = -1;
+    if (aclrtGetDevice(&current_device) != ACL_SUCCESS) {
+        ggml_cann_set_device(0);
+    }
     aclError err     = aclrtMallocHost((void **) &hostPtr, size);
     if (err != ACL_SUCCESS) {
         GGML_LOG_WARN("%s: failed to allocate %.2f MiB of pinned memory: %s\n", __func__, size / 1024.0 / 1024.0,
@@ -2087,6 +2094,10 @@ static void ggml_backend_cann_set_tensor_async(ggml_backend_t backend,
     GGML_ASSERT(buf->buft == ggml_backend_cann_buffer_type(cann_ctx->device) && "unsupported buffer type");
     GGML_ASSERT(!ggml_is_quantized(tensor->type));
 
+    // Bind the calling thread to the device: worker threads (e.g. the
+    // token2wav thread) may reach here as their first CANN call, and
+    // aclrtMemcpyAsync requires a thread-local ACL context.
+    ggml_cann_set_device(cann_ctx->device);
     ACL_CHECK(aclrtMemcpyAsync((char *) tensor->data + offset, size, data, size, ACL_MEMCPY_HOST_TO_DEVICE,
                                cann_ctx->stream()));
 }
@@ -2113,6 +2124,8 @@ static void ggml_backend_cann_get_tensor_async(ggml_backend_t      backend,
     GGML_ASSERT(buf->buft == ggml_backend_cann_buffer_type(cann_ctx->device) && "unsupported buffer type");
     GGML_ASSERT(!ggml_is_quantized(tensor->type));
 
+    // Same as set_tensor_async: ensure this thread has an ACL context.
+    ggml_cann_set_device(cann_ctx->device);
     ACL_CHECK(aclrtMemcpyAsync(data, size, (char *) tensor->data + offset, size, ACL_MEMCPY_DEVICE_TO_HOST,
                                cann_ctx->stream()));
 }

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -3394,6 +3394,19 @@ llama_context * llama_init_from_model(
         params.flash_attn_type = LLAMA_FLASH_ATTN_TYPE_DISABLED;
     }
 
+    // CANN (Ascend NPU): the fused attention operator is numerically unstable
+    // on some SOCs under long / multi-image shapes. Force-disable FA on CANN in
+    // AUTO mode; pass --flash-attn on to opt back in.
+    if (params.flash_attn_type == LLAMA_FLASH_ATTN_TYPE_AUTO) {
+        for (const auto & dev : model->devices) {
+            if (dev.dev && strncmp(ggml_backend_dev_name(dev.dev), "CANN", 4) == 0) {
+                LLAMA_LOG_WARN("%s: flash_attn is not compatible with CANN - forcing off\n", __func__);
+                params.flash_attn_type = LLAMA_FLASH_ATTN_TYPE_DISABLED;
+                break;
+            }
+        }
+    }
+
     if (model->split_mode() == LLAMA_SPLIT_MODE_TENSOR) {
         if (params.flash_attn_type == LLAMA_FLASH_ATTN_TYPE_AUTO) {
             LLAMA_LOG_INFO("%s: enabling flash_attn since it is required for SPLIT_MODE_TENSOR\n", __func__);

--- a/tools/omni/token2wav/token2wav-impl.cpp
+++ b/tools/omni/token2wav/token2wav-impl.cpp
@@ -9678,7 +9678,20 @@ bool Token2Wav::load_models(const std::string & encoder_gguf,
                             const std::string & coreml_model_path) {
     reset_stream();
 
-    constexpr int kDefaultThreads = 8;
+    // CPU thread count for token2mel / vocoder. Overridable via env
+    // OMNI_T2W_THREADS: on many-core servers the vocoder-on-CPU path
+    // benefits from far more than 8 threads. Only affects CPU backends.
+    int kDefaultThreads = 8;
+    {
+        const char * th = getenv("OMNI_T2W_THREADS");
+        if (th && th[0]) {
+            int v = atoi(th);
+            if (v > 0) {
+                kDefaultThreads = v;
+            }
+        }
+    }
+    std::fprintf(stderr, "Token2Wav.load_models: using %d CPU threads (token2mel+vocoder)\n", kDefaultThreads);
     if (!t2m_.load_model(encoder_gguf, flow_matching_gguf, flow_extra_gguf, device_token2mel, kDefaultThreads,
                          coreml_model_path)) {
         LOG_ERROR( "Token2Wav.load_models: Token2Mel.load_model failed\n");


### PR DESCRIPTION
## Summary

Follow-up to the Ascend CANN backend work on this branch. Fixes two remaining issues that kept Token2Wav from running end-to-end on NPU, and disables the numerically unstable fused attention path on CANN.

- Bind a thread-local ACL context on the Token2Wav worker thread so async host/device copies no longer abort
- Disable Flash Attention by default on CANN in AUTO mode
- Add `OMNI_T2W_THREADS` to tune the token2mel / vocoder CPU thread count

## Details

### Token2Wav streaming crashes

`set_tensor_async` / `get_tensor_async` did not bind a thread-local ACL context, so `aclrtMemcpyAsync` aborted with "ctx is NULL" the first time the token2wav worker thread reached them. `ggml_cann_host_malloc` had the same problem and would silently lose pinned memory.

- `set/get_tensor_async` bind the device via `ggml_cann_set_device` before the async memcpy
- `ggml_cann_host_malloc` binds the primary device when the calling thread has no ACL context yet

(The `GGML_OP_SQR` re-eval crash is already fixed on this branch, so it is not touched here.)

### Flash Attention in AUTO mode

The fused attention operator is numerically unstable on some Ascend SOCs under long / multi-image shapes, producing degraded logits. AUTO only checks device placement, not numerical validity, so it would enable Flash Attention on CANN. Force-disable it on CANN in AUTO mode, matching the existing Grok override. Pass `--flash-attn on` to opt back in.

### Thread config

`OMNI_T2W_THREADS` overrides the token2mel / vocoder CPU thread count (default 8), which helps the vocoder-on-CPU path on many-core servers.

## Verification

- `src/llama-context.cpp` and `tools/omni/token2wav/token2wav-impl.cpp` compiled cleanly (object build, no new warnings)
- `ggml/src/ggml-cann/ggml-cann.cpp` could not be built locally (no Ascend SDK); all called symbols verified against their prototypes and the file's thread-local device-binding model