### PR TITLE
[CANN] fix flash-attn mask: use BOOL attenMask instead of F16 -Inf pseShift

### DIFF
--- a/ggml/src/ggml-cann/aclnn_ops.cpp
+++ b/ggml/src/ggml-cann/aclnn_ops.cpp
@@ -56,6 +56,7 @@
 #include <aclnnop/aclnn_index_select.h>
 #include <aclnnop/aclnn_layer_norm.h>
 #include <aclnnop/aclnn_log.h>
+#include <aclnnop/aclnn_lt_scalar.h>
 #include <aclnnop/aclnn_matmul.h>
 #include <aclnnop/aclnn_max_pool.h>
 #include <aclnnop/aclnn_mean.h>
@@ -3970,48 +3971,62 @@ void ggml_cann_flash_attn_ext(ggml_backend_cann_context & ctx, ggml_tensor * dst
             src2_bsnd_ne[0] = D_padded;
         }
 
-        // Step 3: create the PSEShift tensor if needed
-        //         this tensor is considered as mask (f16) in the llama.cpp
+        // Step 3: attention mask / position encoding for FusedInferAttentionScoreV2.
+        // Ascend docs:
+        //   - attenMaskOptional: BOOL/INT8/UINT8 hard mask (True/1 = do not attend)
+        //   - pseShiftOptional:  FLOAT16/BFLOAT16 position encoding (ALiBi etc.), NOT -Inf masks
+        // llama.cpp src3 is an additive F16 mask (-Inf masked, finite keep/bias). Convert the
+        // hard-mask part to BOOL attenMask; keep finite ALiBi bias in pseShift when needed.
+        acl_tensor_ptr       atten_mask_tensor;
         acl_tensor_ptr       bcast_pse_tensor;
+        ggml_cann_pool_alloc atten_mask_allocator(ctx.pool());
         ggml_cann_pool_alloc bcast_pse_allocator(ctx.pool());
         if (src3 != nullptr) {
-            // Construct the truncated pse tensor (common for prefill/decode)
-            int64_t trunc_pse_ne[GGML_MAX_DIMS] = {
-                src3->ne[0],  // D
-                src0->ne[1],  // S (number of Q tokens)
-                src3->ne[2],  // mask N
+            // Truncate to current Q length; ACL layout after reverse is [B, N_mask, Q_S, KV_S].
+            int64_t mask_ne[GGML_MAX_DIMS] = {
+                src3->ne[0],  // KV_S
+                src0->ne[1],  // Q_S
+                src3->ne[2],  // mask N (often 1)
                 src3->ne[3]   // B
             };
-            size_t * trunc_pse_nb = src3->nb;
+            size_t * mask_src_nb = src3->nb;
 
             acl_tensor_ptr acl_mask_f16_trunc_tensor = ggml_cann_create_tensor(
-                src3->data, ACL_FLOAT16, sizeof(uint16_t), trunc_pse_ne, trunc_pse_nb, GGML_MAX_DIMS);
+                src3->data, ACL_FLOAT16, sizeof(uint16_t), mask_ne, mask_src_nb, GGML_MAX_DIMS);
 
-            int64_t bcast_pse_ne[GGML_MAX_DIMS];
-            size_t  bcast_pse_nb[GGML_MAX_DIMS];
-            bcast_pse_ne[0] = src3->ne[0];  // D
-            bcast_pse_ne[1] = src0->ne[1];  // S
-            bcast_pse_ne[2] = src0->ne[2];  // N (num_heads)
-            bcast_pse_ne[3] = src3->ne[3];  // B
-            if (maxBias == 0.0f) {
-                // When maxBias == 0.0f, use nb = 0 reduce once repeat (Qwen2)
-                // Construct the bcast tensor (simulate repeat on the head dimension using stride=0)
-                bcast_pse_nb[0] = sizeof(uint16_t);
-                bcast_pse_nb[1] = bcast_pse_nb[0] * bcast_pse_ne[0];
-                bcast_pse_nb[2] = 0;  // <---- the head dimension shares the same data
-                bcast_pse_nb[3] = src3->nb[3];
+            // Contiguous BOOL attenMask: True where additive mask is -Inf / large negative.
+            size_t mask_bool_nb[GGML_MAX_DIMS];
+            mask_bool_nb[0] = sizeof(uint8_t);
+            for (int i = 1; i < GGML_MAX_DIMS; ++i) {
+                mask_bool_nb[i] = mask_bool_nb[i - 1] * (size_t) mask_ne[i - 1];
+            }
+            const int64_t mask_nelems = mask_ne[0] * mask_ne[1] * mask_ne[2] * mask_ne[3];
+            void *        atten_buf   = atten_mask_allocator.alloc((size_t) mask_nelems * sizeof(uint8_t));
+            atten_mask_tensor =
+                ggml_cann_create_tensor(atten_buf, ACL_BOOL, sizeof(uint8_t), mask_ne, mask_bool_nb, GGML_MAX_DIMS);
 
-                bcast_pse_tensor = ggml_cann_create_tensor(src3->data, ACL_FLOAT16, sizeof(uint16_t), bcast_pse_ne,
-                                                           bcast_pse_nb, GGML_MAX_DIMS);
+            float          thresh   = -1.0e4f;
+            acl_scalar_ptr thresh_s = ggml_cann_create_scalar(&thresh, ACL_FLOAT);
+            GGML_CANN_CALL_ACLNN_OP(ctx, LtScalar, acl_mask_f16_trunc_tensor.get(), thresh_s.get(),
+                                    atten_mask_tensor.get());
 
-            } else {
+            // ALiBi / max_bias: finite position bias still belongs in pseShift.
+            if (maxBias != 0.0f) {
+                int64_t bcast_pse_ne[GGML_MAX_DIMS] = {
+                    src3->ne[0],  // KV_S
+                    src0->ne[1],  // Q_S
+                    src0->ne[2],  // N heads
+                    src3->ne[3]   // B
+                };
+                size_t bcast_pse_nb[GGML_MAX_DIMS];
                 bcast_pse_nb[0] = sizeof(uint16_t);
                 for (int i = 1; i < GGML_MAX_DIMS; i++) {
-                    bcast_pse_nb[i] = bcast_pse_nb[i - 1] * bcast_pse_ne[i - 1];
+                    bcast_pse_nb[i] = bcast_pse_nb[i - 1] * (size_t) bcast_pse_ne[i - 1];
                 }
 
-                void * bcast_pse_buffer =
-                    bcast_pse_allocator.alloc(ggml_nelements(src3) * src0->ne[2] * sizeof(uint16_t));
+                void * bcast_pse_buffer = bcast_pse_allocator.alloc(
+                    (size_t) (bcast_pse_ne[0] * bcast_pse_ne[1] * bcast_pse_ne[2] * bcast_pse_ne[3]) *
+                    sizeof(uint16_t));
 
                 bcast_pse_tensor = ggml_cann_create_tensor(bcast_pse_buffer, ACL_FLOAT16, sizeof(uint16_t),
                                                            bcast_pse_ne, bcast_pse_nb, GGML_MAX_DIMS);
@@ -4019,8 +4034,14 @@ void ggml_cann_flash_attn_ext(ggml_backend_cann_context & ctx, ggml_tensor * dst
                 int64_t repeats[] = { 1, src0->ne[2], 1, 1 };
                 aclnn_repeat(ctx, acl_mask_f16_trunc_tensor.get(), bcast_pse_tensor.get(), repeats);
 
-                // alibi
-                // Compute the slope if needed. Derived from ggml_cann_softmax().
+                // Remove -Inf from PSE; hard masking is already in attenMask.
+                float          lo    = -1.0e4f;
+                float          hi    = 1.0e4f;
+                acl_scalar_ptr min_s = ggml_cann_create_scalar(&lo, ACL_FLOAT);
+                acl_scalar_ptr max_s = ggml_cann_create_scalar(&hi, ACL_FLOAT);
+                GGML_CANN_CALL_ACLNN_OP(ctx, Clamp, bcast_pse_tensor.get(), min_s.get(), max_s.get(),
+                                        bcast_pse_tensor.get());
+
                 const int64_t        n_heads = src0->ne[2];
                 ggml_cann_pool_alloc slope_allocator(ctx.pool(), n_heads * sizeof(uint16_t));
                 void *               slope_buffer = slope_allocator.get();
@@ -4030,7 +4051,7 @@ void ggml_cann_flash_attn_ext(ggml_backend_cann_context & ctx, ggml_tensor * dst
                 size_t  slope_nb[GGML_MAX_DIMS];
                 slope_nb[0] = sizeof(uint16_t);
                 for (int i = 1; i < GGML_MAX_DIMS; i++) {
-                    slope_nb[i] = slope_nb[i - 1] * slope_ne[0];
+                    slope_nb[i] = slope_nb[i - 1] * (size_t) slope_ne[0];
                 }
 
                 acl_tensor_ptr slope_tensor = ggml_cann_create_tensor(slope_buffer, ACL_FLOAT16, sizeof(uint16_t),
@@ -4050,12 +4071,16 @@ void ggml_cann_flash_attn_ext(ggml_backend_cann_context & ctx, ggml_tensor * dst
         int64_t nextTokens         = 65535;
         char    layout[5]          = { 'B', 'S', 'N', 'D', 0 };
         int64_t sparseMode         = 0;
+        // Q_S>1 + custom attenMask: high-precision + row-invalid fix (bit1), per Ascend docs.
         int64_t innerPrecise       = (src0->ne[1] == 1) ? 0 : 2;
         int64_t blockSize          = 0;
         int64_t antiquantMode      = 0;
         bool    softmaxLseFlag     = false;
         int64_t keyAntiquantMode   = 0;
         int64_t valueAntiquantMode = 0;
+
+        aclTensor * pse_arg  = bcast_pse_tensor.get();   // set only when maxBias != 0
+        aclTensor * mask_arg = atten_mask_tensor.get();  // BOOL attenMask from additive F16 mask
 
         GGML_ASSERT(dst->type == GGML_TYPE_F32 || dst->type == GGML_TYPE_F16);
         acl_tensor_ptr       fa_dst_tensor;
@@ -4078,7 +4103,7 @@ void ggml_cann_flash_attn_ext(ggml_backend_cann_context & ctx, ggml_tensor * dst
 
         GGML_CANN_CALL_ACLNN_OP(ctx, FusedInferAttentionScoreV2, acl_q_tensor.get(), acl_k_tensor_list.get(),
                                 acl_v_tensor_list.get(),               // q, k, v
-                                bcast_pse_tensor.get(), nullptr,       // pse, mask
+                                pse_arg, mask_arg,                     // pse, mask
                                 nullptr, nullptr,                      // actSeqLen, actSeqLenkv
                                 nullptr, nullptr,                      // deqScale1, quantScale1
                                 nullptr, nullptr, nullptr,             // deqScale2, quantScale2, quantOffset2

--- a/ggml/src/ggml-cann/aclnn_ops.cpp
+++ b/ggml/src/ggml-cann/aclnn_ops.cpp
@@ -3974,9 +3974,9 @@ void ggml_cann_flash_attn_ext(ggml_backend_cann_context & ctx, ggml_tensor * dst
         // Step 3: attention mask / position encoding for FusedInferAttentionScoreV2.
         // Ascend docs:
         //   - attenMaskOptional: BOOL/INT8/UINT8 hard mask (True/1 = do not attend)
-        //   - pseShiftOptional:  FLOAT16/BFLOAT16 position encoding (ALiBi etc.), NOT -Inf masks
-        // llama.cpp src3 is an additive F16 mask (-Inf masked, finite keep/bias). Convert the
-        // hard-mask part to BOOL attenMask; keep finite ALiBi bias in pseShift when needed.
+        //   - pseShiftOptional:  FLOAT16/BFLOAT16 additive position bias (not -Inf masks)
+        // llama.cpp src3 is an additive F16 mask that may mix -Inf (hard mask) with finite
+        // biases (ALiBi / test masks). Split: -Inf -> BOOL attenMask; finite values -> pseShift.
         acl_tensor_ptr       atten_mask_tensor;
         acl_tensor_ptr       bcast_pse_tensor;
         ggml_cann_pool_alloc atten_mask_allocator(ctx.pool());
@@ -4010,38 +4010,37 @@ void ggml_cann_flash_attn_ext(ggml_backend_cann_context & ctx, ggml_tensor * dst
             GGML_CANN_CALL_ACLNN_OP(ctx, LtScalar, acl_mask_f16_trunc_tensor.get(), thresh_s.get(),
                                     atten_mask_tensor.get());
 
-            // ALiBi / max_bias: finite position bias still belongs in pseShift.
+            // Finite additive bias -> pseShift (broadcast over heads). Never pass -Inf in PSE.
+            int64_t bcast_pse_ne[GGML_MAX_DIMS] = {
+                src3->ne[0],  // KV_S
+                src0->ne[1],  // Q_S
+                src0->ne[2],  // N heads
+                src3->ne[3]   // B
+            };
+            size_t bcast_pse_nb[GGML_MAX_DIMS];
+            bcast_pse_nb[0] = sizeof(uint16_t);
+            for (int i = 1; i < GGML_MAX_DIMS; i++) {
+                bcast_pse_nb[i] = bcast_pse_nb[i - 1] * (size_t) bcast_pse_ne[i - 1];
+            }
+
+            void * bcast_pse_buffer = bcast_pse_allocator.alloc(
+                (size_t) (bcast_pse_ne[0] * bcast_pse_ne[1] * bcast_pse_ne[2] * bcast_pse_ne[3]) *
+                sizeof(uint16_t));
+
+            bcast_pse_tensor = ggml_cann_create_tensor(bcast_pse_buffer, ACL_FLOAT16, sizeof(uint16_t),
+                                                       bcast_pse_ne, bcast_pse_nb, GGML_MAX_DIMS);
+
+            int64_t repeats[] = { 1, src0->ne[2], 1, 1 };
+            aclnn_repeat(ctx, acl_mask_f16_trunc_tensor.get(), bcast_pse_tensor.get(), repeats);
+
+            float          lo    = -1.0e4f;
+            float          hi    = 1.0e4f;
+            acl_scalar_ptr min_s = ggml_cann_create_scalar(&lo, ACL_FLOAT);
+            acl_scalar_ptr max_s = ggml_cann_create_scalar(&hi, ACL_FLOAT);
+            GGML_CANN_CALL_ACLNN_OP(ctx, Clamp, bcast_pse_tensor.get(), min_s.get(), max_s.get(),
+                                    bcast_pse_tensor.get());
+
             if (maxBias != 0.0f) {
-                int64_t bcast_pse_ne[GGML_MAX_DIMS] = {
-                    src3->ne[0],  // KV_S
-                    src0->ne[1],  // Q_S
-                    src0->ne[2],  // N heads
-                    src3->ne[3]   // B
-                };
-                size_t bcast_pse_nb[GGML_MAX_DIMS];
-                bcast_pse_nb[0] = sizeof(uint16_t);
-                for (int i = 1; i < GGML_MAX_DIMS; i++) {
-                    bcast_pse_nb[i] = bcast_pse_nb[i - 1] * (size_t) bcast_pse_ne[i - 1];
-                }
-
-                void * bcast_pse_buffer = bcast_pse_allocator.alloc(
-                    (size_t) (bcast_pse_ne[0] * bcast_pse_ne[1] * bcast_pse_ne[2] * bcast_pse_ne[3]) *
-                    sizeof(uint16_t));
-
-                bcast_pse_tensor = ggml_cann_create_tensor(bcast_pse_buffer, ACL_FLOAT16, sizeof(uint16_t),
-                                                           bcast_pse_ne, bcast_pse_nb, GGML_MAX_DIMS);
-
-                int64_t repeats[] = { 1, src0->ne[2], 1, 1 };
-                aclnn_repeat(ctx, acl_mask_f16_trunc_tensor.get(), bcast_pse_tensor.get(), repeats);
-
-                // Remove -Inf from PSE; hard masking is already in attenMask.
-                float          lo    = -1.0e4f;
-                float          hi    = 1.0e4f;
-                acl_scalar_ptr min_s = ggml_cann_create_scalar(&lo, ACL_FLOAT);
-                acl_scalar_ptr max_s = ggml_cann_create_scalar(&hi, ACL_FLOAT);
-                GGML_CANN_CALL_ACLNN_OP(ctx, Clamp, bcast_pse_tensor.get(), min_s.get(), max_s.get(),
-                                        bcast_pse_tensor.get());
-
                 const int64_t        n_heads = src0->ne[2];
                 ggml_cann_pool_alloc slope_allocator(ctx.pool(), n_heads * sizeof(uint16_t));
                 void *               slope_buffer = slope_allocator.get();
@@ -4079,8 +4078,8 @@ void ggml_cann_flash_attn_ext(ggml_backend_cann_context & ctx, ggml_tensor * dst
         int64_t keyAntiquantMode   = 0;
         int64_t valueAntiquantMode = 0;
 
-        aclTensor * pse_arg  = bcast_pse_tensor.get();   // set only when maxBias != 0
-        aclTensor * mask_arg = atten_mask_tensor.get();  // BOOL attenMask from additive F16 mask
+        aclTensor * pse_arg  = bcast_pse_tensor.get();
+        aclTensor * mask_arg = atten_mask_tensor.get();
 
         GGML_ASSERT(dst->type == GGML_TYPE_F32 || dst->type == GGML_TYPE_F16);
         acl_tensor_ptr       fa_dst_tensor;

--- a/tools/omni/CMakeLists.txt
+++ b/tools/omni/CMakeLists.txt
@@ -175,6 +175,13 @@ set_target_properties  (${TARGET_DUPLEX_TEST} PROPERTIES OUTPUT_NAME llama-omni-
 target_link_libraries  (${TARGET_DUPLEX_TEST} PRIVATE llama-common omni Threads::Threads)
 target_compile_features(${TARGET_DUPLEX_TEST} PRIVATE cxx_std_17)
 
+# 双工可行性 profiling（低侵入：仅复用 omni API + audio_output_cb 钩子）
+set(TARGET_DUPLEX_PERF llama-omni-perf-duplex)
+add_executable         (${TARGET_DUPLEX_PERF} perf/perf-duplex.cpp)
+set_target_properties  (${TARGET_DUPLEX_PERF} PROPERTIES OUTPUT_NAME llama-omni-perf-duplex)
+target_link_libraries  (${TARGET_DUPLEX_PERF} PRIVATE llama-common omni Threads::Threads)
+target_compile_features(${TARGET_DUPLEX_PERF} PRIVATE cxx_std_17)
+
 # Token2Wav 测试程序 - 纯 C++ 单线程 baseline（用于 profile 对照，不占 LLM/TTS GPU）
 add_executable(token2wav-example token2wav/token2wav-example.cpp)
 target_link_libraries(token2wav-example PRIVATE llama-common omni Threads::Threads)

--- a/tools/omni/perf/DUPLEX_PROFILING.md
+++ b/tools/omni/perf/DUPLEX_PROFILING.md
@@ -1,0 +1,84 @@
+# Duplex profiling
+
+This directory contains a small profiling tool for checking whether a machine can run MiniCPM-o duplex mode in real time.
+
+The profiler reuses the normal omni duplex API and writes two reports:
+
+- `perf_report.json`: structured timing data
+- `perf_report.md`: human-readable summary and pass/fail result
+
+## What It Measures
+
+The report focuses on these real-time metrics:
+
+| Metric | Meaning | Pass criterion |
+|---|---|---|
+| LLM decision latency | Time from pushing one input frame to receiving the LISTEN/SPEAK decision | P95 below the input frame interval |
+| First audio latency (e2e) | Time from the first SPEAK frame push in a turn to the first generated wav chunk | P95 below the input frame interval |
+| TTS RTF | Wall time from LLM decision done (`t_done`) to the last wav of that turn, divided by generated audio duration | Average TTS RTF below 1.0 |
+| e2e RTF (info only) | Wall time from SPEAK first-frame push to the last wav, divided by audio duration | Not used for pass/fail |
+
+`RTF` means real-time factor:
+
+```text
+TTS RTF = (t_last_wav - t_llm_done) / generated_audio_duration
+e2e RTF = (t_last_wav - t_speak_push) / generated_audio_duration
+```
+
+For example, `TTS RTF = 0.7` means producing 1 second of audio takes about 0.7 seconds of TTS/pipeline wall time after the LLM decision, which is faster than real-time playback.
+
+SPEAK turns and audio turns are matched by timestamps (latest unused SPEAK whose `t_push <=` first wav time), not by array index. A SPEAK turn with no audio does not shift later matches.
+
+The report also includes a wav chunk duration section. This is informational only: input frames and output wav chunks are not expected to map one-to-one.
+
+## Usage
+
+Build and run the default duplex profiling case:
+
+```bash
+tools/omni/perf/run_perf.sh --build \
+  -m ./models/MiniCPM-o-4_5-gguf/MiniCPM-o-4_5-Q4_K_M.gguf
+```
+
+Run with a custom test set:
+
+```bash
+tools/omni/perf/run_perf.sh \
+  -m <llm.gguf> \
+  --test <input-prefix> <frame-count>
+```
+
+Analyze an existing JSON report:
+
+```bash
+python3 tools/omni/perf/analyze_perf.py tools/omni/output/perf_report.json \
+  --interval-ms 1000 \
+  --md tools/omni/output/perf_report.md
+```
+
+## Options
+
+- `--stream-interval <ms>` controls how often input frames are pushed. The default is `1000`, which simulates one frame per second.
+- `--interval-ms <ms>` controls the real-time threshold used by `analyze_perf.py`. If omitted, the analyzer reads it from the JSON metadata.
+- `--no-tts` skips audio generation. The report can still show LLM latency, but the final duplex verdict is `incomplete` (exit code 3), not pass.
+- `--vision-backend <metal|coreml>` selects the vision backend when supported.
+
+## Interpreting Results
+
+The machine is considered suitable for duplex mode only when TTS was actually exercised and all required checks pass:
+
+```text
+[PASS] LLM decision latency
+[PASS] First audio latency (e2e)
+[PASS] TTS RTF
+```
+
+If LLM decision latency fails, frame processing is slower than the input rate. If first audio latency fails, users may notice delayed responses. If TTS RTF fails, audio generation is slower than playback and may underrun.
+
+Exit codes:
+
+| Code | Meaning |
+|---|---|
+| 0 | Pass: machine looks suitable for duplex |
+| 2 | Fail: at least one real-time check failed |
+| 3 | Incomplete: `--no-tts`, no SPEAK/audio coverage, or missing audio timeline; do not treat as duplex-ready |

--- a/tools/omni/perf/analyze_perf.py
+++ b/tools/omni/perf/analyze_perf.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+双工可行性报告生成器
+
+读取 perf-duplex 产出的 JSON（frames + audio_chunks 时间线），计算关键指标，
+给出「该机器能否支撑双工」的判定。
+
+指标含义（详见 DUPLEX_PROFILING.md）：
+  - LLM 判定实时性 : 每帧 push->判定(ms_total) 的 P50/P95/max。
+                     P95 必须 < 进帧间隔(stream_interval_ms)。
+  - 首响 e2e       : SPEAK 轮首帧 push -> 匹配到的首个 wav 落盘。
+  - TTS RTF        : LLM 判定完成(t_done) -> 该轮末 wav / 音频时长；硬门槛 < 1.0。
+  - e2e RTF        : 首帧 push -> 末 wav / 音频时长；仅展示，含 LLM 等待。
+
+SPEAK 轮与音频轮按时间戳匹配（不用数组下标一一对应），避免中间无音频的
+SPEAK 轮导致错位。
+
+退出码:
+  0 = 通过（可支撑双工）
+  2 = 未通过实时性判据
+  3 = 数据不完整（--no-tts / 无音频等），不能判定双工可行性
+
+用法:
+  python3 analyze_perf.py <perf_report.json> [--interval-ms 1000] [--md out.md]
+"""
+
+import argparse
+import json
+import sys
+
+
+def percentile(values, p):
+    if not values:
+        return 0.0
+    s = sorted(values)
+    if len(s) == 1:
+        return s[0]
+    k = (len(s) - 1) * (p / 100.0)
+    lo = int(k)
+    hi = min(lo + 1, len(s) - 1)
+    frac = k - lo
+    return s[lo] * (1 - frac) + s[hi] * frac
+
+
+def segment_speak_turns(frames):
+    """把连续的 is_speak 帧聚合成 SPEAK 轮次。返回 [(start_idx, end_idx)]。"""
+    turns = []
+    cur = None
+    for i, fr in enumerate(frames):
+        if fr.get("is_speak"):
+            if cur is None:
+                cur = [i, i]
+            else:
+                cur[1] = i
+        else:
+            if cur is not None:
+                turns.append(tuple(cur))
+                cur = None
+    if cur is not None:
+        turns.append(tuple(cur))
+    return turns
+
+
+def segment_audio_turns(audio):
+    """优先按 audio_turn_id 分组；否则按 is_final 切分。返回 [chunk子列表]。"""
+    if audio and all("audio_turn_id" in a for a in audio):
+        groups = {}
+        order = []
+        for a in audio:
+            tid = a["audio_turn_id"]
+            if tid not in groups:
+                groups[tid] = []
+                order.append(tid)
+            groups[tid].append(a)
+        return [groups[tid] for tid in order]
+
+    turns = []
+    cur = []
+    for a in audio:
+        cur.append(a)
+        if a.get("is_final"):
+            turns.append(cur)
+            cur = []
+    if cur:
+        turns.append(cur)
+    return turns
+
+
+def match_speak_audio_turns(frames, speak_turns, audio_turns):
+    """
+    按时间戳匹配 SPEAK 轮与音频轮，避免靠数组下标错位。
+
+    对每个音频轮（按时间顺序）：取「尚未匹配、且 t_push <= 首 wav 落盘」的
+    最晚一个 SPEAK 轮。被跳过的 SPEAK 轮记为无音频输出。
+    """
+    pairs = []
+    unmatched_speak = []
+    unmatched_audio = []
+    next_s = 0
+
+    for a_idx, a_turn in enumerate(audio_turns):
+        if not a_turn:
+            unmatched_audio.append(a_idx)
+            continue
+        t0 = a_turn[0]["t_complete_ms"]
+        candidate = None
+        while next_s < len(speak_turns):
+            s0, _s1 = speak_turns[next_s]
+            t_push = frames[s0]["t_push_ms"]
+            if t_push <= t0:
+                if candidate is not None:
+                    unmatched_speak.append(candidate)
+                candidate = next_s
+                next_s += 1
+            else:
+                break
+        if candidate is None:
+            unmatched_audio.append(a_idx)
+        else:
+            pairs.append((candidate, a_idx))
+
+    while next_s < len(speak_turns):
+        unmatched_speak.append(next_s)
+        next_s += 1
+
+    return pairs, unmatched_speak, unmatched_audio
+
+
+def speak_turn_label(frames, speak_turns, s_idx):
+    s0, _s1 = speak_turns[s_idx]
+    tid = frames[s0].get("speak_turn_id")
+    if tid is not None and tid >= 0:
+        return f"speak#{tid}"
+    return f"speak@{s_idx}"
+
+
+def analyze(report, interval_ms):
+    meta = report.get("meta", {})
+    frames = report.get("frames", [])
+    audio = report.get("audio_chunks", [])
+
+    interval = interval_ms if interval_ms is not None else meta.get("stream_interval_ms", 1000)
+    if interval <= 0:
+        interval = 1000
+
+    use_tts = bool(meta.get("use_tts", True))
+
+    lines = []
+
+    def out(s=""):
+        lines.append(s)
+
+    out("=" * 64)
+    out("MiniCPM-o 双工可行性报告")
+    out("=" * 64)
+    out(f"LLM           : {meta.get('llm_path', '?')}")
+    out(f"Vision backend: {meta.get('vision_backend', '?')}   "
+        f"use_tts: {meta.get('use_tts')}   media_type: {meta.get('media_type')}")
+    out(f"n_threads     : {meta.get('n_threads', '?')}   "
+        f"采样率: {meta.get('sample_rate_hint', '?')}Hz")
+    out(f"进帧间隔(基准): {interval} ms")
+    out("")
+
+    n_speak = sum(1 for f in frames if f.get("is_speak"))
+    n_listen = sum(1 for f in frames if not f.get("is_speak"))
+    out(f"帧数: {len(frames)}  (SPEAK {n_speak} / LISTEN {n_listen})")
+    out("")
+
+    # ---- 1. LLM 判定实时性 ----
+    ms_total = [f["ms_total"] for f in frames if f.get("ok")]
+    ms_decode = [f["ms_decode"] for f in frames if f.get("ok")]
+    p50 = percentile(ms_total, 50)
+    p95 = percentile(ms_total, 95)
+    mx = max(ms_total) if ms_total else 0.0
+    out("[1] LLM 判定延迟 (push -> LISTEN/SPEAK, ms_total)")
+    if ms_decode:
+        out(f"    P50 {p50:.1f}ms | P95 {p95:.1f}ms | max {mx:.1f}ms | "
+            f"avg decode {sum(ms_decode)/len(ms_decode):.1f}ms")
+    else:
+        out("    无数据")
+    jud_llm = bool(ms_total) and p95 < interval
+    out(f"    判据: P95({p95:.1f}ms) < 进帧间隔({interval}ms)  => "
+        f"{'PASS' if jud_llm else 'FAIL'}")
+    out("")
+
+    speak_turns = segment_speak_turns(frames)
+    audio_turns = segment_audio_turns(audio)
+    pairs, unmatched_speak, unmatched_audio = match_speak_audio_turns(
+        frames, speak_turns, audio_turns)
+
+    out("[匹配] SPEAK 轮 <-> 音频轮 (按时间戳，非下标对齐)")
+    out(f"    SPEAK 轮: {len(speak_turns)} | 音频轮: {len(audio_turns)} | "
+        f"匹配成功: {len(pairs)}")
+    if unmatched_speak:
+        labels = [speak_turn_label(frames, speak_turns, i) for i in unmatched_speak]
+        out(f"    无音频的 SPEAK 轮: {labels}")
+    if unmatched_audio:
+        out(f"    未匹配到 SPEAK 的音频轮 index: {unmatched_audio}")
+    out("")
+
+    # TTS 侧是否具备判定条件
+    if not use_tts:
+        tts_status = "skipped"   # --no-tts
+        tts_reason = "use_tts=false (--no-tts)，跳过音频侧判定"
+    elif n_speak == 0:
+        tts_status = "skipped"   # 全程 LISTEN，没有可测的 speak/audio
+        tts_reason = "全程 LISTEN，无 SPEAK 轮，跳过音频侧判定"
+    elif not audio or not pairs:
+        tts_status = "incomplete"
+        tts_reason = "有 SPEAK 但无可用音频时间线，无法判定首响/RTF"
+    else:
+        tts_status = "ok"
+        tts_reason = ""
+
+    # ---- 2. 首响延迟 ----
+    out("[2] 首响延迟")
+    out("    e2e  = SPEAK 首帧 push -> 该轮首 wav（硬判据）")
+    out("    tts  = SPEAK 首帧 t_done(LLM完成) -> 首 wav（仅展示）")
+    first_resp_e2e = []
+    first_resp_tts = []
+    if tts_status != "ok":
+        out(f"    {tts_reason}")
+        jud_resp = None
+    else:
+        for s_idx, a_idx in pairs:
+            s0, _s1 = speak_turns[s_idx]
+            a_turn = audio_turns[a_idx]
+            t_push = frames[s0]["t_push_ms"]
+            t_done = frames[s0]["t_done_ms"]
+            t_first = a_turn[0]["t_complete_ms"]
+            d_e2e = t_first - t_push
+            d_tts = t_first - t_done
+            first_resp_e2e.append(d_e2e)
+            first_resp_tts.append(d_tts)
+            label = speak_turn_label(frames, speak_turns, s_idx)
+            out(f"    {label}/audio#{a_idx}: e2e {d_e2e:.0f}ms | tts {d_tts:.0f}ms "
+                f"(push@{t_push:.0f} done@{t_done:.0f} wav@{t_first:.0f})")
+        out(f"    e2e P50 {percentile(first_resp_e2e,50):.0f}ms | "
+            f"P95 {percentile(first_resp_e2e,95):.0f}ms")
+        out(f"    tts P50 {percentile(first_resp_tts,50):.0f}ms | "
+            f"P95 {percentile(first_resp_tts,95):.0f}ms")
+        jud_resp = percentile(first_resp_e2e, 95) < interval
+        out(f"    判据: 首响 e2e P95 < 进帧间隔({interval}ms) => "
+            f"{'PASS' if jud_resp else 'FAIL'}")
+    out("")
+
+    # ---- 3. 音频 RTF ----
+    out("[3] 音频 RTF")
+    out("    TTS RTF = (末 wav - LLM t_done) / 音频时长  （硬判据，需 < 1.0）")
+    out("    e2e RTF = (末 wav - 首帧 push) / 音频时长  （仅展示，含 LLM 等待）")
+    total_audio_s = sum(a["duration_s"] for a in audio)
+    tts_rtf_turns = []
+    e2e_rtf_turns = []
+    if tts_status != "ok":
+        out(f"    {tts_reason}")
+        jud_rtf = None
+    else:
+        for s_idx, a_idx in pairs:
+            s0, _s1 = speak_turns[s_idx]
+            a_turn = audio_turns[a_idx]
+            audio_s = sum(c["duration_s"] for c in a_turn)
+            if audio_s <= 0:
+                continue
+            t_push = frames[s0]["t_push_ms"]
+            t_done = frames[s0]["t_done_ms"]
+            t_first = a_turn[0]["t_complete_ms"]
+            t_last = a_turn[-1]["t_complete_ms"]
+            # 若音频回调早于 wait_next_frame 返回，用首 wav 时刻避免负 wall
+            tts_wall_start = min(t_done, t_first)
+            tts_wall_s = max(1e-6, (t_last - tts_wall_start) / 1000.0)
+            e2e_wall_s = max(1e-6, (t_last - t_push) / 1000.0)
+            tts_rtf = tts_wall_s / audio_s
+            e2e_rtf = e2e_wall_s / audio_s
+            tts_rtf_turns.append(tts_rtf)
+            e2e_rtf_turns.append(e2e_rtf)
+            label = speak_turn_label(frames, speak_turns, s_idx)
+            out(f"    {label}/audio#{a_idx}: 音频 {audio_s:.2f}s | "
+                f"TTS wall {tts_wall_s:.2f}s RTF {tts_rtf:.2f} | "
+                f"e2e wall {e2e_wall_s:.2f}s RTF {e2e_rtf:.2f}")
+        if tts_rtf_turns:
+            avg_tts = sum(tts_rtf_turns) / len(tts_rtf_turns)
+            avg_e2e = sum(e2e_rtf_turns) / len(e2e_rtf_turns)
+            out(f"    平均 TTS RTF: {avg_tts:.2f} | 平均 e2e RTF: {avg_e2e:.2f}")
+            jud_rtf = avg_tts < 1.0
+            out(f"    判据: 平均 TTS RTF < 1.0 => {'PASS' if jud_rtf else 'FAIL'}")
+        else:
+            out("    匹配轮次音频时长均为 0，无法计算 RTF")
+            jud_rtf = None
+            tts_status = "incomplete"
+            tts_reason = "匹配轮次无有效音频时长"
+    out("")
+
+    # ---- 4. 单 wav 时长分布 ----
+    out("[4] 单个 wav chunk 时长分布 (验证「一帧!=1s音频」)")
+    durs = [a["duration_s"] for a in audio]
+    if durs:
+        out(f"    chunk 数: {len(durs)} | 总音频 {total_audio_s:.2f}s")
+        out(f"    时长 min {min(durs):.2f}s | P50 {percentile(durs,50):.2f}s | "
+            f"max {max(durs):.2f}s")
+        finals = [a["duration_s"] for a in audio if a.get("is_final")]
+        if finals:
+            out(f"    轮末 (is_final) 时长: {[f'{x:.2f}s' for x in finals]}")
+        out("    说明: 满窗 chunk ≈1.0s，轮末 remainder 在 (0,1.0]s；"
+            "单帧产出的音频量取决于该帧说了多少字。")
+    else:
+        out("    无音频输出。")
+    out("")
+
+    # ---- 总判定 ----
+    out("=" * 64)
+    checks = [
+        ("LLM 判定实时性 (P95<间隔)", jud_llm if ms_total else None),
+        ("首响 e2e (<间隔)", jud_resp),
+        ("TTS RTF (<1.0)", jud_rtf),
+    ]
+    for name, v in checks:
+        if v is None:
+            tag = "SKIP"
+        elif v:
+            tag = "PASS"
+        else:
+            tag = "FAIL"
+        out(f"  [{tag:>4}] {name}")
+
+    hard = [v for _n, v in checks if v is not None]
+    any_fail = any(v is False for _n, v in checks)
+
+    if tts_status == "incomplete" or (tts_status == "skipped" and use_tts is False):
+        # --no-tts 或音频数据缺失：不能宣称可支撑双工
+        if any_fail:
+            verdict = "fail"
+            summary = "未通过实时性判据（且音频侧数据不完整）"
+        else:
+            verdict = "incomplete"
+            summary = f"数据不完整，不能判定双工可行性 ({tts_reason or tts_status})"
+    elif tts_status == "skipped" and n_speak == 0:
+        # 全程 LISTEN：只看 LLM；通过也不等于「双工音频 OK」，标 incomplete
+        if any_fail:
+            verdict = "fail"
+            summary = "未通过实时性判据"
+        else:
+            verdict = "incomplete"
+            summary = "全程 LISTEN，未覆盖 SPEAK/TTS，不能判定双工可行性"
+    elif not hard:
+        verdict = "incomplete"
+        summary = "无有效判据数据"
+    elif all(hard):
+        verdict = "pass"
+        summary = "该机器可支撑双工"
+    else:
+        verdict = "fail"
+        summary = "该机器暂不满足双工实时性"
+
+    out("-" * 64)
+    out(f"  最终判定: {summary}")
+    out("=" * 64)
+
+    return "\n".join(lines), verdict
+
+
+def main():
+    ap = argparse.ArgumentParser(description="双工可行性报告生成器")
+    ap.add_argument("json_path", help="perf-duplex 产出的 JSON 路径")
+    ap.add_argument("--interval-ms", type=int, default=None,
+                    help="进帧间隔基准 (默认读 JSON meta.stream_interval_ms)")
+    ap.add_argument("--md", default=None, help="额外把报告写到该 markdown 文件")
+    args = ap.parse_args()
+
+    with open(args.json_path, "r", encoding="utf-8") as f:
+        report = json.load(f)
+
+    text, verdict = analyze(report, args.interval_ms)
+    print(text)
+
+    if args.md:
+        with open(args.md, "w", encoding="utf-8") as f:
+            f.write("```\n" + text + "\n```\n")
+        print(f"\n[已写入 markdown: {args.md}]")
+
+    if verdict == "pass":
+        sys.exit(0)
+    if verdict == "incomplete":
+        sys.exit(3)
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/omni/perf/perf-duplex.cpp
+++ b/tools/omni/perf/perf-duplex.cpp
@@ -1,0 +1,545 @@
+/**
+ * 双工 (Duplex) 性能 / 可行性 Profiling
+ *
+ * 目标：在不侵入 omni.cpp 推理流程的前提下，复刻 test-duplex.cpp 的
+ *       push_frame / wait_next_frame 流程，额外通过 *已存在* 的
+ *       ctx_omni->audio_output_cb 钩子采集「每个 wav chunk 落盘时刻 + 时长」，
+ *       最终把每帧 LLM 判定延迟 + 音频生成时间线写成 JSON，交给
+ *       analyze_perf.py 产出「该机器能否支撑双工」的报告。
+ *
+ * 与 test-duplex.cpp 的唯一区别：
+ *   1. 注册 audio_output_cb 采集音频时间线（零修改 omni.cpp）。
+ *   2. 用统一的 session 时钟给所有事件打相对时间戳。
+ *   3. 把 frame 结果 + audio chunk 时间线序列化成 JSON。
+ *
+ * 判据参考（详见 DUPLEX_PROFILING.md）：
+ *   - 每帧 push->判定 (ms_total) 的 P95 < 进帧间隔（默认 1000ms），否则跟不上实时进帧。
+ *   - 首响 e2e：SPEAK 轮首帧 push -> 该轮首个 wav；P95 < 进帧间隔。
+ *   - TTS RTF：LLM 判定完成 (t_done) -> 该轮末 wav / 音频时长；平均 < 1.0。
+ *   - e2e RTF（仅展示）：首帧 push -> 末 wav / 音频时长，含 LLM 等待。
+ */
+
+#include "omni-impl.h"
+#include "omni.h"
+
+#include "arg.h"
+#include "llama.h"
+#include "ggml.h"
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+#include <signal.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#elif defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#include <signal.h>
+#endif
+
+static volatile bool g_is_interrupted = false;
+
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__)) || defined(_WIN32)
+static void sigint_handler(int signo) {
+    if (signo == SIGINT) {
+        if (g_is_interrupted) _exit(1);
+        g_is_interrupted = true;
+    }
+}
+#endif
+
+// ==================== session 时钟 ====================
+// 所有事件（push / frame done / audio chunk）都用相对于 g_t0 的毫秒数，
+// 方便 Python 端在同一条时间线上对齐。
+
+static std::chrono::high_resolution_clock::time_point g_t0;
+
+static double now_ms() {
+    return std::chrono::duration<double, std::milli>(
+        std::chrono::high_resolution_clock::now() - g_t0).count();
+}
+
+// ==================== 采集到的数据 ====================
+
+struct AudioChunkRecord {
+    double t_complete_ms = 0;  // 相对 session 时钟：该 wav chunk 落盘/回调时刻
+    int    n_samples     = 0;
+    int    sample_rate   = 0;
+    double duration_s    = 0;  // n_samples / sample_rate
+    bool   is_final      = false;
+    int    audio_turn_id = -1; // 按 is_final 切分的音频轮次 id（0,1,2,...）
+};
+
+struct FrameRecord {
+    int64_t user_seq      = 0;
+    int64_t frame_id      = -1;
+    double  t_push_ms     = 0;  // 相对 session 时钟：push_frame 时刻
+    double  t_done_ms     = 0;  // 相对 session 时钟：result 出队时刻
+    bool    ok            = false;
+    bool    is_speak      = false;
+    int     speak_turn_id = -1; // 连续 SPEAK 帧共享同一 id；LISTEN 为 -1
+    double  ms_decode     = 0;
+    double  ms_total      = 0;
+    int     n_past_after  = 0;
+    int     text_len      = 0;
+    std::string text;           // 仅取前 80 字节，JSON 转义
+};
+
+struct PerfCollector {
+    std::mutex                    mtx;
+    std::vector<AudioChunkRecord> audio;          // audio_output_cb 采集
+    std::unordered_map<int64_t, double> push_ms;  // frame_id -> push 时刻
+    std::vector<FrameRecord>      frames;
+    int  next_speak_turn_id = 0;
+    bool in_speak_turn      = false;
+    int  cur_speak_turn_id  = -1;
+    int  cur_audio_turn_id  = 0;
+};
+
+static PerfCollector g_perf;
+
+// ==================== 模型路径解析（复用 test-duplex 逻辑） ====================
+
+struct TestModelPaths {
+    std::string llm, vision, audio, tts, projector, vision_coreml, base_dir;
+};
+
+static std::string get_parent_dir(const std::string & path) {
+    size_t last_slash = path.find_last_of("/\\");
+    return (last_slash != std::string::npos) ? path.substr(0, last_slash) : ".";
+}
+
+static bool file_exists(const std::string & path) {
+    FILE * f = fopen(path.c_str(), "rb");
+    if (f) { fclose(f); return true; }
+    return false;
+}
+
+static TestModelPaths resolve_model_paths(const std::string & llm_path) {
+    TestModelPaths p;
+    p.llm = llm_path;
+    p.base_dir = get_parent_dir(llm_path);
+    p.vision        = p.base_dir + "/vision/MiniCPM-o-4_5-vision-F16.gguf";
+    p.audio         = p.base_dir + "/audio/MiniCPM-o-4_5-audio-F16.gguf";
+    p.tts           = p.base_dir + "/tts/MiniCPM-o-4_5-tts-F16.gguf";
+    p.projector     = p.base_dir + "/tts/MiniCPM-o-4_5-projector-F16.gguf";
+    p.vision_coreml = p.base_dir + "/vision/coreml_minicpmo45_vit_all_f16.mlmodelc";
+    return p;
+}
+
+// ==================== JSON 序列化（手写，无外部依赖） ====================
+
+static std::string json_escape(const std::string & s) {
+    std::string out;
+    out.reserve(s.size() + 8);
+    for (unsigned char c : s) {
+        switch (c) {
+            case '"':  out += "\\\""; break;
+            case '\\': out += "\\\\"; break;
+            case '\n': out += "\\n";  break;
+            case '\r': out += "\\r";  break;
+            case '\t': out += "\\t";  break;
+            default:
+                if (c < 0x20) {
+                    char buf[8];
+                    snprintf(buf, sizeof(buf), "\\u%04x", c);
+                    out += buf;
+                } else {
+                    out += (char)c;
+                }
+        }
+    }
+    return out;
+}
+
+static bool write_json_report(const std::string & path,
+                              int    interval_ms,
+                              int    n_threads,
+                              int    sample_rate_hint,
+                              const std::string & llm_path,
+                              const std::string & vision_backend,
+                              bool   use_tts,
+                              int    media_type) {
+    FILE * f = fopen(path.c_str(), "wb");
+    if (!f) {
+        fprintf(stderr, "[perf] 无法写 JSON: %s\n", path.c_str());
+        return false;
+    }
+
+    std::lock_guard<std::mutex> lk(g_perf.mtx);
+
+    fprintf(f, "{\n");
+    fprintf(f, "  \"meta\": {\n");
+    fprintf(f, "    \"stream_interval_ms\": %d,\n", interval_ms);
+    fprintf(f, "    \"n_threads\": %d,\n", n_threads);
+    fprintf(f, "    \"sample_rate_hint\": %d,\n", sample_rate_hint);
+    fprintf(f, "    \"llm_path\": \"%s\",\n", json_escape(llm_path).c_str());
+    fprintf(f, "    \"vision_backend\": \"%s\",\n", json_escape(vision_backend).c_str());
+    fprintf(f, "    \"use_tts\": %s,\n", use_tts ? "true" : "false");
+    fprintf(f, "    \"media_type\": %d\n", media_type);
+    fprintf(f, "  },\n");
+
+    // frames
+    fprintf(f, "  \"frames\": [\n");
+    for (size_t i = 0; i < g_perf.frames.size(); ++i) {
+        const auto & fr = g_perf.frames[i];
+        fprintf(f,
+            "    {\"user_seq\": %lld, \"frame_id\": %lld, \"t_push_ms\": %.3f, "
+            "\"t_done_ms\": %.3f, \"ok\": %s, \"is_speak\": %s, \"speak_turn_id\": %d, "
+            "\"ms_decode\": %.3f, \"ms_total\": %.3f, \"n_past_after\": %d, "
+            "\"text_len\": %d, \"text\": \"%s\"}%s\n",
+            (long long)fr.user_seq, (long long)fr.frame_id, fr.t_push_ms,
+            fr.t_done_ms, fr.ok ? "true" : "false", fr.is_speak ? "true" : "false",
+            fr.speak_turn_id, fr.ms_decode, fr.ms_total, fr.n_past_after, fr.text_len,
+            json_escape(fr.text).c_str(),
+            (i + 1 < g_perf.frames.size()) ? "," : "");
+    }
+    fprintf(f, "  ],\n");
+
+    // audio chunks
+    fprintf(f, "  \"audio_chunks\": [\n");
+    for (size_t i = 0; i < g_perf.audio.size(); ++i) {
+        const auto & a = g_perf.audio[i];
+        fprintf(f,
+            "    {\"t_complete_ms\": %.3f, \"n_samples\": %d, \"sample_rate\": %d, "
+            "\"duration_s\": %.4f, \"is_final\": %s, \"audio_turn_id\": %d}%s\n",
+            a.t_complete_ms, a.n_samples, a.sample_rate, a.duration_s,
+            a.is_final ? "true" : "false", a.audio_turn_id,
+            (i + 1 < g_perf.audio.size()) ? "," : "");
+    }
+    fprintf(f, "  ]\n");
+    fprintf(f, "}\n");
+
+    fclose(f);
+    return true;
+}
+
+// ==================== 双工 profiling 核心 ====================
+
+static void duplex_perf_run(struct omni_context * ctx_omni,
+                            const std::string & data_path_prefix,
+                            int cnt,
+                            int stream_interval_ms) {
+    printf("\n=== Duplex perf: %d chunks, interval=%dms ===\n", cnt, stream_interval_ms);
+
+    std::vector<OmniDuplexFrame> frames(cnt);
+    for (int il = 0; il < cnt; ++il) {
+        char idx[16]; snprintf(idx, sizeof(idx), "%04d", il);
+        frames[il].aud_fname = data_path_prefix + idx + ".wav";
+        std::string img = data_path_prefix + idx + ".jpg";
+        if (file_exists(img)) frames[il].img_fname = img;
+        frames[il].user_seq = il + 1;
+        if (!file_exists(frames[il].aud_fname)) {
+            fprintf(stderr, "[错误] 音频不存在: %s\n", frames[il].aud_fname.c_str());
+            return;
+        }
+    }
+
+    if (!omni_duplex_session_begin(ctx_omni, /*voice_audio=*/"", /*debug_dir=*/"./")) {
+        fprintf(stderr, "[错误] omni_duplex_session_begin failed\n");
+        return;
+    }
+
+    // session 时钟从这里起算
+    g_t0 = std::chrono::high_resolution_clock::now();
+
+    std::thread producer([&]() {
+        auto t_start = std::chrono::high_resolution_clock::now();
+        for (int il = 0; il < cnt && !g_is_interrupted; ++il) {
+            if (stream_interval_ms > 0) {
+                std::this_thread::sleep_until(
+                    t_start + std::chrono::milliseconds((int64_t)il * stream_interval_ms));
+            }
+            double t_push = now_ms();
+            int64_t fid = omni_duplex_push_frame(ctx_omni, frames[il]);
+            if (fid < 0) {
+                fprintf(stderr, "[push] frame %d 提交失败\n", il + 1);
+                break;
+            }
+            std::lock_guard<std::mutex> lk(g_perf.mtx);
+            g_perf.push_ms[fid] = t_push;
+        }
+    });
+
+    int speak = 0, listen = 0, completed = 0;
+    double sum_decode = 0, sum_e2e = 0;
+
+    for (int il = 0; il < cnt && !g_is_interrupted; ++il) {
+        OmniDuplexFrameResult r;
+        if (!omni_duplex_wait_next_frame(ctx_omni, &r, /*timeout_ms=*/30000) || !r.ok) {
+            fprintf(stderr, "[错误] frame %d 处理失败/超时\n", il + 1);
+            break;
+        }
+        (r.is_speak ? speak : listen)++;
+        sum_decode += r.ms_decode;
+        sum_e2e    += r.ms_total;
+        completed++;
+
+        FrameRecord fr;
+        fr.user_seq     = r.user_seq;
+        fr.frame_id     = r.frame_id;
+        fr.t_done_ms    = now_ms();
+        fr.ok           = r.ok;
+        fr.is_speak     = r.is_speak;
+        fr.ms_decode    = r.ms_decode;
+        fr.ms_total     = r.ms_total;
+        fr.n_past_after = r.n_past_after;
+        fr.text_len     = (int)r.text.size();
+        fr.text         = r.text.size() > 80 ? r.text.substr(0, 80) : r.text;
+        {
+            std::lock_guard<std::mutex> lk(g_perf.mtx);
+            auto it = g_perf.push_ms.find(r.frame_id);
+            fr.t_push_ms = (it != g_perf.push_ms.end()) ? it->second : 0.0;
+            if (r.is_speak) {
+                if (!g_perf.in_speak_turn) {
+                    g_perf.cur_speak_turn_id = g_perf.next_speak_turn_id++;
+                    g_perf.in_speak_turn = true;
+                }
+                fr.speak_turn_id = g_perf.cur_speak_turn_id;
+            } else {
+                g_perf.in_speak_turn = false;
+                g_perf.cur_speak_turn_id = -1;
+                fr.speak_turn_id = -1;
+            }
+            g_perf.frames.push_back(std::move(fr));
+        }
+
+        printf("--- Chunk %lld/%d --- decode %.1fms | e2e %.1fms | n_past %d | %s\n",
+               (long long)r.user_seq, cnt, r.ms_decode, r.ms_total, r.n_past_after,
+               r.is_speak ? "<|speak|>" : "<|listen|>");
+    }
+
+    if (producer.joinable()) producer.join();
+    omni_duplex_session_end(ctx_omni);
+
+    printf("\n=== Summary: %d/%d chunks | avg decode %.1fms | avg e2e %.1fms | speak %d listen %d ===\n",
+           completed, cnt,
+           completed ? sum_decode / completed : 0,
+           completed ? sum_e2e    / completed : 0,
+           speak, listen);
+}
+
+// ==================== 帮助信息 ====================
+
+static void show_usage(const char * prog_name) {
+    printf(
+        "MiniCPM-o Duplex Perf / Feasibility Profiler\n\n"
+        "Usage: %s -m <llm_model_path> [options]\n\n"
+        "Required:\n"
+        "  -m <path>           LLM 模型路径\n\n"
+        "Options:\n"
+        "  --vision <path>     覆盖 vision 模型路径\n"
+        "  --audio <path>      覆盖 audio 模型路径\n"
+        "  --tts <path>        覆盖 TTS 模型路径\n"
+        "  --projector <path>  覆盖 projector 模型路径\n"
+        "  --ref-audio <path>  参考音频路径\n"
+        "  -c, --ctx-size <n>  上下文大小 (默认: 4096)\n"
+        "  -ngl <n>            GPU 层数 (默认: 99)\n"
+        "  --no-tts            禁用 TTS\n"
+        "  --omni              启用 omni 模式 (audio+vision)；默认已开\n"
+        "  --vision-backend <m>  'metal'(默认) 或 'coreml'(ANE)\n"
+        "  --vision-coreml <p>   CoreML/ANE 模型路径 (.mlmodelc)\n"
+        "  --test <prefix> <n> 指定测试数据前缀和 chunk 数量\n"
+        "                      (默认: duplex_omni_test_case 共 36 帧)\n"
+        "  --stream-interval <ms>  push frame 的最小间隔 (默认 1000=模拟真实流式)\n"
+        "  -o <dir>            输出目录 (默认: ./tools/omni/output)\n"
+        "  --out-json <path>   性能报告 JSON 路径 (默认: <out>/perf_report.json)\n"
+        "  -h, --help          显示帮助\n\n"
+        "Example (全部用默认硬编码样本/参考音频):\n"
+        "  %s -m ./models/MiniCPM-o-4_5-gguf/MiniCPM-o-4_5-Q4_K_M.gguf\n",
+        prog_name, prog_name
+    );
+}
+
+// ==================== Main ====================
+
+int main(int argc, char ** argv) {
+    ggml_time_init();
+
+    std::string llm_path;
+    std::string vision_path_override, audio_path_override, tts_path_override, projector_path_override;
+    std::string ref_audio_path = "tools/omni/assets/default_ref_audio/default_ref_audio.wav";
+    std::string output_dir = "./tools/omni/output";
+    std::string out_json;
+    std::string vision_backend = "metal";
+    std::string vision_coreml_model_path;
+    int n_ctx = 4096;
+    int n_gpu_layers = 99;
+    int media_type = 2;     // 1=audio only, 2=omni；默认 omni（硬编码样本含图像）
+    bool use_tts = true;
+    bool run_test = false;
+    int  stream_interval_ms = 1000;  // 默认模拟真实 1s 流式输入
+    std::string test_prefix;
+    int test_count = 0;
+    std::string token2wav_device = "gpu";
+    if (const char * v = std::getenv("OMNI_T2W_DEVICE")) {
+        if (*v) token2wav_device = v;
+    }
+
+    for (int i = 1; i < argc; i++) {
+        std::string arg = argv[i];
+        if (arg == "-h" || arg == "--help") { show_usage(argv[0]); return 0; }
+        else if (arg == "-m" && i + 1 < argc) { llm_path = argv[++i]; }
+        else if (arg == "--vision" && i + 1 < argc) { vision_path_override = argv[++i]; }
+        else if (arg == "--audio" && i + 1 < argc) { audio_path_override = argv[++i]; }
+        else if (arg == "--tts" && i + 1 < argc) { tts_path_override = argv[++i]; }
+        else if (arg == "--projector" && i + 1 < argc) { projector_path_override = argv[++i]; }
+        else if (arg == "--ref-audio" && i + 1 < argc) { ref_audio_path = argv[++i]; }
+        else if ((arg == "-c" || arg == "--ctx-size") && i + 1 < argc) { n_ctx = std::atoi(argv[++i]); }
+        else if (arg == "-ngl" && i + 1 < argc) { n_gpu_layers = std::atoi(argv[++i]); }
+        else if (arg == "--no-tts") { use_tts = false; }
+        else if (arg == "--omni") { media_type = 2; }
+        else if (arg == "--vision-backend" && i + 1 < argc) {
+            vision_backend = argv[++i];
+            if (vision_backend != "metal" && vision_backend != "coreml") {
+                fprintf(stderr, "Error: --vision-backend must be 'metal' or 'coreml'\n");
+                return 1;
+            }
+        }
+        else if (arg == "--vision-coreml" && i + 1 < argc) {
+            vision_coreml_model_path = argv[++i];
+            vision_backend = "coreml";
+        }
+        else if (arg == "-o" && i + 1 < argc) { output_dir = argv[++i]; }
+        else if (arg == "--out-json" && i + 1 < argc) { out_json = argv[++i]; }
+        else if (arg == "--test" && i + 2 < argc) {
+            run_test = true;
+            test_prefix = argv[++i];
+            test_count = std::atoi(argv[++i]);
+        }
+        else if (arg == "--stream-interval" && i + 1 < argc) {
+            stream_interval_ms = std::atoi(argv[++i]);
+        }
+        else {
+            fprintf(stderr, "Unknown argument: %s\n", arg.c_str());
+            show_usage(argv[0]);
+            return 1;
+        }
+    }
+
+    if (llm_path.empty()) {
+        fprintf(stderr, "Error: -m <llm_model_path> is required\n\n");
+        show_usage(argv[0]);
+        return 1;
+    }
+
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__)) || defined(_WIN32)
+    struct sigaction sigint_action;
+    sigint_action.sa_handler = sigint_handler;
+    sigemptyset(&sigint_action.sa_mask);
+    sigint_action.sa_flags = 0;
+    sigaction(SIGINT, &sigint_action, NULL);
+#endif
+
+    TestModelPaths paths = resolve_model_paths(llm_path);
+    if (!vision_path_override.empty()) paths.vision = vision_path_override;
+    if (!audio_path_override.empty()) paths.audio = audio_path_override;
+    if (!tts_path_override.empty()) paths.tts = tts_path_override;
+    if (!projector_path_override.empty()) paths.projector = projector_path_override;
+    if (!vision_coreml_model_path.empty()) paths.vision_coreml = vision_coreml_model_path;
+
+    if (out_json.empty()) out_json = output_dir + "/perf_report.json";
+
+    printf("=== Duplex Perf Profiler ===\n");
+    printf("  LLM:    %s\n", paths.llm.c_str());
+    printf("  Vision: %s (backend=%s)\n", paths.vision.c_str(), vision_backend.c_str());
+    printf("  Audio:  %s\n", paths.audio.c_str());
+    printf("  TTS:    %s (use_tts=%d)\n", paths.tts.c_str(), use_tts ? 1 : 0);
+    printf("  Interval: %dms | out-json: %s\n", stream_interval_ms, out_json.c_str());
+
+    if (!file_exists(paths.llm))   { fprintf(stderr, "Error: LLM not found\n");   return 1; }
+    if (!file_exists(paths.audio)) { fprintf(stderr, "Error: Audio not found\n"); return 1; }
+    if (use_tts && !file_exists(paths.tts)) {
+        fprintf(stderr, "Warning: TTS not found, disabling TTS\n");
+        use_tts = false;
+    }
+
+    common_params params;
+    params.model.path   = paths.llm;
+    params.vpm_model    = paths.vision;
+    params.apm_model    = paths.audio;
+    params.tts_model    = paths.tts;
+    params.n_ctx        = n_ctx;
+    params.n_gpu_layers = n_gpu_layers;
+    if (vision_backend == "coreml") {
+        params.vision_coreml_model_path = paths.vision_coreml;
+    }
+
+    {
+        const char * seed_env = std::getenv("OMNI_SAMPLER_SEED");
+        uint32_t     seed     = seed_env ? (uint32_t) std::strtoul(seed_env, nullptr, 10) : 42u;
+        params.sampling.seed  = seed;
+    }
+
+    std::string tts_bin_dir = get_parent_dir(paths.tts);
+
+    common_init();
+
+    auto ctx_omni = omni_init(&params, media_type, use_tts, tts_bin_dir,
+                              /*tts_gpu_layers=*/-1, /*token2wav_device=*/token2wav_device,
+                              /*duplex_mode=*/true,
+                              /*existing_model=*/nullptr, /*existing_ctx=*/nullptr,
+                              /*base_output_dir=*/output_dir);
+    if (ctx_omni == nullptr) {
+        fprintf(stderr, "Error: Failed to initialize omni context\n");
+        return 1;
+    }
+    ctx_omni->async = true;
+    ctx_omni->ref_audio_path = ref_audio_path;
+
+    // [低侵入核心] 注册已存在的 audio_output_cb 钩子采集 wav chunk 时间线。
+    //    T2W 线程每写完一个 wav chunk 就会调用它（cpp / python 两条 T2W 路径都会调）。
+    //    与 SPEAK 轮次的对齐在 analyze_perf.py 里按时间戳做，不依赖数组下标。
+    ctx_omni->audio_output_cb =
+        [](const float * /*samples*/, int n_samples, int sample_rate, bool is_final) {
+            AudioChunkRecord rec;
+            rec.t_complete_ms = now_ms();
+            rec.n_samples     = n_samples;
+            rec.sample_rate   = sample_rate;
+            rec.duration_s    = (sample_rate > 0) ? (double)n_samples / sample_rate : 0.0;
+            rec.is_final      = is_final;
+            std::lock_guard<std::mutex> lk(g_perf.mtx);
+            rec.audio_turn_id = g_perf.cur_audio_turn_id;
+            g_perf.audio.push_back(rec);
+            if (is_final) {
+                g_perf.cur_audio_turn_id++;
+            }
+        };
+
+    // 硬编码默认样本：duplex omni 测试集（audio + image，共 36 帧 0000~0035）
+    const std::string default_prefix =
+        "tools/omni/assets/test_case/duplex_omni_test_case/duplex_omni_test_case_";
+    const int default_count = 36;
+    duplex_perf_run(ctx_omni,
+                    run_test ? test_prefix : default_prefix,
+                    run_test ? test_count  : default_count,
+                    stream_interval_ms);
+
+    // 等所有 speak 帧的 audio 落盘（audio_output_cb 也会在这期间继续触发）。
+    omni_duplex_drain_tts_audio(ctx_omni);
+
+    // 写报告（在 omni_free 之前，确保 audio_output_cb 已不会再被调用）。
+    int sr_hint = g_perf.audio.empty() ? 24000 : g_perf.audio.front().sample_rate;
+    write_json_report(out_json, stream_interval_ms, params.cpuparams.n_threads,
+                      sr_hint, paths.llm, vision_backend, use_tts, media_type);
+    printf("\n[perf] JSON 报告已写入: %s\n", out_json.c_str());
+    printf("[perf] 运行 analyze_perf.py 生成可读报告与可行性判定。\n");
+
+    llama_perf_context_print(ctx_omni->ctx_llama);
+    omni_free(ctx_omni);
+
+    printf("\n=== Duplex perf finished ===\n");
+    return 0;
+}

--- a/tools/omni/perf/run_perf.sh
+++ b/tools/omni/perf/run_perf.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# 双工可行性 profiling 一键脚本
+#   1. (可选) 编译 llama-omni-perf-duplex target
+#   2. 跑 perf-duplex，按 1s 节奏推帧，产出 perf_report.json
+#   3. 跑 analyze_perf.py，输出可读报告 + 可行性判定
+#
+# 用法:
+#   tools/omni/perf/run_perf.sh -m <llm.gguf> [--omni] \
+#       [--test <prefix> <n>] [--stream-interval 1000] [--build] [-- <额外 perf-duplex 参数>]
+#
+# 退出码: 0=可支撑双工, 2=不满足实时性, 3=数据不完整(不能判定), 其它=运行/编译失败
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+BUILD_DIR="${BUILD_DIR:-${REPO_ROOT}/build}"
+OUTPUT_DIR="${OUTPUT_DIR:-${REPO_ROOT}/tools/omni/output}"
+JSON_PATH="${OUTPUT_DIR}/perf_report.json"
+MD_PATH="${OUTPUT_DIR}/perf_report.md"
+DO_BUILD=0
+INTERVAL=1000
+
+PERF_ARGS=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --build) DO_BUILD=1; shift ;;
+        --stream-interval) INTERVAL="$2"; PERF_ARGS+=("--stream-interval" "$2"); shift 2 ;;
+        -o) OUTPUT_DIR="$2"; JSON_PATH="$2/perf_report.json"; MD_PATH="$2/perf_report.md"; PERF_ARGS+=("-o" "$2"); shift 2 ;;
+        --out-json) JSON_PATH="$2"; PERF_ARGS+=("--out-json" "$2"); shift 2 ;;
+        --) shift; while [[ $# -gt 0 ]]; do PERF_ARGS+=("$1"); shift; done ;;
+        *) PERF_ARGS+=("$1"); shift ;;
+    esac
+done
+
+mkdir -p "${OUTPUT_DIR}"
+
+if [[ "${DO_BUILD}" == "1" ]]; then
+    echo "[run_perf] 编译 llama-omni-perf-duplex ..."
+    cmake --build "${BUILD_DIR}" --target llama-omni-perf-duplex -j
+fi
+
+PERF_BIN="${BUILD_DIR}/bin/llama-omni-perf-duplex"
+if [[ ! -x "${PERF_BIN}" ]]; then
+    PERF_BIN="${BUILD_DIR}/tools/omni/llama-omni-perf-duplex"
+fi
+if [[ ! -x "${PERF_BIN}" ]]; then
+    echo "[run_perf] 未找到 llama-omni-perf-duplex，请先用 --build 编译。" >&2
+    exit 3
+fi
+
+echo "[run_perf] 运行 profiler: ${PERF_BIN}"
+echo "[run_perf] 进帧间隔=${INTERVAL}ms  输出=${JSON_PATH}"
+# perf-duplex 默认 --stream-interval 1000；这里把 OUTPUT_DIR/JSON 透传
+"${PERF_BIN}" --out-json "${JSON_PATH}" -o "${OUTPUT_DIR}" "${PERF_ARGS[@]}"
+
+echo ""
+echo "[run_perf] 生成可行性报告 ..."
+set +e
+python3 "${SCRIPT_DIR}/analyze_perf.py" "${JSON_PATH}" --interval-ms "${INTERVAL}" --md "${MD_PATH}"
+RC=$?
+set -e
+echo "[run_perf] markdown 报告: ${MD_PATH}"
+exit ${RC}

--- a/tools/server/CMakeLists.txt
+++ b/tools/server/CMakeLists.txt
@@ -29,37 +29,6 @@ target_include_directories(${TARGET} PRIVATE ../omni/voxcpm2)
 target_include_directories(${TARGET} PRIVATE ${CMAKE_SOURCE_DIR})
 target_link_libraries(${TARGET} PRIVATE llama-common omni mtmd voxcpm2_runtime ${CMAKE_THREAD_LIBS_INIT})
 
-# llama-server-impl: server logic, reusable by app
-
-set(TARGET llama-server-impl)
-
-add_library(${TARGET}
-    server.cpp
-    server-http.cpp
-    server-http.h
-    server-models.cpp
-    server-models.h
-)
-set_target_properties(${TARGET} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
-
-target_include_directories(${TARGET} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_include_directories(${TARGET} PRIVATE ../mtmd ${CMAKE_SOURCE_DIR})
-target_link_libraries(${TARGET} PUBLIC server-context llama-ui cpp-httplib ${CMAKE_THREAD_LIBS_INIT})
-
-if(LLAMA_TOOLS_INSTALL)
-    install(TARGETS ${TARGET} LIBRARY)
-endif()
-
-# llama-server executable
-
-set(TARGET llama-server)
-
-add_executable(${TARGET} main.cpp)
-install(TARGETS ${TARGET} RUNTIME)
-
-target_link_libraries(${TARGET} PRIVATE llama-server-impl)
-target_compile_features(${TARGET} PRIVATE cxx_std_17)
-
 # llama-omni-server executable (standalone omni HTTP API)
 
 if (LLAMA_OPENSSL)


### PR DESCRIPTION
## Overview
  FusedInferAttentionScoreV2 was receiving llama.cpp's additive F16 attention mask (-Inf for masked positions) via `pseShiftOptional`. Ascend documents `pseShift` as position encoding (F16/BFLOAT16) and `attenMask` as BOOL/INT8/UINT8.On long KV lengths (e.g. multi-image MiniCPM-o, Sk≈768), putting -Inf into `pseShift` produced NaNs in the fused op and garbled generation (`?` floods).

This change:
  - converts the hard-mask part of src3 (-Inf) to a contiguous BOOL `attenMask` (True = do not attend) and passes it via `attenMaskOptional`
  - keeps finite additive biases in `pseShift` (clamped so PSE never contains -Inf)
  - when `max_bias != 0` (ALiBi), multiplies the finite PSE by the ALiBi slopes
 
## Additional information
  - Ascend `aclnnFusedInferAttentionScoreV2`:
    - `attenMaskOptional`: BOOL / INT8 / UINT8
    - `pseShiftOptional`: F16 / BF16 position encoding / additive bias
  - Related prior workaround: CANN AUTO flash-attn force-off in `llama-context.cpp` (can revisit in a follow-up after this lands)
  - Same pse-as-mask pattern also exists in upstream `ggml-org/llama.cpp`
  ## Test plan
  - [x] `test-backend-ops -b CANN0 -o FLASH_ATTN_EXT -p "mask=1,sinks=0,max_bias=0"` → 320/320 OK
  - [x] MiniCPM-o, multi-image, `--flash-attn on`: no NaN / no `?` flood
  - [x] text-only + `--flash-attn on` (`llama-cli --single-turn`): OK
  - [x] Rebuild `ggml-cann` with this change
  ## Requirements
  <!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->
  - I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
  - AI usage disclosure: YES - used AI to help isolate the CANN FA NaN (mask vs pseShift) and draft the attenMask conversion; I reviewed the final patch line-by-line and can explain / maintain it