### PR TITLE
feat: add static Omni runtime profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,59 @@ cmake --build build --target llama-omni-server --target llama-omni-cli -j
 
 > CMake will auto-detect and enable Metal (macOS) or CUDA (Linux with NVIDIA GPU).
 
+### Runtime profile
+
+`--profile auto` reads a static JSON profile. The default path is
+`<model-dir>/omni-runtime-profile.json`; `--profile-config PATH` selects a
+different file. The JSON file names every Omni module, its quantization, GGML
+backend device name, and runtime settings. The server does not select a model
+from available files and does not have a built-in CPU or accelerator fallback.
+
+The server exits before loading weights when the profile file is missing or
+invalid, a required field is absent, a configured model path does not exist, or
+a configured GGML backend device cannot be mapped to a visible accelerator. A
+complete example is in
+[`docs/examples/omni-runtime-profile-auto.md`](docs/examples/omni-runtime-profile-auto.md).
+
+```bash
+./build/bin/llama-omni-server \
+    --profile auto \
+    --model-dir /path/to/MiniCPM-o-4_5-gguf \
+    --host 0.0.0.0 \
+    --port 9060
+```
+
+Inspect the selection without loading weights or opening the HTTP port:
+
+```bash
+./build/bin/llama-omni-server \
+    --profile auto \
+    --model-dir /path/to/MiniCPM-o-4_5-gguf \
+    --print-effective-config
+```
+
+The resolver assigns LLM, Vision, Audio, TTS, Projector, and Token2Wav to the
+devices named in the JSON file. The example uses fixed `CUDA0` and `CUDA1`
+backend names for the first and second visible CUDA devices; `cpu` always means
+the CPU backend. The configured names must be present in the current process,
+otherwise profile validation fails. `primary` and `secondary` remain accepted
+as backward-compatible aliases. `CUDA_VISIBLE_DEVICES` (or the corresponding
+vendor visibility variable) limits which accelerators can be mapped.
+
+The output contains one `placement=` line for each module. Each line names the
+model path, precision, GGML backend class, selected device, execution mode, and
+`active` status. `llama-omni-server` passes the LLM and TTS placements to
+`llama_model_params`, and passes the Vision, Audio, and Projector placements to
+their GGML backend initializers. Token2Wav receives the resolved `gpu:N` or
+`cpu` device string.
+
+Explicit `--model`, `--n-gpu-layers`, `--ctx-size`, and
+`--token2wav-threads` values are applied after the JSON file for compatibility
+with existing scripts. Per-module placement still comes from the JSON file.
+Use `--print-effective-config` to inspect the loaded file, model paths,
+quantization, module placement, and Token2Wav thread count before starting the
+server.
+
 ### Usage
 
 ```bash
@@ -476,6 +529,8 @@ POST /v1/stream/omni_init
 | `duplex_mode` | `true` enables full-duplex streaming |
 | `voice_audio` | Reference WAV for voice cloning. Omit to use default voice |
 | `output_dir` | Directory where TTS WAV files will be written |
+
+When the server starts with `--profile`, the effective runtime configuration controls `duplex_mode`, `tts_gpu_layers`, and `token2wav_device`. Values for those fields in the `omni_init` request are ignored so a request cannot silently replace the static profile placement. Without `--profile`, the request fields keep their legacy behavior.
 
 **Expected response:**
 ```json

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -53,6 +53,10 @@
 using json = nlohmann::ordered_json;
 using namespace common_arg_utils;
 
+static bool is_server_example(enum llama_example ex) {
+    return ex == LLAMA_EXAMPLE_SERVER || ex == LLAMA_EXAMPLE_OMNI_SERVER;
+}
+
 static std::initializer_list<enum llama_example> mmproj_examples = {
     LLAMA_EXAMPLE_MTMD,
     LLAMA_EXAMPLE_SERVER,
@@ -628,7 +632,7 @@ static bool common_params_parse_ex(int argc, char ** argv, common_params_context
 
     // model is required (except for server)
     // TODO @ngxson : maybe show a list of available models in CLI in this case
-    if (params.model.path.empty() && ctx_arg.ex != LLAMA_EXAMPLE_SERVER && !skip_model_download && !params.usage && !params.completion) {
+    if (params.model.path.empty() && !is_server_example(ctx_arg.ex) && !skip_model_download && !params.usage && !params.completion) {
         throw std::invalid_argument("error: --model is required\n");
     }
 
@@ -1038,7 +1042,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         params.use_jinja = false;   // disable jinja by default
         params.sampling.temp = 0.2; // lower temp by default for better quality
 
-    } else if (ex == LLAMA_EXAMPLE_SERVER) {
+    } else if (is_server_example(ex)) {
         params.n_parallel = -1;     // auto by default
     }
 
@@ -1067,7 +1071,10 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
      * - if both {LLAMA_EXAMPLE_COMMON, LLAMA_EXAMPLE_*,} are set, we will prioritize the LLAMA_EXAMPLE_* matching current example
      */
     auto add_opt = [&](common_arg arg) {
-        if ((arg.in_example(ex) || arg.in_example(LLAMA_EXAMPLE_COMMON)) && !arg.is_exclude(ex)) {
+        const bool inherits_server = ex == LLAMA_EXAMPLE_OMNI_SERVER && arg.in_example(LLAMA_EXAMPLE_SERVER);
+        const bool excluded_as_server = ex == LLAMA_EXAMPLE_OMNI_SERVER && arg.is_exclude(LLAMA_EXAMPLE_SERVER);
+        if ((arg.in_example(ex) || inherits_server || arg.in_example(LLAMA_EXAMPLE_COMMON)) &&
+            !arg.is_exclude(ex) && !excluded_as_server) {
             ctx_arg.options.push_back(std::move(arg));
         }
     };
@@ -1089,6 +1096,48 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             exit(0);
         }
     ));
+    add_opt(common_arg(
+        {"--profile"}, "NAME",
+        "select an Omni runtime profile (supported: auto)",
+        [](common_params & params, const std::string & value) {
+            if (value != "auto") {
+                throw std::invalid_argument("unsupported Omni runtime profile: " + value);
+            }
+            params.omni_runtime_profile.profile = value;
+        }
+    ).set_examples({LLAMA_EXAMPLE_OMNI_SERVER}));
+    add_opt(common_arg(
+        {"--model-dir"}, "DIR",
+        "directory containing the MiniCPM-o 4.5 GGUF model tree used by --profile",
+        [](common_params & params, const std::string & value) {
+            params.omni_runtime_profile.model_dir = value;
+        }
+    ).set_examples({LLAMA_EXAMPLE_OMNI_SERVER}));
+    add_opt(common_arg(
+        {"--profile-config"}, "PATH",
+        "static JSON runtime profile read by --profile auto (default: MODEL_DIR/omni-runtime-profile.json)",
+        [](common_params & params, const std::string & value) {
+            params.omni_runtime_profile.profile_config = value;
+        }
+    ).set_examples({LLAMA_EXAMPLE_OMNI_SERVER}));
+    add_opt(common_arg(
+        {"--token2wav-threads"}, "N",
+        "number of CPU threads used by Token2Wav (default: 8)",
+        [](common_params & params, int value) {
+            if (value <= 0) {
+                throw std::invalid_argument("--token2wav-threads must be positive");
+            }
+            params.omni_runtime_profile.token2wav_threads = value;
+            params.omni_runtime_profile.token2wav_threads_explicit = true;
+        }
+    ).set_examples({LLAMA_EXAMPLE_OMNI_SERVER}));
+    add_opt(common_arg(
+        {"--print-effective-config"},
+        "print the resolved Omni runtime configuration and exit",
+        [](common_params & params) {
+            params.omni_runtime_profile.print_effective_config = true;
+        }
+    ).set_examples({LLAMA_EXAMPLE_OMNI_SERVER}));
     add_opt(common_arg(
         {"-cl", "--cache-list"},
         "show list of models in cache",
@@ -1267,6 +1316,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         string_format("size of the prompt context (default: %d, 0 = loaded from model)", params.n_ctx),
         [](common_params & params, int value) {
             params.n_ctx = value;
+            params.omni_runtime_profile.n_ctx_explicit = true;
             if (value == 0) {
                 // disable context reduction in llama_params_fit if the user explicitly requests the full context size:
                 params.fit_params_min_ctx = UINT32_MAX;
@@ -2143,7 +2193,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             LOG_WRN("DEPRECATED: --defrag-thold is deprecated and no longer necessary to specify\n");
         }
     ).set_env("LLAMA_ARG_DEFRAG_THOLD"));
-    if (ex == LLAMA_EXAMPLE_SERVER) {
+    if (is_server_example(ex)) {
         // this is to make sure this option appears in the server-specific section of the help message
         add_opt(common_arg(
             {"-np", "--parallel"}, "N",
@@ -2350,6 +2400,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             } else {
                 params.n_gpu_layers = std::stoi(value);
             }
+            params.omni_runtime_profile.n_gpu_layers_explicit = true;
             if (!llama_supports_gpu_offload()) {
                 fprintf(stderr, "warning: no usable GPU found, --gpu-layers option will be ignored\n");
                 fprintf(stderr, "warning: one possible reason is that llama.cpp was compiled without GPU support\n");
@@ -2592,6 +2643,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             : "model path to load",
         [](common_params & params, const std::string & value) {
             params.model.path = value;
+            params.omni_runtime_profile.model_explicit = true;
         }
     ).set_examples({LLAMA_EXAMPLE_COMMON, LLAMA_EXAMPLE_EXPORT_LORA}).set_env("LLAMA_ARG_MODEL"));
     add_opt(common_arg(

--- a/common/common.h
+++ b/common/common.h
@@ -96,6 +96,7 @@ enum llama_example {
     LLAMA_EXAMPLE_FIT_PARAMS,
     LLAMA_EXAMPLE_RESULTS,
     LLAMA_EXAMPLE_EXPORT_GRAPH_OPS,
+    LLAMA_EXAMPLE_OMNI_SERVER,
 
     LLAMA_EXAMPLE_COUNT,
 };
@@ -391,6 +392,18 @@ struct common_params_diffusion {
     bool    add_gumbel_noise = false; // add gumbel noise to the logits if temp > 0.0
 };
 
+struct common_params_omni_runtime_profile {
+    std::string profile;
+    std::string model_dir;
+    std::string profile_config;
+    int32_t token2wav_threads = 8;
+    bool print_effective_config = false;
+    bool model_explicit = false;
+    bool n_gpu_layers_explicit = false;
+    bool n_ctx_explicit = false;
+    bool token2wav_threads_explicit = false;
+};
+
 // reasoning API response format (not to be confused as chat template's reasoning format)
 // only used by server
 enum common_reasoning_format {
@@ -474,6 +487,7 @@ struct common_params {
     struct common_params_speculative speculative;
     struct common_params_vocoder     vocoder;
     struct common_params_diffusion   diffusion;
+    struct common_params_omni_runtime_profile omni_runtime_profile;
 
     struct common_params_model model;
 

--- a/conversion/llama.py
+++ b/conversion/llama.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import math
+import os
 
 from typing import Callable, Iterable, TYPE_CHECKING
 
@@ -29,6 +30,7 @@ class LlamaModel(TextModel):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self._head_code_params: dict[str, Tensor] = {}
         # fix for SmolVLM2, missing `num_attention_heads` in config.json
         if self.hf_arch == "VLlama3ForCausalLM":
             self.hparams["num_attention_heads"] = self.hparams.get("num_attention_heads", 32)
@@ -40,6 +42,13 @@ class LlamaModel(TextModel):
             self.origin_hf_arch = hparams.get('architectures', [None])[0]
 
     def set_vocab(self):
+        if os.environ.get("OMNI_TTS_NO_VOCAB") == "1":
+            # MiniCPM-o TTS uses emb_text for text tokens; its auxiliary
+            # embed_tokens table is only a 32k placeholder. Avoid emitting
+            # the 158626-entry tokenizer list into this partial model.
+            self._set_vocab_none()
+            return
+
         if self.origin_hf_arch == "GlmasrModel":
             return self._set_vocab_glmedge()
 
@@ -90,7 +99,8 @@ class LlamaModel(TextModel):
         hparams = self.hparams
 
         if not self.is_mistral_format:
-            self.gguf_writer.add_vocab_size(hparams["vocab_size"])
+            vocab_size = 32000 if os.environ.get("OMNI_TTS_NO_VOCAB") == "1" else hparams["vocab_size"]
+            self.gguf_writer.add_vocab_size(vocab_size)
 
         if (rope_dim := hparams.get("head_dim")) is None:
             rope_dim = hparams["hidden_size"] // hparams["num_attention_heads"]
@@ -132,6 +142,55 @@ class LlamaModel(TextModel):
     def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
         n_head = self.find_hparam(["n_heads", "num_attention_heads"])
         n_kv_head = self.find_hparam(["n_kv_heads", "num_key_value_heads"])
+
+        if name == "model.embed_tokens.weight" and os.environ.get("OMNI_TTS_PAD_VOCAB") == "1":
+            # The MiniCPM-o TTS checkpoint carries a 32k placeholder
+            # embed_tokens table, while its tokenizer has 158626 entries and
+            # emb_text contains the real 152064 text embeddings.  llama.cpp
+            # validates token_embd against the tokenizer size, so build the
+            # loader-facing table from emb_text and zero-pad the audio-token
+            # rows.  Omni's direct TTS path still reads emb_text separately.
+            emb_text_gen = self.model_tensors.get("emb_text.weight")
+            if emb_text_gen is None:
+                raise ValueError("OMNI_TTS_PAD_VOCAB requires emb_text.weight")
+            emb_text = emb_text_gen().to(torch.float32)
+            vocab_size = int(self.hparams["vocab_size"])
+            if emb_text.shape[0] > vocab_size:
+                raise ValueError(f"emb_text has {emb_text.shape[0]} rows, larger than vocab_size={vocab_size}")
+            padded = torch.zeros((vocab_size, emb_text.shape[1]), dtype=emb_text.dtype)
+            padded[: emb_text.shape[0]] = emb_text
+            yield "token_embd.weight", padded
+            return
+
+        # MiniCPM-o TTS stores these auxiliary tensors beside the standard
+        # Llama transformer weights.  They are consumed directly by the Omni
+        # runtime, so keep their names unchanged instead of routing them
+        # through the standard Llama tensor map.
+        if name.startswith((
+            "emb_code.",
+            "emb_text.",
+            "projector_semantic.",
+            "projector_spk.",
+        )):
+            yield name, data_torch
+            return
+
+        # Reconstruct the weight-normalized audio-token head. The source
+        # checkpoint stores the scale/vector pair, while the Omni runtime
+        # consumes a single head_code.0.weight tensor.
+        if name in (
+            "head_code.0.parametrizations.weight.original0",
+            "head_code.0.parametrizations.weight.original1",
+        ):
+            self._head_code_params[name] = data_torch
+            scale_name = "head_code.0.parametrizations.weight.original0"
+            vector_name = "head_code.0.parametrizations.weight.original1"
+            if scale_name in self._head_code_params and vector_name in self._head_code_params:
+                scale = self._head_code_params[scale_name].float()
+                vector = self._head_code_params[vector_name].float()
+                norm = torch.linalg.vector_norm(vector, dim=1, keepdim=True).clamp_min(1e-12)
+                yield "head_code.0.weight", scale * vector / norm
+            return
 
         if self.hf_arch == "LlamaModel":
             name = "model." + name

--- a/docs/examples/omni-runtime-profile-auto.md
+++ b/docs/examples/omni-runtime-profile-auto.md
@@ -1,0 +1,69 @@
+# Omni runtime profile example
+
+`--profile auto` requires a static JSON file. By default the server reads
+`<model-dir>/omni-runtime-profile.json`; use `--profile-config PATH` to place
+the file elsewhere. Relative model paths below are resolved from
+`--model-dir`. The server exits if the file, a required field, a model file, or
+a requested device is unavailable.
+
+```bash
+CUDA_VISIBLE_DEVICES=0,1 \
+./build/bin/llama-omni-server \
+    --profile auto \
+    --model-dir /models/MiniCPM-o-4_5-gguf \
+    --host 0.0.0.0 \
+    --port 9060
+```
+
+Example `omni-runtime-profile.json`:
+
+```json
+{
+  "schema_version": 1,
+  "profile": "auto",
+  "llm": {
+    "model": "MiniCPM-o-4_5-Q4_K_M.gguf",
+    "quantization": "Q4_K_M",
+    "device": "CUDA0",
+    "n_gpu_layers": -2
+  },
+  "vision": {
+    "model": "vision/MiniCPM-o-4_5-vision-F16.gguf",
+    "device": "CUDA1"
+  },
+  "audio": {
+    "model": "audio/MiniCPM-o-4_5-audio-F16.gguf",
+    "device": "CUDA1"
+  },
+  "tts": {
+    "model": "tts/MiniCPM-o-4_5-tts-F16.gguf",
+    "device": "CUDA0",
+    "gpu_layers": -1
+  },
+  "projector": {
+    "model": "tts/MiniCPM-o-4_5-projector-F16.gguf",
+    "device": "CUDA1"
+  },
+  "token2wav": {
+    "model_dir": "token2wav-gguf",
+    "device": "CUDA0",
+    "threads": 8
+  },
+  "runtime": {
+    "n_ctx": 8192,
+    "duplex": true,
+    "async": true,
+    "vpm_batch_encode": true
+  }
+}
+```
+
+The example uses fixed GGML backend device names: `CUDA0` for the first visible
+CUDA device and `CUDA1` for the second. Use `cpu` for a CPU module. The names
+must match the devices visible to the current process; a missing device causes
+profile validation to fail. `primary` and `secondary` remain accepted as
+backward-compatible aliases. `--print-effective-config` validates the file and
+prints the resulting paths and placements without loading model weights.
+
+To inspect the resolved configuration without loading model weights or opening
+the HTTP port, add `--print-effective-config` to the same command.

--- a/tools/omni/CMakeLists.txt
+++ b/tools/omni/CMakeLists.txt
@@ -12,6 +12,12 @@ endif()
 add_library(omni
             omni.cpp
             omni.h
+            runtime-profile-session.cpp
+            runtime-profile-session.h
+            runtime-profile.cpp
+            runtime-profile.h
+            tts-weight-layout.cpp
+            tts-weight-layout.h
             tts-condition-graph.cpp
             tts-condition-graph.h
             audition.cpp
@@ -50,7 +56,9 @@ target_link_libraries     (omni PRIVATE Threads::Threads)
 target_include_directories(omni PUBLIC  .)
 target_include_directories(omni PRIVATE ../..)
 target_include_directories(omni PRIVATE ../../vendor)
+target_include_directories(omni PRIVATE ../../examples/gguf-hash/deps)
 target_compile_features   (omni PRIVATE cxx_std_17)
+target_sources(omni PRIVATE ../../examples/gguf-hash/deps/sha256/sha256.c)
 
 # Link CoreML and Accelerate frameworks when CoreML is enabled
 if(ENABLE_COREML)
@@ -201,6 +209,20 @@ endif()
 # voxcpm2-cli build + smoke test (no weights). --help exits non-zero by design,
 # so assert on the usage banner instead of the exit code.
 if (LLAMA_BUILD_TESTS)
+    set(TARGET_HEAD_CODE_LAYOUT_TEST test-head-code-layout)
+    add_executable(${TARGET_HEAD_CODE_LAYOUT_TEST} test/test-head-code-layout.cpp)
+    target_link_libraries(${TARGET_HEAD_CODE_LAYOUT_TEST} PRIVATE omni)
+    target_compile_features(${TARGET_HEAD_CODE_LAYOUT_TEST} PRIVATE cxx_std_17)
+    add_test(NAME ${TARGET_HEAD_CODE_LAYOUT_TEST} COMMAND ${TARGET_HEAD_CODE_LAYOUT_TEST})
+    set_tests_properties(${TARGET_HEAD_CODE_LAYOUT_TEST} PROPERTIES LABELS "main;omni")
+
+    set(TARGET_RUNTIME_PROFILE_TEST test-runtime-profile)
+    add_executable(${TARGET_RUNTIME_PROFILE_TEST} test/test-runtime-profile.cpp)
+    target_link_libraries(${TARGET_RUNTIME_PROFILE_TEST} PRIVATE omni)
+    target_compile_features(${TARGET_RUNTIME_PROFILE_TEST} PRIVATE cxx_std_17)
+    add_test(NAME ${TARGET_RUNTIME_PROFILE_TEST} COMMAND ${TARGET_RUNTIME_PROFILE_TEST})
+    set_tests_properties(${TARGET_RUNTIME_PROFILE_TEST} PROPERTIES LABELS "main;omni")
+
     add_test(
         NAME voxcpm2-cli-smoke
         COMMAND ${TARGET_VOXCPM2_CLI} --help

--- a/tools/omni/audition.cpp
+++ b/tools/omni/audition.cpp
@@ -238,10 +238,17 @@ struct audition_ctx {
             throw std::runtime_error("failed to initialize CPU backend");
         }
         if (audition_params.use_gpu) {
-            auto backend_name = std::getenv("MTMD_BACKEND_DEVICE");
+            const char * backend_name = audition_params.backend_device;
+            const bool explicit_backend = backend_name != nullptr && std::strlen(backend_name) > 0;
+            if (backend_name == nullptr || std::strlen(backend_name) == 0) {
+                backend_name = std::getenv("MTMD_BACKEND_DEVICE");
+            }
             if (backend_name != nullptr) {
                 backend = ggml_backend_init_by_name(backend_name, nullptr);
                 if (!backend) {
+                    if (explicit_backend) {
+                        throw std::runtime_error(std::string("failed to initialize requested audio backend: ") + backend_name);
+                    }
                     LOG_WRN("%s: Warning: Failed to initialize \"%s\" backend, falling back to default GPU backend\n", __func__, backend_name);
                 }
             }

--- a/tools/omni/audition.h
+++ b/tools/omni/audition.h
@@ -151,6 +151,7 @@ struct audition_audio_f32_batch {
 struct audition_context_params {
     bool use_gpu;
     enum ggml_log_level verbosity;
+    const char * backend_device = nullptr;
 };
 
 struct audition_ctx * audition_init(const char * fname, struct audition_context_params ctx_params);

--- a/tools/omni/convert/convert_projector.py
+++ b/tools/omni/convert/convert_projector.py
@@ -16,6 +16,7 @@ Usage:
 import os
 import struct
 import argparse
+import json
 import numpy as np
 
 def write_string(f, s):
@@ -32,30 +33,37 @@ def convert_projector(model_path: str, output_path: str):
     # 查找 safetensors 文件
     if os.path.isdir(model_path):
         safetensors_path = os.path.join(model_path, 'model.safetensors')
-        if not os.path.exists(safetensors_path):
-            # 尝试查找其他 safetensors 文件
-            for f in os.listdir(model_path):
-                if f.endswith('.safetensors'):
-                    safetensors_path = os.path.join(model_path, f)
-                    break
+        if os.path.exists(safetensors_path):
+            safetensors_paths = [safetensors_path]
+        else:
+            index_path = os.path.join(model_path, 'model.safetensors.index.json')
+            if not os.path.exists(index_path):
+                raise FileNotFoundError(f"找不到 safetensors 文件或索引: {model_path}")
+            with open(index_path, 'r', encoding='utf-8') as index_file:
+                index = json.load(index_file)
+            safetensors_paths = sorted({
+                os.path.join(model_path, filename)
+                for filename in index.get('weight_map', {}).values()
+            })
     else:
-        safetensors_path = model_path
-    
-    if not os.path.exists(safetensors_path):
-        raise FileNotFoundError(f"找不到 safetensors 文件: {safetensors_path}")
-    
-    print(f"加载模型权重: {safetensors_path}")
-    f = safe_open(safetensors_path, framework='pt', device='cpu')
-    
+        safetensors_paths = [model_path]
+
+    for path in safetensors_paths:
+        if not os.path.exists(path):
+            raise FileNotFoundError(f"找不到 safetensors shard: {path}")
+
     # 提取 projector_semantic 权重
     weights = {}
-    for key in f.keys():
-        if 'tts.projector_semantic.' in key and 'norm' not in key:
-            # 简化名称: tts.projector_semantic.linear1.weight -> linear1.weight
-            new_key = key.replace('tts.projector_semantic.', '')
-            tensor = f.get_tensor(key).float().numpy()
-            weights[new_key] = tensor
-            print(f"  {key} -> {new_key}: {tensor.shape}")
+    for safetensors_path in safetensors_paths:
+        print(f"加载模型权重: {safetensors_path}")
+        with safe_open(safetensors_path, framework='pt', device='cpu') as f:
+            for key in f.keys():
+                if 'tts.projector_semantic.' in key and 'norm' not in key:
+                    # 简化名称: tts.projector_semantic.linear1.weight -> linear1.weight
+                    new_key = key.replace('tts.projector_semantic.', '')
+                    tensor = f.get_tensor(key).float().numpy()
+                    weights[new_key] = tensor
+                    print(f"  {key} -> {new_key}: {tensor.shape}")
     
     if len(weights) == 0:
         raise ValueError("未找到 projector_semantic 权重")

--- a/tools/omni/convert/convert_tts.py
+++ b/tools/omni/convert/convert_tts.py
@@ -30,6 +30,13 @@ GGUF_VERSION = 3
 GGML_TYPE_F32 = 0
 GGML_TYPE_F16 = 1
 
+# GGUF metadata value types (GGUF v3)
+GGUF_TYPE_UINT32 = 4
+GGUF_TYPE_INT32 = 5
+GGUF_TYPE_FLOAT32 = 6
+GGUF_TYPE_BOOL = 7
+GGUF_TYPE_STRING = 8
+
 
 def write_string(f, s):
     """写入字符串 (长度 + 内容)"""
@@ -43,13 +50,13 @@ def write_metadata_kv(f, key, value_type, value):
     write_string(f, key)
     f.write(struct.pack('<I', value_type))
     
-    if value_type == 4:  # string
+    if value_type == GGUF_TYPE_STRING:
         write_string(f, value)
-    elif value_type == 5:  # uint32
+    elif value_type == GGUF_TYPE_UINT32:
         f.write(struct.pack('<I', value))
-    elif value_type == 6:  # int32
+    elif value_type == GGUF_TYPE_INT32:
         f.write(struct.pack('<i', value))
-    elif value_type == 7:  # float32
+    elif value_type == GGUF_TYPE_FLOAT32:
         f.write(struct.pack('<f', value))
 
 
@@ -116,16 +123,16 @@ def convert_tts_to_gguf(model_dir, output_path, output_type='f32'):
         f.write(struct.pack('<Q', n_kv))
         
         # 写入元数据
-        write_metadata_kv(f, 'general.architecture', 4, 'minicpmtts')
-        write_metadata_kv(f, 'general.name', 4, 'MiniCPM-TTS')
-        write_metadata_kv(f, 'minicpmtts.context_length', 5, config.get('max_position_embeddings', 4096))
-        write_metadata_kv(f, 'minicpmtts.embedding_length', 5, config.get('hidden_size', 768))
-        write_metadata_kv(f, 'minicpmtts.block_count', 5, config.get('num_hidden_layers', 20))
-        write_metadata_kv(f, 'minicpmtts.attention.head_count', 5, config.get('num_attention_heads', 12))
-        write_metadata_kv(f, 'minicpmtts.attention.head_count_kv', 5, config.get('num_key_value_heads', 12))
-        write_metadata_kv(f, 'minicpmtts.feed_forward_length', 5, config.get('intermediate_size', 3072))
-        write_metadata_kv(f, 'minicpmtts.llm_hidden_size', 5, config.get('llm_hidden_size', 4096))
-        write_metadata_kv(f, 'general.file_type', 5, GGML_TYPE_F32 if output_type == 'f32' else GGML_TYPE_F16)
+        write_metadata_kv(f, 'general.architecture', GGUF_TYPE_STRING, 'minicpmtts')
+        write_metadata_kv(f, 'general.name', GGUF_TYPE_STRING, 'MiniCPM-TTS')
+        write_metadata_kv(f, 'minicpmtts.context_length', GGUF_TYPE_UINT32, config.get('max_position_embeddings', 4096))
+        write_metadata_kv(f, 'minicpmtts.embedding_length', GGUF_TYPE_UINT32, config.get('hidden_size', 768))
+        write_metadata_kv(f, 'minicpmtts.block_count', GGUF_TYPE_UINT32, config.get('num_hidden_layers', 20))
+        write_metadata_kv(f, 'minicpmtts.attention.head_count', GGUF_TYPE_UINT32, config.get('num_attention_heads', 12))
+        write_metadata_kv(f, 'minicpmtts.attention.head_count_kv', GGUF_TYPE_UINT32, config.get('num_key_value_heads', 12))
+        write_metadata_kv(f, 'minicpmtts.feed_forward_length', GGUF_TYPE_UINT32, config.get('intermediate_size', 3072))
+        write_metadata_kv(f, 'minicpmtts.llm_hidden_size', GGUF_TYPE_UINT32, config.get('llm_hidden_size', 4096))
+        write_metadata_kv(f, 'general.file_type', GGUF_TYPE_UINT32, GGML_TYPE_F32 if output_type == 'f32' else GGML_TYPE_F16)
         
         # 写入张量信息
         tensor_infos = []
@@ -207,4 +214,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/tools/omni/convert/surgery.py
+++ b/tools/omni/convert/surgery.py
@@ -4,6 +4,7 @@ import sys
 import shutil
 import importlib.util
 import re
+import json
 
 import torch
 from safetensors import safe_open
@@ -65,10 +66,39 @@ def load_safetensors(safetensors_path: str) -> dict:
     Returns:
         state_dict 字典
     """
+    # Hugging Face stores larger checkpoints as an index plus multiple shards.
+    # Read each shard once, while keeping the existing single-file path working.
+    if os.path.isdir(safetensors_path):
+        single_file = os.path.join(safetensors_path, "model.safetensors")
+        index_file = os.path.join(safetensors_path, "model.safetensors.index.json")
+        if os.path.exists(single_file):
+            safetensors_files = [single_file]
+        elif os.path.exists(index_file):
+            with open(index_file, "r", encoding="utf-8") as f:
+                index = json.load(f)
+            safetensors_files = sorted(
+                {
+                    os.path.join(safetensors_path, filename)
+                    for filename in index.get("weight_map", {}).values()
+                }
+            )
+            if not safetensors_files:
+                raise ValueError(f"索引文件没有 weight_map: {index_file}")
+        else:
+            raise FileNotFoundError(
+                f"目录中找不到 model.safetensors 或 model.safetensors.index.json: {safetensors_path}"
+            )
+    else:
+        safetensors_files = [safetensors_path]
+
     state_dict = {}
-    with safe_open(safetensors_path, framework="pt", device="cpu") as f:
-        for key in f.keys():
-            state_dict[key] = f.get_tensor(key)
+    for shard_path in safetensors_files:
+        if not os.path.exists(shard_path):
+            raise FileNotFoundError(f"索引引用的 safetensors shard 不存在: {shard_path}")
+        print(f"  读取 shard: {shard_path}")
+        with safe_open(shard_path, framework="pt", device="cpu") as f:
+            for key in f.keys():
+                state_dict[key] = f.get_tensor(key)
     return state_dict
 
 
@@ -121,14 +151,23 @@ def main():
     print(f"  - VPM: {vpm_dir}")
     print(f"  - APM: {apm_dir}")
 
-    # 检查 safetensors 文件
-    safetensors_path = os.path.join(args.model, "model.safetensors")
-    if not os.path.exists(safetensors_path):
-        raise FileNotFoundError(f"找不到 safetensors 文件: {safetensors_path}")
+    # 检查单文件或分片 safetensors checkpoint
+    safetensors_path = args.model
+    single_file = os.path.join(args.model, "model.safetensors")
+    index_file = os.path.join(args.model, "model.safetensors.index.json")
+    if os.path.exists(single_file):
+        safetensors_path = single_file
+    elif not os.path.exists(index_file):
+        raise FileNotFoundError(
+            f"找不到 model.safetensors 或 model.safetensors.index.json: {args.model}"
+        )
     
     print(f"\n正在加载 safetensors: {safetensors_path}")
-    file_size = os.path.getsize(safetensors_path) / 1024 / 1024 / 1024
-    print(f"  文件大小: {file_size:.2f} GB")
+    if os.path.isfile(safetensors_path):
+        file_size = os.path.getsize(safetensors_path) / 1024 / 1024 / 1024
+        print(f"  文件大小: {file_size:.2f} GB")
+    else:
+        print("  使用 model.safetensors.index.json 分片权重")
     
     # 加载 safetensors 文件
     checkpoint = load_safetensors(safetensors_path)

--- a/tools/omni/omni.cpp
+++ b/tools/omni/omni.cpp
@@ -4283,15 +4283,17 @@ struct omni_context * omni_init(struct common_params * params, int media_type, b
         // Check if token2wav model files exist
         // 优先检查 HF 模型目录下的 token2wav-gguf (tts_bin_dir 的父目录)
         // 目录结构: {model_dir}/token2wav-gguf/
-        std::string gguf_root_dir = tts_bin_dir;
-        size_t last_slash = gguf_root_dir.find_last_of("/\\");
-        if (last_slash != std::string::npos) {
-            gguf_root_dir = gguf_root_dir.substr(0, last_slash);  // 获取 tts 的父目录
-        }
-        ctx_omni->token2wav_model_dir = gguf_root_dir + "/token2wav-gguf";
-        
-        std::string encoder_test = ctx_omni->token2wav_model_dir + "/encoder.gguf";
-        {
+        if (runtime_config != nullptr && !runtime_config->token2wav_model_dir.empty()) {
+            ctx_omni->token2wav_model_dir = runtime_config->token2wav_model_dir;
+        } else {
+            std::string gguf_root_dir = tts_bin_dir;
+            size_t last_slash = gguf_root_dir.find_last_of("/\\");
+            if (last_slash != std::string::npos) {
+                gguf_root_dir = gguf_root_dir.substr(0, last_slash);  // 获取 tts 的父目录
+            }
+            ctx_omni->token2wav_model_dir = gguf_root_dir + "/token2wav-gguf";
+
+            std::string encoder_test = ctx_omni->token2wav_model_dir + "/encoder.gguf";
             std::ifstream f(encoder_test);
             if (!f.good()) {
                 // 尝试备用路径 (本地开发用)
@@ -4344,13 +4346,18 @@ struct omni_context * omni_init(struct common_params * params, int media_type, b
                     return NULL;
                 }
             } else {
+                if (ctx_omni->strict_runtime_config) {
+                    device_vocoder = token2wav_device;
+                    print_with_timestamp("Token2Wav: profile requires vocoder on %s\n", device_vocoder.c_str());
+                } else {
 #ifdef GGML_USE_CUDA
-                device_vocoder = token2wav_device;
-                print_with_timestamp("Token2Wav: CUDA detected, vocoder using GPU (%s)\n", device_vocoder.c_str());
+                    device_vocoder = token2wav_device;
+                    print_with_timestamp("Token2Wav: CUDA detected, vocoder using GPU (%s)\n", device_vocoder.c_str());
 #else
-                device_vocoder = "cpu";
-                print_with_timestamp("Token2Wav: non-CUDA backend, vocoder using CPU for better performance\n");
+                    device_vocoder = "cpu";
+                    print_with_timestamp("Token2Wav: non-CUDA backend, vocoder using CPU for better performance\n");
 #endif
+                }
             }
             
             // 🔧 优先使用 prompt_bundle (setup_cache 路径)，否则 fallback 到 prompt_cache.gguf
@@ -4545,7 +4552,7 @@ struct omni_context * omni_init(struct common_params * params, int media_type, b
             print_with_timestamp("Token2Wav: 使用 C++ 实现\n");
         }
     }
-    ctx_omni->async = true;
+    ctx_omni->async = runtime_config != nullptr ? runtime_config->async_mode : true;
     
     // ==================== 初始化特殊 Token ID ====================
     // 从 LLM 词表中查找并缓存特殊 token ID

--- a/tools/omni/omni.cpp
+++ b/tools/omni/omni.cpp
@@ -2,7 +2,9 @@
 #include "vision.h"
 #include "audition.h"
 #include "omni.h"
+#include "runtime-profile.h"
 #include "token2wav/token2wav-impl.h"
+#include "tts-weight-layout.h"
 
 #include "llama.h"
 #include "common/common.h"
@@ -1418,7 +1420,7 @@ static std::mt19937* get_sampler_rng(struct common_sampler * smpl) {
 // 使用 ggml 后端进行计算，支持 CUDA 加速
 // forward(x): relu(linear1(x)) -> linear2
 // ==============================================================================
-bool projector_init(projector_model & model, const std::string & fname, bool use_cuda) {
+bool projector_init(projector_model & model, const std::string & fname, const std::string & device) {
     
     struct gguf_init_params params = {
         /*.no_alloc = */ true,
@@ -1431,19 +1433,16 @@ bool projector_init(projector_model & model, const std::string & fname, bool use
         return false;
     }
     
-#ifdef GGML_USE_CUDA
-    if (use_cuda) {
+    if (device == "cpu") {
+        model.backend = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, NULL);
+    } else if (!device.empty()) {
+        model.backend = ggml_backend_init_by_name(device.c_str(), NULL);
+    } else {
         model.backend = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_GPU, NULL);
         if (!model.backend) {
             model.backend = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, NULL);
         }
-    } else {
-        model.backend = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, NULL);
     }
-#else
-    (void)use_cuda;
-    model.backend = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, NULL);
-#endif
 
     if (!model.backend) {
         LOG_ERR("Projector: failed to init backend\n");
@@ -1525,6 +1524,10 @@ bool projector_init(projector_model & model, const std::string & fname, bool use
     
     model.initialized = true;
     return true;
+}
+
+bool projector_init(projector_model & model, const std::string & fname, bool use_cuda) {
+    return projector_init(model, fname, use_cuda ? std::string() : std::string("cpu"));
 }
 
 void projector_free(projector_model & model) {
@@ -1609,19 +1612,50 @@ std::vector<float> projector_forward(projector_model & model, const float * inpu
 }
 // ==============================================================================
 
+static void free_tts_raw_weights(struct omni_context * ctx_omni) {
+    free(ctx_omni->emb_code_weight);
+    ctx_omni->emb_code_weight = nullptr;
+    ctx_omni->emb_code_vocab_size = 0;
+    ctx_omni->emb_code_hidden_size = 0;
+    ctx_omni->emb_code_stored_as_transposed = false;
+
+    free(ctx_omni->emb_text_weight);
+    ctx_omni->emb_text_weight = nullptr;
+    ctx_omni->emb_text_vocab_size = 0;
+    ctx_omni->emb_text_hidden_size = 0;
+
+    free(ctx_omni->projector_semantic_linear1_weight);
+    ctx_omni->projector_semantic_linear1_weight = nullptr;
+    free(ctx_omni->projector_semantic_linear1_bias);
+    ctx_omni->projector_semantic_linear1_bias = nullptr;
+    free(ctx_omni->projector_semantic_linear2_weight);
+    ctx_omni->projector_semantic_linear2_weight = nullptr;
+    free(ctx_omni->projector_semantic_linear2_bias);
+    ctx_omni->projector_semantic_linear2_bias = nullptr;
+    ctx_omni->projector_semantic_input_dim = 0;
+    ctx_omni->projector_semantic_output_dim = 0;
+
+    free(ctx_omni->head_code_weight);
+    ctx_omni->head_code_weight = nullptr;
+    ctx_omni->head_code_hidden_size = 0;
+    ctx_omni->head_code_num_audio_tokens = 0;
+}
+
 // Load TTS weights from GGUF file
 bool load_tts_weights_from_gguf(struct omni_context * ctx_omni, const char * tts_model_path) {
 
-    auto ggml_tensor_to_f32 = [](const ggml_tensor * t, float * dst, int64_t n) {
+    auto ggml_tensor_to_f32 = [](const ggml_tensor * t, float * dst, int64_t n) -> bool {
         if (t->type == GGML_TYPE_F32) {
             memcpy(dst, t->data, (size_t)n * sizeof(float));
-            return;
+            return true;
         }
         const auto * traits = ggml_get_type_traits(t->type);
         if (traits && traits->to_float) {
             traits->to_float(t->data, dst, n);
+            return true;
         } else {
             LOG_ERR("TTS: no to_float converter for ggml type %d\n", (int)t->type);
+            return false;
         }
     };
 
@@ -1637,6 +1671,13 @@ bool load_tts_weights_from_gguf(struct omni_context * ctx_omni, const char * tts
         LOG_ERR("TTS: Failed to load GGUF file: %s\n", tts_model_path);
         return false;
     }
+
+    auto fail = [&]() -> bool {
+        free_tts_raw_weights(ctx_omni);
+        ggml_free(ctx_meta);
+        gguf_free(ctx_gguf);
+        return false;
+    };
     
     // Load emb_code.0.weight: (num_audio_tokens=6562, hidden_size=768)
     // This is used to convert audio token IDs to embeddings during decode phase
@@ -1664,9 +1705,7 @@ bool load_tts_weights_from_gguf(struct omni_context * ctx_omni, const char * tts
                 hidden_size = dim1;
             } else {
                 LOG_ERR("TTS: emb_code.0.weight has unexpected shape [%ld, %ld], expected [768, 6562] or [6562, 768]\n", dim0, dim1);
-                ggml_free(ctx_meta);
-                gguf_free(ctx_gguf);
-                return false;
+                return fail();
             }
             
             // Allocate memory and copy data
@@ -1674,16 +1713,12 @@ bool load_tts_weights_from_gguf(struct omni_context * ctx_omni, const char * tts
             ctx_omni->emb_code_weight = (float *)malloc(emb_code_size);
             if (!ctx_omni->emb_code_weight) {
                 LOG_ERR("TTS: Failed to allocate memory for emb_code.0.weight\n");
-                ggml_free(ctx_meta);
-                gguf_free(ctx_gguf);
-                return false;
+                return fail();
             }
             
-            // Copy/convert tensor data based on type
-            enum ggml_type emb_code_type = emb_code_tensor->type;
-            int64_t emb_code_elements = dim0 * dim1;
-            
-            ggml_tensor_to_f32(emb_code_tensor, ctx_omni->emb_code_weight, dim0 * dim1);
+            if (!ggml_tensor_to_f32(emb_code_tensor, ctx_omni->emb_code_weight, dim0 * dim1)) {
+                return fail();
+            }
             
             ctx_omni->emb_code_vocab_size = num_audio_tokens;  // 6562
             ctx_omni->emb_code_hidden_size = hidden_size;     // 768
@@ -1694,9 +1729,7 @@ bool load_tts_weights_from_gguf(struct omni_context * ctx_omni, const char * tts
             ctx_omni->emb_code_stored_as_transposed = false; // Data is always (vocab_size, hidden_size) in memory
         } else {
             LOG_ERR("TTS: Failed to get tensor %s from GGUF context\n", emb_code_name);
-            ggml_free(ctx_meta);
-            gguf_free(ctx_gguf);
-            return false;
+            return fail();
         }
     } else {
         LOG_ERR("TTS: Tensor %s not found in GGUF file (this is OK if using token IDs)\n", emb_code_name);
@@ -1740,15 +1773,11 @@ bool load_tts_weights_from_gguf(struct omni_context * ctx_omni, const char * tts
                 vocab_size = dim0;   // 152064
                 hidden_size = dim1;  // 768
                 LOG_ERR("TTS: emb_text.weight has unusual GGML shape, not handled\n");
-                ggml_free(ctx_meta);
-                gguf_free(ctx_gguf);
-                return false;
+                return fail();
             } else {
                 LOG_ERR("TTS: emb_text.weight has unexpected shape [%ld, %ld], expected ne=[%ld, %ld]\n", 
                        dim0, dim1, expected_hidden_size, expected_vocab_size);
-                ggml_free(ctx_meta);
-                gguf_free(ctx_gguf);
-                return false;
+                return fail();
             }
             
             // Allocate memory for the weight
@@ -1756,30 +1785,23 @@ bool load_tts_weights_from_gguf(struct omni_context * ctx_omni, const char * tts
             ctx_omni->emb_text_weight = (float *)malloc(emb_text_size);
             if (!ctx_omni->emb_text_weight) {
                 LOG_ERR("TTS: Failed to allocate memory for emb_text.weight\n");
-                ggml_free(ctx_meta);
-                gguf_free(ctx_gguf);
-                return false;
+                return fail();
             }
-            
-            // Copy/convert tensor data based on type
-            enum ggml_type emb_text_type = emb_text_tensor->type;
-            int64_t emb_text_elements = vocab_size * hidden_size;
-            
-            ggml_tensor_to_f32(emb_text_tensor, ctx_omni->emb_text_weight, vocab_size * hidden_size);
+
+            if (!ggml_tensor_to_f32(
+                    emb_text_tensor, ctx_omni->emb_text_weight, vocab_size * hidden_size)) {
+                return fail();
+            }
             
             ctx_omni->emb_text_vocab_size = vocab_size;   // 152064
             ctx_omni->emb_text_hidden_size = hidden_size;  // 768
         } else {
             LOG_ERR("TTS: Failed to get tensor %s from GGUF context\n", emb_text_name);
-            ggml_free(ctx_meta);
-            gguf_free(ctx_gguf);
-            return false;
+            return fail();
         }
     } else {
         LOG_ERR("TTS: Tensor %s not found in GGUF file\n", emb_text_name);
-        ggml_free(ctx_meta);
-        gguf_free(ctx_gguf);
-        return false;
+        return fail();
     }
     
     // Load projector_semantic weights
@@ -1864,16 +1886,7 @@ bool load_tts_weights_from_gguf(struct omni_context * ctx_omni, const char * tts
                     *projector_ptrs[i] = (float *)malloc(transposed_size);
                     if (!*projector_ptrs[i]) {
                         LOG_ERR("TTS: Failed to allocate memory for transposed %s\n", projector_names[i]);
-                        // Clean up
-                        for (int j = 0; j < i; j++) {
-                            if (*projector_ptrs[j]) {
-                                free(*projector_ptrs[j]);
-                                *projector_ptrs[j] = nullptr;
-                            }
-                        }
-                        ggml_free(ctx_meta);
-                        gguf_free(ctx_gguf);
-                        return false;
+                        return fail();
                     }
                     
                     // Transpose: src[out_dim][in_dim] -> dst[in_dim][out_dim]
@@ -1887,7 +1900,9 @@ bool load_tts_weights_from_gguf(struct omni_context * ctx_omni, const char * tts
                         }
                     } else {
                         std::vector<float> tmp(dim0 * dim1);
-                        ggml_tensor_to_f32(tensor, tmp.data(), dim0 * dim1);
+                        if (!ggml_tensor_to_f32(tensor, tmp.data(), dim0 * dim1)) {
+                            return fail();
+                        }
                         for (int64_t out = 0; out < out_dim; out++) {
                             for (int64_t in = 0; in < in_dim; in++) {
                                 dst_data[in * out_dim + out] = tmp[out * in_dim + in];
@@ -1900,36 +1915,19 @@ bool load_tts_weights_from_gguf(struct omni_context * ctx_omni, const char * tts
                     *projector_ptrs[i] = (float *)malloc(output_size);
                     if (!*projector_ptrs[i]) {
                         LOG_ERR("TTS: Failed to allocate memory for %s\n", projector_names[i]);
-                        for (int j = 0; j < i; j++) { free(*projector_ptrs[j]); *projector_ptrs[j] = nullptr; }
-                        ggml_free(ctx_meta); gguf_free(ctx_gguf); return false;
+                        return fail();
                     }
-                    ggml_tensor_to_f32(tensor, *projector_ptrs[i], num_elements);
+                    if (!ggml_tensor_to_f32(tensor, *projector_ptrs[i], num_elements)) {
+                        return fail();
+                    }
                 }
             } else {
                 LOG_ERR("TTS: Failed to get tensor %s from GGUF context\n", projector_names[i]);
-                // Clean up
-                for (int j = 0; j < i; j++) {
-                    if (*projector_ptrs[j]) {
-                        free(*projector_ptrs[j]);
-                        *projector_ptrs[j] = nullptr;
-                    }
-                }
-                ggml_free(ctx_meta);
-                gguf_free(ctx_gguf);
-                return false;
+                return fail();
             }
         } else {
             LOG_ERR("TTS: Tensor %s not found in GGUF file\n", projector_names[i]);
-            // Clean up
-            for (int j = 0; j < i; j++) {
-                if (*projector_ptrs[j]) {
-                    free(*projector_ptrs[j]);
-                    *projector_ptrs[j] = nullptr;
-                }
-            }
-            ggml_free(ctx_meta);
-            gguf_free(ctx_gguf);
-            return false;
+            return fail();
         }
     }
     
@@ -1946,164 +1944,78 @@ bool load_tts_weights_from_gguf(struct omni_context * ctx_omni, const char * tts
         if (head_code_tensor) {
             // head_code is Linear(hidden_size, num_audio_tokens, bias=False)
             // In PyTorch: weight shape is (num_audio_tokens, hidden_size) = [6562, 768]
-            // In GGUF: stored as (hidden_size, num_audio_tokens) = [768, 6562] (already transposed)
+            // GGML reports ne[0]=hidden_size and ne[1]=num_audio_tokens. Contiguous data is
+            // output-major: [num_audio_tokens][hidden_size].
             int64_t dim0 = head_code_tensor->ne[0];
             int64_t dim1 = (ggml_n_dims(head_code_tensor) > 1) ? head_code_tensor->ne[1] : 0;
             
             // Expected shape in GGUF: (hidden_size=768, num_audio_tokens=6562)
             int64_t expected_hidden_size = 768;
             int64_t expected_num_audio_tokens = 6562;
-            
-            // Allocate memory for weight: (hidden_size, num_audio_tokens) = [768, 6562]
+
+            const int64_t n_dims = ggml_n_dims(head_code_tensor);
+            const int64_t n_elements = ggml_nelements(head_code_tensor);
+            if (!omni::has_supported_head_code_weight_layout(
+                    n_dims, n_elements, dim0, dim1,
+                    expected_hidden_size, expected_num_audio_tokens)) {
+                LOG_ERR("TTS: head_code.0.weight has unexpected shape: n_dims=%ld, nelements=%ld, "
+                        "ne=[%ld, %ld], expected a 2D tensor with ne=[%ld, %ld] or [%ld, %ld]\n",
+                        n_dims, n_elements, dim0, dim1,
+                        expected_hidden_size, expected_num_audio_tokens,
+                        expected_num_audio_tokens, expected_hidden_size);
+                return fail();
+            }
+
+            // Allocate the normalized output-major weight: [num_audio_tokens][hidden_size].
             size_t head_code_size = expected_hidden_size * expected_num_audio_tokens * sizeof(float);
             ctx_omni->head_code_weight = (float *)malloc(head_code_size);
             if (!ctx_omni->head_code_weight) {
                 LOG_ERR("TTS: Failed to allocate memory for head_code.0.weight\n");
-                // Clean up already loaded weights
-                if (ctx_omni->emb_text_weight) {
-                    free(ctx_omni->emb_text_weight);
-                    ctx_omni->emb_text_weight = nullptr;
-                }
-                for (int j = 0; j < 4; j++) {
-                    if (*projector_ptrs[j]) {
-                        free(*projector_ptrs[j]);
-                        *projector_ptrs[j] = nullptr;
-                    }
-                }
-                ggml_free(ctx_meta);
-                gguf_free(ctx_gguf);
-                return false;
+                return fail();
             }
-            
-            // CRITICAL FIX: The conversion script transposes head_code weight to [768, 6562] before saving,
-            // but the GGUF metadata shape may still be [6562, 768] due to how add_tensor works.
-            // We need to detect the actual data format by testing both layouts.
-            // 
-            // Strategy: Try both formats and see which one produces correct logits.
-            // But a simpler approach: Since the conversion script always transposes to [768, 6562],
-            // and the actual data is stored in that format, we should always use the data as-is
-            // (treating it as [768, 6562]) regardless of metadata shape.
-            //
-            // However, to be safe, we'll check: if metadata says [6562, 768], the data might be
-            // in that format (old conversion) or already transposed (new conversion).
-            // We'll use a heuristic: check if the first few values match what we expect.
-            
-            const float * src_data = (const float *)head_code_tensor->data;
-            bool need_transpose = false;
-            
-            // CRITICAL FIX: Based on conversion script analysis, the script always transposes
-            // head_code to [768, 6562] before saving. So the actual data is always [768, 6562],
-            // regardless of metadata shape. We should NOT transpose based on metadata.
-            //
-            // However, if metadata says [6562, 768], it might be an old conversion that didn't transpose.
-            // We'll use a simple heuristic: if metadata says [6562, 768], assume data needs transpose.
-            // If metadata says [768, 6562], assume data is already correct.
-            
-            if (dim0 == expected_hidden_size && dim1 == expected_num_audio_tokens) {
-                // Metadata says (768, 6562) - data should already be in correct format
-                need_transpose = false;
-            } else if (dim0 == expected_num_audio_tokens && dim1 == expected_hidden_size) {
-                // Metadata says (6562, 768) - but conversion script may have already transposed the data
-                // We need to check: if conversion script transposed, data is actually [768, 6562] and we should NOT transpose
-                // If conversion script didn't transpose, data is [6562, 768] and we SHOULD transpose
-                //
-                // Since the conversion script ALWAYS transposes (line 351: W_transposed = W.T),
-                // the data is always [768, 6562] regardless of metadata.
-                // So we should NOT transpose.
-                need_transpose = false;  // CRITICAL FIX: Don't transpose, data is already [768, 6562]
-            } else {
-                LOG_ERR("TTS: head_code.0.weight has unexpected shape [%ld, %ld], expected [%d, %d] or [%d, %d]\n",
-                       dim0, dim1, expected_hidden_size, expected_num_audio_tokens, expected_num_audio_tokens, expected_hidden_size);
-                // Clean up
-                free(ctx_omni->head_code_weight);
-                ctx_omni->head_code_weight = nullptr;
-                if (ctx_omni->emb_text_weight) {
-                    free(ctx_omni->emb_text_weight);
-                    ctx_omni->emb_text_weight = nullptr;
-                }
-                for (int j = 0; j < 4; j++) {
-                    if (*projector_ptrs[j]) {
-                        free(*projector_ptrs[j]);
-                        *projector_ptrs[j] = nullptr;
-                    }
-                }
-                ggml_free(ctx_meta);
-                gguf_free(ctx_gguf);
-                return false;
-            }
-            
-            // Check tensor type and copy/convert accordingly
-            // ⚡ 优化：转置存储为 [6562, 768]，使每个output token的权重连续存储
-            // 这样在计算logits时可以用高效的向量点积
-            // 原始: weight[j * 6562 + i] = W[j, i]  (j=hidden, i=output)
-            // 转置后: weight[i * 768 + j] = W[i, j] (i=output, j=hidden)
+
+            const bool has_standard_layout = dim0 == expected_hidden_size && dim1 == expected_num_audio_tokens;
+
             enum ggml_type tensor_type = head_code_tensor->type;
             int64_t total_elements = expected_hidden_size * expected_num_audio_tokens;
-            
-            print_with_timestamp("TTS: head_code shape: dim0=%ld, dim1=%ld, will transpose to [%ld, %ld]\n", 
-                                dim0, dim1, expected_num_audio_tokens, expected_hidden_size);
-            
-            // Transpose: [hidden, audio_tokens] -> [audio_tokens, hidden]
+
+            const float * source = nullptr;
+            std::vector<float> converted;
             if (tensor_type == GGML_TYPE_F32) {
-                const float * src_data = (const float *)head_code_tensor->data;
-                for (int64_t i = 0; i < expected_num_audio_tokens; ++i) {
-                    for (int64_t j = 0; j < expected_hidden_size; ++j) {
-                        ctx_omni->head_code_weight[i * expected_hidden_size + j] = src_data[j * expected_num_audio_tokens + i];
-                    }
-                }
+                source = static_cast<const float *>(head_code_tensor->data);
             } else {
-                std::vector<float> tmp(expected_hidden_size * expected_num_audio_tokens);
-                ggml_tensor_to_f32(head_code_tensor, tmp.data(), expected_hidden_size * expected_num_audio_tokens);
-                for (int64_t i = 0; i < expected_num_audio_tokens; ++i) {
-                    for (int64_t j = 0; j < expected_hidden_size; ++j) {
-                        ctx_omni->head_code_weight[i * expected_hidden_size + j] = tmp[j * expected_num_audio_tokens + i];
-                    }
+                converted.resize(total_elements);
+                if (!ggml_tensor_to_f32(head_code_tensor, converted.data(), total_elements)) {
+                    return fail();
                 }
+                source = converted.data();
             }
-            
+
+            if (!omni::copy_head_code_weight_to_output_major(
+                    source, dim0, dim1, expected_hidden_size, expected_num_audio_tokens,
+                    ctx_omni->head_code_weight)) {
+                LOG_ERR("TTS: failed to normalize head_code.0.weight layout\n");
+                return fail();
+            }
+
+            print_with_timestamp("TTS: head_code shape: dim0=%ld, dim1=%ld, source_layout=%s, normalized=[%ld, %ld]\n",
+                                 dim0, dim1, has_standard_layout ? "output-major" : "legacy-hidden-major",
+                                 expected_num_audio_tokens, expected_hidden_size);
+
             ctx_omni->head_code_hidden_size = expected_hidden_size;
             ctx_omni->head_code_num_audio_tokens = expected_num_audio_tokens;
-            
-            // 🔍 调试：验证加载的数据
-            // Python weight[0, 0:5] = [0.01385498, -0.01647949, 0.0111084, -0.01367188, -0.01141357]
-            // C++ head_code_weight[0..4] 应该和 Python 一致
+
             print_with_timestamp("TTS: head_code loaded, verifying first few values:\n");
-            print_with_timestamp("  head_code_weight[0] = %.8f (expect ~0.01385498)\n", ctx_omni->head_code_weight[0]);
-            print_with_timestamp("  head_code_weight[1] = %.8f (expect ~-0.01647949)\n", ctx_omni->head_code_weight[1]);
-            print_with_timestamp("  head_code_weight[768] = %.8f (this is weight[1, 0], expect ~0.04150391)\n", ctx_omni->head_code_weight[768]);
+            print_with_timestamp("  head_code_weight[0] = %.8f\n", ctx_omni->head_code_weight[0]);
+            print_with_timestamp("  head_code_weight[1] = %.8f\n", ctx_omni->head_code_weight[1]);
+            print_with_timestamp("  head_code_weight[768] = %.8f\n", ctx_omni->head_code_weight[768]);
         } else {
             LOG_ERR("TTS: Failed to get tensor %s from GGUF context\n", head_code_name);
-            // Clean up
-            if (ctx_omni->emb_text_weight) {
-                free(ctx_omni->emb_text_weight);
-                ctx_omni->emb_text_weight = nullptr;
-            }
-            for (int j = 0; j < 4; j++) {
-                if (*projector_ptrs[j]) {
-                    free(*projector_ptrs[j]);
-                    *projector_ptrs[j] = nullptr;
-                }
-            }
-            ggml_free(ctx_meta);
-            gguf_free(ctx_gguf);
-            return false;
+            return fail();
         }
     } else {
         LOG_ERR("TTS: Tensor %s not found in GGUF file\n", head_code_name);
-        // Clean up
-        if (ctx_omni->emb_text_weight) {
-            free(ctx_omni->emb_text_weight);
-            ctx_omni->emb_text_weight = nullptr;
-        }
-        for (int j = 0; j < 4; j++) {
-            if (*projector_ptrs[j]) {
-                free(*projector_ptrs[j]);
-                *projector_ptrs[j] = nullptr;
-            }
-        }
-        ggml_free(ctx_meta);
-        gguf_free(ctx_gguf);
-        return false;
+        return fail();
     }
     
     ggml_free(ctx_meta);
@@ -3888,6 +3800,8 @@ struct DuplexPrefillPacket {
     std::vector<std::vector<float>> vision_embed;  // [0]=overview, [1..]=slices
     std::vector<float>              audio_embed;
     int                             index = 0;
+    double                          encoder_ms = 0;
+    bool                            modalities_ok = true;
 };
 
 struct DuplexDecodeReq {
@@ -3895,6 +3809,8 @@ struct DuplexDecodeReq {
     int                round_idx = -1;
     std::atomic<bool>  done{false};
     std::atomic<bool>  ok{false};
+    double             encoder_ms = 0;
+    double             ttft_ms    = 0;
 };
 
 // Duplex Stage 3: 特殊 token 的 embedding 查表。
@@ -3977,6 +3893,42 @@ void print_with_timestamp(const char* format, ...)
     va_end(args);
 }
 
+static std::string omni_runtime_module_device(const omni::effective_runtime_config * config,
+                                              const std::string & module) {
+    if (config == nullptr) {
+        return {};
+    }
+    for (const auto & placement : config->placements) {
+        if (placement.module == module) {
+            return placement.device;
+        }
+    }
+    return {};
+}
+
+static bool configure_llama_model_device(llama_model_params & model_params,
+                                         const std::string & device,
+                                         std::vector<ggml_backend_dev_t> & device_storage) {
+    if (device.empty()) {
+        return true;
+    }
+    ggml_backend_dev_t backend_device = device == "cpu"
+                                            ? ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU)
+                                            : ggml_backend_dev_by_name(device.c_str());
+    if (backend_device == nullptr) {
+        LOG_ERR("Omni: unable to resolve model device '%s'\n", device.c_str());
+        return false;
+    }
+    device_storage = { backend_device, nullptr };
+    model_params.devices = device_storage.data();
+    model_params.split_mode = LLAMA_SPLIT_MODE_NONE;
+    model_params.main_gpu = 0;
+    if (device == "cpu") {
+        model_params.n_gpu_layers = 0;
+    }
+    return true;
+}
+
 static struct llama_model * llama_init(common_params * params, std::string model_path) {
     llama_backend_init();
     llama_numa_init(params->numa);
@@ -3992,16 +3944,26 @@ static struct llama_model * llama_init(common_params * params, std::string model
 
 // TTS专用模型加载 - 支持独立的GPU层数设置
 // 通过环境变量 TTS_GPU_LAYERS 控制，-1 表示使用与LLM相同的设置
-static struct llama_model * llama_init_tts(common_params * params, std::string model_path, int n_gpu_layers_override = -1) {
+static struct llama_model * llama_init_tts(common_params * params, std::string model_path,
+                                           int n_gpu_layers_override = -1,
+                                           const std::string & device = {}) {
     llama_backend_init();
     llama_numa_init(params->numa);
     
     llama_model_params model_params = common_model_params_to_llama(*params);
     model_params.partial_load = true;  // TTS GGUF contains extra tensors (emb_code, head_code, projector_*) beyond standard llama
 
+    std::vector<ggml_backend_dev_t> device_storage;
+    if (!configure_llama_model_device(model_params, device, device_storage)) {
+        return NULL;
+    }
+
     // 如果指定了override值(>=0)，使用它；否则保持与LLM相同的设置
     if (n_gpu_layers_override >= 0) {
         model_params.n_gpu_layers = n_gpu_layers_override;
+    }
+    if (device == "cpu") {
+        model_params.n_gpu_layers = 0;
     }
     
     llama_model * model = llama_load_model_from_file(model_path.c_str(), model_params);
@@ -4015,7 +3977,10 @@ static struct llama_model * llama_init_tts(common_params * params, std::string m
 struct omni_context * omni_init(struct common_params * params, int media_type, bool use_tts, std::string tts_bin_dir,
                                 int tts_gpu_layers, const std::string & token2wav_device, bool duplex_mode,
                                 llama_model * existing_model, llama_context * existing_ctx,
-                                const std::string & base_output_dir) {
+                                const std::string & base_output_dir,
+                                const omni::effective_runtime_config * runtime_config,
+                                bool strict_runtime_config,
+                                int token2wav_threads) {
     // process the prompt
     print_with_timestamp("=== omni_init start\n");
     // if (params->prompt.empty() && params->interactive == false) {
@@ -4029,6 +3994,15 @@ struct omni_context * omni_init(struct common_params * params, int media_type, b
     ctx_omni->media_type = media_type;
     ctx_omni->use_tts = use_tts;
     ctx_omni->duplex_mode = duplex_mode;
+    ctx_omni->strict_runtime_config = strict_runtime_config;
+    if (runtime_config != nullptr) {
+        token2wav_threads = runtime_config->token2wav_threads;
+    }
+    if (token2wav_threads <= 0) {
+        LOG_ERR("%s: token2wav_threads must be positive\n", __func__);
+        delete ctx_omni;
+        return NULL;
+    }
     ctx_omni->base_output_dir = base_output_dir;  // 🔧 [多实例支持] 设置可配置的输出目录
     print_with_timestamp("media_type = %d, duplex_mode = %d, base_output_dir = %s\n", media_type, duplex_mode, base_output_dir.c_str());
     // 🔧 [对齐 Python MiniCPM-o-4_5-latest] prompt 格式
@@ -4128,13 +4102,13 @@ struct omni_context * omni_init(struct common_params * params, int media_type, b
     ctx_omni->ctx_llama = ctx_llama;
     ctx_omni->model = model;
     ctx_omni->ctx_sampler = sampler;
-
     if (use_tts && !params->tts_model.empty()) {
         print_with_timestamp("=== omni_init: loading TTS model\n");
         // 使用TTS专用的模型加载函数，支持独立的GPU层数设置
         // tts_gpu_layers 从 omni_init 参数传入，-1 表示使用与LLM相同的设置
         print_with_timestamp("TTS model: loading with n_gpu_layers=%d\n", tts_gpu_layers);
-        llama_model * tts_model = llama_init_tts(params, params->tts_model, tts_gpu_layers);
+        const std::string tts_device = omni_runtime_module_device(runtime_config, "tts");
+        llama_model * tts_model = llama_init_tts(params, params->tts_model, tts_gpu_layers, tts_device);
         if (tts_model == NULL) {
             LOG_ERR("%s: error: failed to init TTS model from %s\n", __func__, params->tts_model.c_str());
             llama_free(ctx_llama);
@@ -4196,15 +4170,23 @@ struct omni_context * omni_init(struct common_params * params, int media_type, b
             return NULL;
         }
         print_with_timestamp("TTS: weights loaded successfully\n");
-        
-        // Load Projector Semantic from GGUF file
-        // 路径: {tts_bin_dir}/MiniCPM-o-4_5-projector-F16.gguf
-        std::string projector_path = tts_bin_dir + "/MiniCPM-o-4_5-projector-F16.gguf";
+        // Load Projector Semantic from the profile-provided path when available.
+        std::string projector_path = params->projector_model.empty()
+                                          ? tts_bin_dir + "/MiniCPM-o-4_5-projector-F16.gguf"
+                                          : params->projector_model;
         print_with_timestamp("Projector: loading from %s\n", projector_path.c_str());
-        if (projector_init(ctx_omni->projector, projector_path, true)) {
+        const std::string projector_device = omni_runtime_module_device(runtime_config, "projector");
+        if (projector_init(ctx_omni->projector, projector_path,
+                           projector_device.empty() ? std::string() : projector_device)) {
             print_with_timestamp("Projector: loaded successfully\n");
         } else {
             print_with_timestamp("Projector: failed to load, will use fallback implementation\n");
+            if (ctx_omni->strict_runtime_config) {
+                LOG_ERR("%s: strict runtime config requires the requested Projector backend\n", __func__);
+                projector_free(ctx_omni->projector);
+                omni_free(ctx_omni);
+                return NULL;
+            }
         }
     }
 
@@ -4224,7 +4206,11 @@ struct omni_context * omni_init(struct common_params * params, int media_type, b
         delete ctx_omni;
         return NULL;
     }
-    ctx_omni->ctx_audio = audition_init(params->apm_model.c_str(), audition_context_params{true, GGML_LOG_LEVEL_INFO});
+    const std::string audio_device = omni_runtime_module_device(runtime_config, "audio");
+    ctx_omni->ctx_audio = audition_init(
+        params->apm_model.c_str(),
+        audition_context_params{audio_device != "cpu", GGML_LOG_LEVEL_INFO,
+                                audio_device.empty() || audio_device == "cpu" ? nullptr : audio_device.c_str()});
     print_with_timestamp("APM: init from %s\n", params->apm_model.c_str());
     if (ctx_omni->ctx_audio == nullptr) {
         LOG_ERR("%s: error: failed to init audition model from %s\n", __func__, params->apm_model.c_str());
@@ -4240,14 +4226,23 @@ struct omni_context * omni_init(struct common_params * params, int media_type, b
         delete ctx_omni;
         return NULL;
     }
-
     ctx_omni->n_past = 0;
     
     if (media_type == 2) {
         LOG_INF("init vision....");
         const char * vision_path = ctx_omni->params->vpm_model.c_str();
-        auto * ctx_vision = vision_init(vision_path, vision_context_params{true, GGML_LOG_LEVEL_INFO, nullptr});
+        const std::string vision_device = omni_runtime_module_device(runtime_config, "vision");
+        auto * ctx_vision = vision_init(
+            vision_path,
+            vision_context_params{vision_device != "cpu", GGML_LOG_LEVEL_INFO, nullptr,
+                                  vision_device.empty() || vision_device == "cpu" ? nullptr : vision_device.c_str()});
         ctx_omni->ctx_vision = ctx_vision;
+
+        if (ctx_vision == nullptr && ctx_omni->strict_runtime_config) {
+            LOG_ERR("%s: strict runtime config requires the requested Vision backend\n", __func__);
+            omni_free(ctx_omni);
+            return NULL;
+        }
 
         // 🔧 [batch encode 开关] 由 common_params 控制（默认关闭）
         if (ctx_vision) {
@@ -4266,7 +4261,6 @@ struct omni_context * omni_init(struct common_params * params, int media_type, b
             }
         }
     }
-    
     ctx_omni->llm_thread_info = new LLMThreadInfo(1000);
     if (ctx_omni->use_tts) {
         LOG_INF("init tts....");
@@ -4343,6 +4337,12 @@ struct omni_context * omni_init(struct common_params * params, int media_type, b
             if (voc_dev_env) {
                 device_vocoder = voc_dev_env;
                 print_with_timestamp("Token2Wav: vocoder device overridden by OMNI_VOC_DEVICE=%s\n", voc_dev_env);
+                if (ctx_omni->strict_runtime_config && device_vocoder != token2wav_device) {
+                    LOG_ERR("%s: strict runtime config rejects OMNI_VOC_DEVICE=%s because Token2Wav placement is %s\n",
+                            __func__, voc_dev_env, token2wav_device.c_str());
+                    omni_free(ctx_omni);
+                    return NULL;
+                }
             } else {
 #ifdef GGML_USE_CUDA
                 device_vocoder = token2wav_device;
@@ -4402,21 +4402,24 @@ struct omni_context * omni_init(struct common_params * params, int media_type, b
 
             init_ok = ctx_omni->token2wav_session->init_from_prompt_cache_gguf(
                     encoder_gguf, flow_matching_gguf, flow_extra_gguf, prompt_cache_gguf,
-                    vocoder_gguf, device_token2mel, device_vocoder, 5, 1.0f, coreml_model_path);
+                    vocoder_gguf, device_token2mel, device_vocoder, 5, 1.0f, coreml_model_path,
+                    token2wav_threads,
+                    omni::flow::token2wav_device_fallback_allowed(ctx_omni->strict_runtime_config));
             if (!init_ok && use_prompt_bundle) {
                 print_with_timestamp("Token2Wav: prompt_cache failed, fallback to prompt_bundle from %s\n", prompt_bundle_dir.c_str());
                 init_ok = ctx_omni->token2wav_session->init_from_prompt_bundle(
                         encoder_gguf, flow_matching_gguf, flow_extra_gguf, prompt_bundle_dir,
-                        vocoder_gguf, device_token2mel, device_vocoder, 5, 1.0f);
+                        vocoder_gguf, device_token2mel, device_vocoder, 5, 1.0f, "", token2wav_threads,
+                        omni::flow::token2wav_device_fallback_allowed(ctx_omni->strict_runtime_config));
             }
             // Fallback to CPU
-            if (!init_ok) {
+            if (!init_ok && omni::flow::token2wav_device_fallback_allowed(ctx_omni->strict_runtime_config)) {
                 print_with_timestamp("Token2Wav: GPU init failed, trying CPU mode...\n");
                 ctx_omni->token2wav_session.reset();
                 ctx_omni->token2wav_session = std::make_unique<omni::flow::Token2WavSession>();
                 init_ok = ctx_omni->token2wav_session->init_from_prompt_cache_gguf(
                         encoder_gguf, flow_matching_gguf, flow_extra_gguf, prompt_cache_gguf,
-                        vocoder_gguf, "cpu", "cpu", 5, 1.0f);
+                        vocoder_gguf, "cpu", "cpu", 5, 1.0f, "", token2wav_threads);
             }
             
             if (init_ok) {
@@ -4434,7 +4437,12 @@ struct omni_context * omni_init(struct common_params * params, int media_type, b
         } else {
             print_with_timestamp("Token2Wav: model files not found in %s\n", ctx_omni->token2wav_model_dir.c_str());
         }
-        
+
+        if (ctx_omni->strict_runtime_config && !ctx_omni->token2wav_initialized) {
+            LOG_ERR("%s: strict runtime config requires Token2Wav on the requested device\n", __func__);
+            omni_free(ctx_omni);
+            return NULL;
+        }
         // ==================== 初始化 Python Token2Wav ====================
         // 🔧 默认使用 Python Token2Wav（精度更高）
         // 设置 Python T2W 脚本目录和模型目录
@@ -4774,35 +4782,7 @@ void omni_free(struct omni_context * ctx_omni) {
             tts_condition_graph_free(ctx_omni);
         }
         
-        // Free TTS weights
-        if (ctx_omni->emb_code_weight) {
-            free(ctx_omni->emb_code_weight);
-            ctx_omni->emb_code_weight = nullptr;
-        }
-        if (ctx_omni->emb_text_weight) {
-            free(ctx_omni->emb_text_weight);
-            ctx_omni->emb_text_weight = nullptr;
-        }
-        if (ctx_omni->projector_semantic_linear1_weight) {
-            free(ctx_omni->projector_semantic_linear1_weight);
-            ctx_omni->projector_semantic_linear1_weight = nullptr;
-        }
-        if (ctx_omni->projector_semantic_linear1_bias) {
-            free(ctx_omni->projector_semantic_linear1_bias);
-            ctx_omni->projector_semantic_linear1_bias = nullptr;
-        }
-        if (ctx_omni->projector_semantic_linear2_weight) {
-            free(ctx_omni->projector_semantic_linear2_weight);
-            ctx_omni->projector_semantic_linear2_weight = nullptr;
-        }
-        if (ctx_omni->projector_semantic_linear2_bias) {
-            free(ctx_omni->projector_semantic_linear2_bias);
-            ctx_omni->projector_semantic_linear2_bias = nullptr;
-        }
-        if (ctx_omni->head_code_weight) {
-            free(ctx_omni->head_code_weight);
-            ctx_omni->head_code_weight = nullptr;
-        }
+        free_tts_raw_weights(ctx_omni);
         
         // Free C++ Token2Wav session
         if (ctx_omni->token2wav_session) {
@@ -8683,6 +8663,15 @@ void t2w_thread_func_python(struct omni_context * ctx_omni, common_params *param
         }
         
         lock.unlock();
+
+        if (ctx_omni->tts_token_output_cb) {
+            if (!new_tokens.empty()) {
+                ctx_omni->tts_token_output_cb(new_tokens.data(), new_tokens.size(), false);
+            }
+            if (is_final) {
+                ctx_omni->tts_token_output_cb(nullptr, 0, true);
+            }
+        }
         
         if (new_tokens.empty() && !is_chunk_end && !is_final) {
             continue;
@@ -8983,6 +8972,15 @@ void t2w_thread_func_cpp(struct omni_context * ctx_omni, common_params *params) 
         }
         
         lock.unlock();
+
+        if (ctx_omni->tts_token_output_cb) {
+            if (!new_tokens.empty()) {
+                ctx_omni->tts_token_output_cb(new_tokens.data(), new_tokens.size(), false);
+            }
+            if (is_final) {
+                ctx_omni->tts_token_output_cb(nullptr, 0, true);
+            }
+        }
         
         if (new_tokens.empty() && !is_chunk_end && !is_final) {
             continue;
@@ -9374,8 +9372,12 @@ static void duplex_encoder_thread_func(omni_context * ctx_omni, common_params * 
         DuplexPrefillPacket * packet = new DuplexPrefillPacket();
         packet->index = req->index;
 
-        const bool has_img = !req->img_fname.empty() && ctx_omni->ctx_vision != nullptr;
-        const bool has_aud = !req->aud_fname.empty();
+        const bool wants_img = !req->img_fname.empty();
+        const bool wants_aud = !req->aud_fname.empty();
+        const bool has_img   = wants_img && ctx_omni->ctx_vision != nullptr;
+        const bool has_aud   = wants_aud && ctx_omni->ctx_audio != nullptr;
+        bool       vpm_ok    = !wants_img;
+        bool       apm_ok    = !wants_aud;
 
         auto t_enc_begin = std::chrono::high_resolution_clock::now();
 
@@ -9398,6 +9400,9 @@ static void duplex_encoder_thread_func(omni_context * ctx_omni, common_params * 
                 LOG_ERR("Duplex encoder: vision encode failed for %s\n",
                         req->img_fname.c_str());
                 packet->vision_embed.clear();
+                vpm_ok = false;
+            } else {
+                vpm_ok = !packet->vision_embed.empty();
             }
             auto t1 = std::chrono::high_resolution_clock::now();
             return std::chrono::duration<double, std::milli>(t1 - t0).count();
@@ -9414,9 +9419,14 @@ static void duplex_encoder_thread_func(omni_context * ctx_omni, common_params * 
                 std::memcpy(packet->audio_embed.data(), audio_embeds->embed,
                             packet->audio_embed.size() * sizeof(float));
                 omni_embed_free(audio_embeds);
+                apm_ok = true;
             } else {
                 LOG_WRN("Duplex encoder: audio encode returned empty for %s\n",
                         req->aud_fname.c_str());
+                if (audio_embeds != nullptr) {
+                    omni_embed_free(audio_embeds);
+                }
+                apm_ok = false;
             }
             auto t1 = std::chrono::high_resolution_clock::now();
             return std::chrono::duration<double, std::milli>(t1 - t0).count();
@@ -9436,6 +9446,8 @@ static void duplex_encoder_thread_func(omni_context * ctx_omni, common_params * 
 
         auto t_enc_end = std::chrono::high_resolution_clock::now();
         double enc_wall_ms = std::chrono::duration<double, std::milli>(t_enc_end - t_enc_begin).count();
+        packet->encoder_ms = enc_wall_ms;
+        packet->modalities_ok = !ctx_omni->strict_runtime_config || (vpm_ok && apm_ok);
 
         print_with_timestamp(
             "[prof] encoder index=%d VPM=%.1fms APM=%.1fms wall=%.1fms parallel_savings=%.1fms\n",
@@ -9796,7 +9808,7 @@ static void duplex_do_prefill_one(omni_context * ctx_omni, common_params * param
 // 返回 false 表示内部异常或被 break 打断。
 // ---------------------------------------------------------------------------
 static bool duplex_do_decode(omni_context * ctx_omni, common_params * params,
-                             const std::string & debug_dir, int round_idx) {
+                             const std::string & debug_dir, int round_idx, double * ttft_ms) {
     // ---- 轮次同步（与老 stream_decode 对齐） ----
     if (round_idx >= 0) {
         if (ctx_omni->simplex_round_idx != round_idx) {
@@ -9864,6 +9876,10 @@ static bool duplex_do_decode(omni_context * ctx_omni, common_params * params,
             ctx_omni->text_streaming = false;
             ctx_omni->text_cv.notify_all();
         }
+        if (ttft_ms != nullptr) {
+            *ttft_ms = std::chrono::duration<double, std::milli>(
+                           std::chrono::high_resolution_clock::now() - t_dec_begin).count();
+        }
         return true;
     }
 
@@ -9902,6 +9918,11 @@ static bool duplex_do_decode(omni_context * ctx_omni, common_params * params,
             tmp = llama_loop_with_hidden_and_token(
                 ctx_omni, params, ctx_omni->ctx_sampler,
                 ctx_omni->n_past, hidden_states, sampled_token);
+
+            if (ttft_ms != nullptr && *ttft_ms == 0.0) {
+                *ttft_ms = std::chrono::duration<double, std::milli>(
+                               std::chrono::high_resolution_clock::now() - t_dec_begin).count();
+            }
 
             total_tokens_generated++;
 
@@ -10152,6 +10173,7 @@ static void duplex_llm_thread_func(omni_context * ctx_omni, common_params * para
         //   - chunk 0（老路径 prefill）：in_flight=0，直接 decode
         //   - chunk N (N≥1)：in_flight ≥ 1，必有 packet 在途；
         //     wait prefill_queue 非空，消费队头（encoder 是单线程 FIFO 顺序）
+        bool prefill_ok = true;
         if (dup->in_flight_prefill.load() > 0) {
             DuplexPrefillPacket * packet = nullptr;
             {
@@ -10170,9 +10192,13 @@ static void duplex_llm_thread_func(omni_context * ctx_omni, common_params * para
             dup->llm_cv.notify_all();  // encoder 在等 prefill_queue 腾位
 
             if (packet) {
-                // Stage 3: 先试 fused（1 次 llama_decode），失败回退到老 5-7 段路径。
-                if (!duplex_do_prefill_one_fused(ctx_omni, params, packet, hidden_size)) {
-                    duplex_do_prefill_one(ctx_omni, params, packet, hidden_size);
+                decode_req->encoder_ms = packet->encoder_ms;
+                prefill_ok = packet->modalities_ok;
+                if (prefill_ok) {
+                    // Stage 3: 先试 fused（1 次 llama_decode），失败回退到老 5-7 段路径。
+                    if (!duplex_do_prefill_one_fused(ctx_omni, params, packet, hidden_size)) {
+                        duplex_do_prefill_one(ctx_omni, params, packet, hidden_size);
+                    }
                 }
                 delete packet;
                 dup->in_flight_prefill.fetch_sub(1);
@@ -10181,9 +10207,9 @@ static void duplex_llm_thread_func(omni_context * ctx_omni, common_params * para
         }
 
         // ---- Phase 2: decode ----
-        if (!ctx_omni->break_event.load()) {
+        if (!ctx_omni->break_event.load() && prefill_ok) {
             bool ok = duplex_do_decode(ctx_omni, params,
-                                       decode_req->debug_dir, decode_req->round_idx);
+                                       decode_req->debug_dir, decode_req->round_idx, &decode_req->ttft_ms);
             decode_req->ok.store(ok);
         } else {
             decode_req->ok.store(false);
@@ -10267,6 +10293,8 @@ static bool duplex_decode(omni_context * ctx_omni,
             return req.done.load() || !dup->running.load();
         });
     }
+    ctx_omni->last_duplex_encoder_ms.store(req.encoder_ms);
+    ctx_omni->last_duplex_ttft_ms.store(req.ttft_ms);
     return req.ok.load();
 }
 
@@ -10399,6 +10427,13 @@ bool stream_prefill(struct omni_context * ctx_omni, std::string aud_fname, std::
                                 ctx_omni->params->n_batch, &ctx_omni->n_past);
                 omni_embed_free(audio_embeds);
             } else {
+                if (audio_embeds != nullptr) {
+                    omni_embed_free(audio_embeds);
+                }
+                if (ctx_omni->strict_runtime_config) {
+                    LOG_ERR("%s: strict runtime config could not encode the reference audio\n", __func__);
+                    return false;
+                }
             }
             
             // Step 3: 评估 suffix (assistant_prompt，包含 <|audio_end|><|im_end|>)
@@ -11426,10 +11461,21 @@ struct DuplexSession {
 
     std::atomic<int64_t> frame_id_counter{0};
     std::atomic<int>     in_flight{0};   // push 但还未出 done_results 的帧数
+    std::mutex           in_flight_mtx;
+    std::condition_variable in_flight_cv;
 
     std::thread prefill_worker;
     std::thread decode_worker;
 };
+
+static void duplex_session_complete_frames(DuplexSession * sess, int count = 1) {
+    if (count <= 0) return;
+    {
+        std::lock_guard<std::mutex> lock(sess->in_flight_mtx);
+        sess->in_flight.fetch_sub(count);
+    }
+    sess->in_flight_cv.notify_all();
+}
 
 static void duplex_session_prefill_worker_func(omni_context * ctx_omni) {
     DuplexSession * sess = ctx_omni->duplex_session;
@@ -11440,7 +11486,7 @@ static void duplex_session_prefill_worker_func(omni_context * ctx_omni) {
             sess->pending_cv.wait(lk, [&]{
                 return !sess->pending_frames.empty() || !sess->running.load();
             });
-            if (!sess->running.load() && sess->pending_frames.empty()) break;
+            if (!sess->running.load()) break;
             pf = std::move(sess->pending_frames.front());
             sess->pending_frames.pop();
         }
@@ -11451,15 +11497,29 @@ static void duplex_session_prefill_worker_func(omni_context * ctx_omni) {
         bool ok = stream_prefill(ctx_omni, pf.frame.aud_fname, pf.frame.img_fname,
                                  (int)pf.frame_id, pf.frame.max_slice_nums);
 
+        if (!sess->running.load()) {
+            duplex_session_complete_frames(sess);
+            continue;
+        }
+
         OmniDuplexInflightFrame inf;
         inf.frame_id       = pf.frame_id;
         inf.user_seq       = pf.frame.user_seq;
         inf.t_push         = pf.t_push;
         inf.t_prefilled    = std::chrono::high_resolution_clock::now();
         inf.prefill_failed = !ok;
+        bool cancelled = false;
         {
             std::unique_lock<std::mutex> lk(sess->decode_mtx);
-            sess->decode_pending.push(std::move(inf));
+            if (sess->running.load()) {
+                sess->decode_pending.push(std::move(inf));
+            } else {
+                cancelled = true;
+            }
+        }
+        if (cancelled) {
+            duplex_session_complete_frames(sess);
+            continue;
         }
         sess->decode_cv.notify_all();
     }
@@ -11474,7 +11534,7 @@ static void duplex_session_decode_worker_func(omni_context * ctx_omni) {
             sess->decode_cv.wait(lk, [&]{
                 return !sess->decode_pending.empty() || !sess->running.load();
             });
-            if (!sess->running.load() && sess->decode_pending.empty()) break;
+            if (!sess->running.load()) break;
             inf = std::move(sess->decode_pending.front());
             sess->decode_pending.pop();
         }
@@ -11506,7 +11566,9 @@ static void duplex_session_decode_worker_func(omni_context * ctx_omni) {
             }
 
             r.n_past_after = ctx_omni->n_past;
+            r.ms_encoder = ctx_omni->last_duplex_encoder_ms.load();
             r.ms_decode = std::chrono::duration<double, std::milli>(t_dec_end - t_dec_start).count();
+            r.ms_ttft   = ctx_omni->last_duplex_ttft_ms.load();
             r.ms_total  = std::chrono::duration<double, std::milli>(t_dec_end - inf.t_push).count();
         }
         r.ms_prefill_submit = std::chrono::duration<double, std::milli>(inf.t_prefilled - inf.t_push).count();
@@ -11516,7 +11578,7 @@ static void duplex_session_decode_worker_func(omni_context * ctx_omni) {
             sess->done_results.push(std::move(r));
         }
         sess->done_cv.notify_all();
-        sess->in_flight.fetch_sub(1);
+        duplex_session_complete_frames(sess);
     }
 }
 
@@ -11573,9 +11635,12 @@ int64_t omni_duplex_push_frame(struct omni_context * ctx_omni,
             return sess->pending_frames.size() < DuplexSession::PENDING_MAX || !sess->running.load();
         });
         if (!sess->running.load()) return -1;
-        sess->pending_frames.push(std::move(pf));
+        {
+            std::lock_guard<std::mutex> in_flight_lock(sess->in_flight_mtx);
+            sess->in_flight.fetch_add(1);
+            sess->pending_frames.push(std::move(pf));
+        }
     }
-    sess->in_flight.fetch_add(1);
     sess->pending_cv.notify_all();
     return pf.frame_id;
 }
@@ -11627,18 +11692,46 @@ bool omni_duplex_drain_tts_audio(struct omni_context * ctx_omni,
     return false;
 }
 
-void omni_duplex_session_end(struct omni_context * ctx_omni) {
-    if (!ctx_omni || !ctx_omni->duplex_session) return;
+bool omni_duplex_session_end(struct omni_context * ctx_omni, int timeout_ms) {
+    if (!ctx_omni || !ctx_omni->duplex_session) return true;
     DuplexSession * sess = ctx_omni->duplex_session;
 
-    // 1. 等所有已 push 的帧 LLM 完成（drain）
-    //    注意：调用方负责 wait_next_frame 把 done_results 取空；这里只等 in_flight=0。
-    while (sess->in_flight.load() > 0) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    bool drained = false;
+    {
+        std::unique_lock<std::mutex> lock(sess->in_flight_mtx);
+        const auto all_frames_completed = [&] { return sess->in_flight.load() == 0; };
+        if (timeout_ms < 0) {
+            sess->in_flight_cv.wait(lock, all_frames_completed);
+            drained = true;
+        } else {
+            drained = sess->in_flight_cv.wait_for(
+                lock, std::chrono::milliseconds(timeout_ms), all_frames_completed);
+        }
     }
 
-    // 2. 通知 worker 退出
+    // On timeout, cancel frames that have not entered the backend yet. An
+    // inference call already in progress cannot be interrupted externally;
+    // break_event makes the pipeline exit at its next checkpoint.
+    if (!drained) {
+        ctx_omni->break_event.store(true);
+    }
     sess->running.store(false);
+
+    int cancelled_frames = 0;
+    if (!drained) {
+        {
+            std::lock_guard<std::mutex> lock(sess->pending_mtx);
+            cancelled_frames += static_cast<int>(sess->pending_frames.size());
+            while (!sess->pending_frames.empty()) sess->pending_frames.pop();
+        }
+        {
+            std::lock_guard<std::mutex> lock(sess->decode_mtx);
+            cancelled_frames += static_cast<int>(sess->decode_pending.size());
+            while (!sess->decode_pending.empty()) sess->decode_pending.pop();
+        }
+        duplex_session_complete_frames(sess, cancelled_frames);
+    }
+
     sess->pending_cv.notify_all();
     sess->decode_cv.notify_all();
     sess->done_cv.notify_all();
@@ -11649,6 +11742,31 @@ void omni_duplex_session_end(struct omni_context * ctx_omni) {
     delete sess;
     ctx_omni->duplex_session = nullptr;
     print_with_timestamp("omni_duplex_session_end: session destroyed\n");
+    return drained;
+}
+
+bool omni_duplex_flush_tts(struct omni_context * ctx_omni) {
+    if (!ctx_omni || !ctx_omni->async || !ctx_omni->duplex_mode || !ctx_omni->use_tts ||
+        !ctx_omni->tts_thread_info || !tts_thread_running.load()) {
+        return false;
+    }
+
+    auto * end_of_turn = new LLMOut();
+    end_of_turn->llm_finish    = true;
+    end_of_turn->is_end_of_turn = true;
+    end_of_turn->debug_dir     = ctx_omni->base_output_dir;
+    {
+        std::lock_guard<std::mutex> lock(ctx_omni->tts_thread_info->mtx);
+        if (!tts_thread_running.load() ||
+            ctx_omni->tts_thread_info->queue.size() >=
+                static_cast<size_t>(ctx_omni->tts_thread_info->MAX_QUEUE_SIZE)) {
+            delete end_of_turn;
+            return false;
+        }
+        ctx_omni->tts_thread_info->queue.push(end_of_turn);
+    }
+    ctx_omni->tts_thread_info->cv.notify_all();
+    return true;
 }
 
 bool stop_speek(struct omni_context * ctx_omni){

--- a/tools/omni/omni.h
+++ b/tools/omni/omni.h
@@ -27,6 +27,7 @@ namespace omni {
 namespace flow {
 class Token2WavSession;
 }
+struct effective_runtime_config;
 }
 
 // 🔧 [Duplex Pipeline] 仅在 duplex_mode=true 时分配；
@@ -157,6 +158,7 @@ struct projector_model {
 // is_final: true if this is the last chunk of the current generation
 // ============================================================================
 using audio_output_cb_t = std::function<void(const float * samples, int n_samples, int sample_rate, bool is_final)>;
+using tts_token_output_cb_t = std::function<void(const int32_t * tokens, size_t count, bool is_final)>;
 
 struct omni_context {
     struct vision_ctx * ctx_vision = NULL;
@@ -170,6 +172,7 @@ struct omni_context {
     // true: omni_init 内部加载的模型，omni_free 时需要释放
     // false: 外部传入的已有模型（模型复用），omni_free 时不释放
     bool owns_model = true;
+    bool strict_runtime_config = false;
 
     // 🔧 [Length Penalty] 用于调整 EOS token 的采样概率
     // length_penalty > 1.0 会降低 EOS 概率，让模型生成更长的输出
@@ -257,6 +260,8 @@ struct omni_context {
     // 持有内部 prefill_worker/decode_worker 线程及 frame 队列。
     // omni_free 时若仍存在，会被强制 session_end 释放。
     DuplexSession * duplex_session = NULL;
+    std::atomic<double> last_duplex_encoder_ms{0.0};
+    std::atomic<double> last_duplex_ttft_ms{0.0};
     
     volatile bool need_speek = false;
     volatile bool speek_done = true;
@@ -390,7 +395,7 @@ struct omni_context {
     
     // head_code: Linear layer (hidden_size=768 -> num_audio_tokens=6562)
     // Note: num_vq=1, so we only need one head_code layer
-    float * head_code_weight = nullptr;  // (768, 6562) - stored as (hidden_size, num_audio_tokens)
+    float * head_code_weight = nullptr;  // [num_audio_tokens, hidden_size], one contiguous row per output token
     int head_code_hidden_size = 0;  // 768
     int head_code_num_audio_tokens = 0;  // 6562
     
@@ -429,6 +434,7 @@ struct omni_context {
     // macOS 上默认使用 C++ 实现（无 CUDA）
     bool use_python_token2wav = false;
     audio_output_cb_t audio_output_cb = nullptr; // called by T2W threads when a chunk of audio is ready
+    tts_token_output_cb_t tts_token_output_cb = nullptr;
     std::string python_t2w_script_dir;  // Python Token2Wav 脚本目录
     std::string python_t2w_model_dir;   // Python Token2Wav 模型目录
     
@@ -488,7 +494,10 @@ struct omni_context * omni_init(struct common_params * params, int media_type, b
                                 int tts_gpu_layers = -1, const std::string & token2wav_device = "gpu:0",
                                 bool duplex_mode = false,
                                 llama_model * existing_model = nullptr, llama_context * existing_ctx = nullptr,
-                                const std::string & base_output_dir = "./tools/omni/output");
+                                const std::string & base_output_dir = "./tools/omni/output",
+                                const omni::effective_runtime_config * runtime_config = nullptr,
+                                bool strict_runtime_config = false,
+                                int token2wav_threads = 8);
 
 void omni_free(struct omni_context * ctx_omni);
 // Stop/join inference threads and clear queues so the same context can serve a
@@ -551,7 +560,9 @@ struct OmniDuplexFrameResult {
     std::string text;               // 该帧 SPEAK 时生成的文本片段（已剔除控制 token）
     int      n_past_after = 0;      // 帧处理完成时的 ctx_llama n_past（调试用）
     double   ms_prefill_submit = 0; // push_frame → prefill_worker 完成提交（不等编码）
+    double   ms_encoder = 0;        // VPM/APM parallel encoder wall time
     double   ms_decode = 0;         // decode_worker 内部 stream_decode 阻塞时长
+    double   ms_ttft = 0;           // decode start → first sampled token
     double   ms_total = 0;          // push_frame → 本帧 result 出队的端到端 wall time
 };
 
@@ -579,9 +590,14 @@ bool omni_duplex_wait_next_frame(struct omni_context * ctx_omni,
                                  OmniDuplexFrameResult * out,
                                  int timeout_ms = -1);
 
-// 结束会话：等所有已 push 但未完成的帧 LLM 完成（drain），停止 worker 线程并释放。
-// TTS / token2wav 后台音频生成线程不在此处停止，由 omni_free 负责。
-void omni_duplex_session_end(struct omni_context * ctx_omni);
+// 结束会话：等待所有已 push 但未完成的 frame 完成（drain），停止 worker 线程并释放。
+// timeout_ms < 0 时无限等待，timeout_ms >= 0 时最多等待指定毫秒数。
+// timeout 后会取消尚未开始处理的 frame，并返回 false；TTS / token2wav 线程仍由 omni_free 停止。
+bool omni_duplex_session_end(struct omni_context * ctx_omni, int timeout_ms = -1);
+
+// 显式结束仍在 SPEAK 的 duplex turn。end-of-turn marker 会排在已有 TTS 请求之后，
+// 由正常 TTS 路径生成尾部 audio token，并让 Token2Wav 发出 is_final=true callback。
+bool omni_duplex_flush_tts(struct omni_context * ctx_omni);
 
 // 阻塞等待 TTS / token2wav 队列彻底空闲（即所有 speak 帧的 audio 文件已写盘）。
 // 返回前会要求队列连续 idle_ms 毫秒为空，避免误判中间瞬态 idle。
@@ -608,6 +624,7 @@ llama_token sample_tts_token(struct common_sampler * smpl, struct omni_context *
 
 // Projector 函数声明（精度验证版本）
 bool projector_init(projector_model & model, const std::string & fname, bool use_cuda);
+bool projector_init(projector_model & model, const std::string & fname, const std::string & device);
 void projector_free(projector_model & model);
 std::vector<float> projector_forward(projector_model & model, const float * input_data, int n_tokens);
 

--- a/tools/omni/runtime-profile-session.cpp
+++ b/tools/omni/runtime-profile-session.cpp
@@ -1,0 +1,52 @@
+#include "runtime-profile-session.h"
+
+#include "common.h"
+
+namespace omni {
+
+runtime_session_options resolve_runtime_session_options(const effective_runtime_config * config,
+                                                        bool                             requested_duplex_mode,
+                                                        int32_t                          requested_tts_gpu_layers,
+                                                        const std::string &              requested_token2wav_device,
+                                                        int32_t                          requested_token2wav_threads) {
+    if (config != nullptr) {
+        return { config->duplex_mode, config->tts_gpu_layers, config->token2wav_device, config->token2wav_threads,
+                 true };
+    }
+    return { requested_duplex_mode, requested_tts_gpu_layers, requested_token2wav_device, requested_token2wav_threads,
+             false };
+}
+
+bool apply_effective_runtime_config(common_params &                  params,
+                                    const effective_runtime_config & config,
+                                    std::string &                    error) {
+    error.clear();
+    params.model.path       = config.llm_model;
+    params.n_gpu_layers     = config.n_gpu_layers;
+    params.n_ctx            = config.n_ctx;
+    params.vpm_model        = config.vision_model;
+    params.apm_model        = config.audio_model;
+    params.tts_model        = config.tts_model;
+    params.projector_model  = config.projector_model;
+    params.vpm_batch_encode = config.vpm_batch_encode;
+
+    const auto separator = config.tts_model.find_last_of("/\\");
+    params.tts_bin_dir   = separator == std::string::npos ? "." : config.tts_model.substr(0, separator);
+
+    ggml_backend_dev_t llm_device = config.llm_device == "cpu" ?
+                                        ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU) :
+                                        ggml_backend_dev_by_name(config.llm_device.c_str());
+    if (llm_device == nullptr) {
+        error = "resolved LLM placement device is unavailable: " + config.llm_device;
+        return false;
+    }
+    params.devices    = { llm_device, nullptr };
+    params.split_mode = LLAMA_SPLIT_MODE_NONE;
+    params.main_gpu   = 0;
+    if (config.llm_device == "cpu") {
+        params.n_gpu_layers = 0;
+    }
+    return true;
+}
+
+}  // namespace omni

--- a/tools/omni/runtime-profile-session.cpp
+++ b/tools/omni/runtime-profile-session.cpp
@@ -8,13 +8,13 @@ runtime_session_options resolve_runtime_session_options(const effective_runtime_
                                                         bool                             requested_duplex_mode,
                                                         int32_t                          requested_tts_gpu_layers,
                                                         const std::string &              requested_token2wav_device,
-                                                        int32_t                          requested_token2wav_threads) {
+    int32_t                          requested_token2wav_threads) {
     if (config != nullptr) {
-        return { config->duplex_mode, config->tts_gpu_layers, config->token2wav_device, config->token2wav_threads,
-                 true };
+        return { config->duplex_mode, config->async_mode, config->tts_gpu_layers, config->token2wav_device,
+                 config->token2wav_threads, true };
     }
-    return { requested_duplex_mode, requested_tts_gpu_layers, requested_token2wav_device, requested_token2wav_threads,
-             false };
+    return { requested_duplex_mode, true, requested_tts_gpu_layers, requested_token2wav_device,
+             requested_token2wav_threads, false };
 }
 
 bool apply_effective_runtime_config(common_params &                  params,

--- a/tools/omni/runtime-profile-session.h
+++ b/tools/omni/runtime-profile-session.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "runtime-profile.h"
+
+#include <cstdint>
+#include <string>
+
+struct common_params;
+
+namespace omni {
+
+struct runtime_session_options {
+    bool        duplex_mode          = false;
+    int32_t     tts_gpu_layers       = 100;
+    std::string token2wav_device     = "gpu:0";
+    int32_t     token2wav_threads    = 8;
+    bool        strict_runtime_config = false;
+};
+
+runtime_session_options resolve_runtime_session_options(const effective_runtime_config * config,
+                                                        bool                             requested_duplex_mode,
+                                                        int32_t                          requested_tts_gpu_layers,
+                                                        const std::string &              requested_token2wav_device,
+                                                        int32_t                          requested_token2wav_threads = 8);
+
+bool apply_effective_runtime_config(common_params &                  params,
+                                    const effective_runtime_config & config,
+                                    std::string &                    error);
+
+}  // namespace omni

--- a/tools/omni/runtime-profile-session.h
+++ b/tools/omni/runtime-profile-session.h
@@ -11,6 +11,7 @@ namespace omni {
 
 struct runtime_session_options {
     bool        duplex_mode          = false;
+    bool        async_mode           = true;
     int32_t     tts_gpu_layers       = 100;
     std::string token2wav_device     = "gpu:0";
     int32_t     token2wav_threads    = 8;

--- a/tools/omni/runtime-profile.cpp
+++ b/tools/omni/runtime-profile.cpp
@@ -1,0 +1,576 @@
+#include "runtime-profile.h"
+
+#include "ggml-backend.h"
+
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+
+namespace omni {
+
+static std::string existing_file(const std::filesystem::path & root, const std::filesystem::path & relative_path) {
+    const auto      path = root / relative_path;
+    std::error_code error;
+    if (std::filesystem::is_regular_file(path, error)) {
+        return path.string();
+    }
+    return {};
+}
+
+model_inventory discover_model_inventory(const std::string & model_root) {
+    model_inventory inventory;
+    inventory.root = model_root;
+    const std::filesystem::path root(model_root);
+
+    inventory.llm_f16    = existing_file(root, "MiniCPM-o-4_5-F16.gguf");
+    inventory.llm_q8_0   = existing_file(root, "MiniCPM-o-4_5-Q8_0.gguf");
+    inventory.llm_q4_k_m = existing_file(root, "MiniCPM-o-4_5-Q4_K_M.gguf");
+    inventory.vision     = existing_file(root, "vision/MiniCPM-o-4_5-vision-F16.gguf");
+    inventory.audio      = existing_file(root, "audio/MiniCPM-o-4_5-audio-F16.gguf");
+    inventory.tts        = existing_file(root, "tts/MiniCPM-o-4_5-tts-F16.gguf");
+    inventory.projector  = existing_file(root, "tts/MiniCPM-o-4_5-projector-F16.gguf");
+
+    const auto      token2wav_dir = root / "token2wav-gguf";
+    std::error_code error;
+    if (std::filesystem::is_directory(token2wav_dir, error)) {
+        inventory.token2wav_dir = token2wav_dir.string();
+    }
+    inventory.token2wav_encoder       = existing_file(root, "token2wav-gguf/encoder.gguf");
+    inventory.token2wav_flow_matching = existing_file(root, "token2wav-gguf/flow_matching.gguf");
+    inventory.token2wav_flow_extra    = existing_file(root, "token2wav-gguf/flow_extra.gguf");
+    inventory.token2wav_hifigan       = existing_file(root, "token2wav-gguf/hifigan2.gguf");
+    inventory.token2wav_prompt_cache  = existing_file(root, "token2wav-gguf/prompt_cache.gguf");
+    return inventory;
+}
+
+hardware_snapshot detect_hardware_snapshot() {
+    hardware_snapshot snapshot;
+    ggml_backend_load_all();
+    for (size_t index = 0; index < ggml_backend_dev_count(); ++index) {
+        ggml_backend_dev_t device = ggml_backend_dev_get(index);
+        if (device == nullptr) {
+            continue;
+        }
+
+        size_t free_memory  = 0;
+        size_t total_memory = 0;
+        ggml_backend_dev_memory(device, &free_memory, &total_memory);
+        const auto device_type = ggml_backend_dev_type(device);
+        const char * type_name = device_type == GGML_BACKEND_DEVICE_TYPE_CPU ? "CPU" :
+                                 device_type == GGML_BACKEND_DEVICE_TYPE_GPU ? "GPU" : "ACCEL";
+        snapshot.devices.push_back({
+            ggml_backend_dev_name(device),
+            ggml_backend_dev_description(device),
+            device_type != GGML_BACKEND_DEVICE_TYPE_CPU,
+            static_cast<uint64_t>(free_memory),
+            static_cast<uint64_t>(total_memory),
+            type_name,
+        });
+    }
+    return snapshot;
+}
+
+static std::vector<const runtime_device *> accelerator_devices(const hardware_snapshot & hardware) {
+    std::vector<const runtime_device *> devices;
+    for (const auto & device : hardware.devices) {
+        if (device.is_accelerator) {
+            devices.push_back(&device);
+        }
+    }
+    std::sort(devices.begin(), devices.end(), [](const runtime_device * lhs, const runtime_device * rhs) {
+        if (lhs->free_memory != rhs->free_memory) {
+            return lhs->free_memory > rhs->free_memory;
+        }
+        return lhs->name < rhs->name;
+    });
+    return devices;
+}
+
+static std::string token2wav_device_for(const runtime_device & device) {
+    std::string digits;
+    for (auto it = device.name.rbegin(); it != device.name.rend() && std::isdigit(static_cast<unsigned char>(*it)); ++it) {
+        digits.push_back(*it);
+    }
+    if (!digits.empty()) {
+        std::reverse(digits.begin(), digits.end());
+        return "gpu:" + digits;
+    }
+    return "gpu:0";
+}
+
+static const runtime_device * find_device(const hardware_snapshot & hardware, const std::string & name) {
+    for (const auto & device : hardware.devices) {
+        if (device.name == name) {
+            return &device;
+        }
+    }
+    return nullptr;
+}
+
+static std::string normalize_device(const std::string & requested,
+                                    const hardware_snapshot & hardware,
+                                    const std::string & module,
+                                    std::string & error) {
+    const auto accelerators = accelerator_devices(hardware);
+    const runtime_device * primary = accelerators.empty() ? nullptr : accelerators.front();
+    if (requested.empty() || requested == "cpu") {
+        return requested.empty() ? "cpu" : requested;
+    }
+    if (requested == "primary" || requested == "secondary") {
+        const size_t index = requested == "primary" ? 0 : 1;
+        if (index < accelerators.size()) {
+            return accelerators[index]->name;
+        }
+        error = "unsupported " + module + " placement device: " + requested +
+                " (the requested accelerator is not available)";
+        return {};
+    }
+    if (requested == "gpu") {
+        if (primary != nullptr) {
+            return primary->name;
+        }
+        error = "unsupported " + module + " placement device: gpu (no accelerator is available)";
+        return {};
+    }
+    if (requested.rfind("gpu:", 0) == 0) {
+        try {
+            const size_t index = static_cast<size_t>(std::stoul(requested.substr(4)));
+            const auto accelerators = accelerator_devices(hardware);
+            if (index < accelerators.size()) {
+                return accelerators[index]->name;
+            }
+        } catch (...) {
+        }
+    }
+    if (find_device(hardware, requested) != nullptr) {
+        return requested;
+    }
+    error = "unsupported " + module + " placement device: " + requested;
+    return {};
+}
+
+static void add_module_placement(effective_runtime_config & config,
+                                 const std::string & module,
+                                 const std::string & model,
+                                 const std::string & precision,
+                                 const std::string & device,
+                                 const std::string & execution = "independent") {
+    config.placements.push_back({ module, model, precision, device,
+                                  device == "cpu" ? "cpu" : "gpu", execution, "active" });
+}
+
+static std::string quantization_from_path(const std::string & path) {
+    std::string upper = path;
+    std::transform(upper.begin(), upper.end(), upper.begin(),
+                   [](unsigned char ch) { return static_cast<char>(std::toupper(ch)); });
+    if (upper.find("Q4_K_M") != std::string::npos) {
+        return "Q4_K_M";
+    }
+    if (upper.find("Q8_0") != std::string::npos) {
+        return "Q8_0";
+    }
+    if (upper.find("F16") != std::string::npos) {
+        return "F16";
+    }
+    return "UNKNOWN";
+}
+
+static void apply_overrides(effective_runtime_config & config, const runtime_profile_overrides & overrides) {
+    if (overrides.llm_model) {
+        config.llm_model        = *overrides.llm_model;
+        config.llm_quantization = quantization_from_path(*overrides.llm_model);
+        config.reason += "; explicit LLM model override applied";
+    }
+    if (overrides.n_gpu_layers) {
+        config.n_gpu_layers = *overrides.n_gpu_layers;
+    }
+    if (overrides.n_ctx) {
+        config.n_ctx = *overrides.n_ctx;
+    }
+    if (overrides.token2wav_threads) {
+        config.token2wav_threads = *overrides.token2wav_threads;
+    }
+    if (overrides.vpm_batch_encode) {
+        config.vpm_batch_encode = *overrides.vpm_batch_encode;
+    }
+    for (auto & placement : config.placements) {
+        if (placement.module == "llm") {
+            placement.model = config.llm_model;
+            placement.precision = config.llm_quantization;
+            placement.device = config.llm_device;
+            break;
+        }
+    }
+}
+
+runtime_profile_result resolve_runtime_profile(const std::string &               requested_profile,
+                                               const hardware_snapshot &         hardware,
+                                               const model_inventory &           inventory,
+                                               const runtime_profile_overrides & overrides) {
+    runtime_profile_result result;
+    (void) hardware;
+    (void) inventory;
+    (void) overrides;
+    result.config.requested_profile = requested_profile;
+    result.error = requested_profile == "auto"
+                       ? "profile auto requires a static profile config file; use --profile-config or the default "
+                         "MODEL_DIR/omni-runtime-profile.json"
+                       : "unsupported runtime profile: " + requested_profile;
+    return result;
+}
+
+using profile_json = nlohmann::ordered_json;
+
+template <typename T>
+static bool read_required_profile_value(const profile_json & object,
+                                        const char *         section,
+                                        const char *         key,
+                                        T &                  value,
+                                        std::string &        error) {
+    if (!object.is_object() || !object.contains(key)) {
+        error = std::string("profile config missing required field: ") + section + "." + key;
+        return false;
+    }
+    try {
+        value = object.at(key).get<T>();
+    } catch (const std::exception & exception) {
+        error = std::string("profile config field ") + section + "." + key + " has an invalid type: " +
+                exception.what();
+        return false;
+    }
+    return true;
+}
+
+static bool read_required_profile_object(const profile_json & root,
+                                         const char *         key,
+                                         profile_json &       value,
+                                         std::string &        error) {
+    if (!root.contains(key) || !root.at(key).is_object()) {
+        error = std::string("profile config missing required object: ") + key;
+        return false;
+    }
+    value = root.at(key);
+    return true;
+}
+
+static std::string resolve_profile_model_path(const std::string & model_root, const std::string & configured_path) {
+    std::filesystem::path path(configured_path);
+    if (path.is_relative()) {
+        path = std::filesystem::path(model_root) / path;
+    }
+    return path.lexically_normal().string();
+}
+
+static bool require_profile_file(const std::string & module,
+                                 const std::string & path,
+                                 std::string &       error) {
+    std::error_code filesystem_error;
+    if (!std::filesystem::is_regular_file(path, filesystem_error)) {
+        error = "profile config " + module + " model file does not exist: " + path;
+        return false;
+    }
+    return true;
+}
+
+static bool require_profile_directory(const std::string & module,
+                                      const std::string & path,
+                                      std::string &       error) {
+    std::error_code filesystem_error;
+    if (!std::filesystem::is_directory(path, filesystem_error)) {
+        error = "profile config " + module + " model directory does not exist: " + path;
+        return false;
+    }
+    return true;
+}
+
+static bool require_non_empty_profile_value(const char * section,
+                                            const char * key,
+                                            const std::string & value,
+                                            std::string & error) {
+    if (value.empty()) {
+        error = std::string("profile config field ") + section + "." + key + " must not be empty";
+        return false;
+    }
+    return true;
+}
+
+runtime_profile_result resolve_runtime_profile_from_config(const std::string &               config_path,
+                                                           const hardware_snapshot &         hardware,
+                                                           const model_inventory &           inventory,
+                                                           const runtime_profile_overrides & overrides) {
+    runtime_profile_result result;
+    result.config.requested_profile = "auto";
+
+    if (config_path.empty()) {
+        result.error = "profile config file path is empty";
+        return result;
+    }
+    if (inventory.root.empty()) {
+        result.error = "profile config requires a model root; pass --model-dir or --model";
+        return result;
+    }
+
+    std::ifstream file(config_path);
+    if (!file.good()) {
+        result.error = "profile config file does not exist or cannot be read: " + config_path;
+        return result;
+    }
+
+    profile_json document;
+    try {
+        file >> document;
+    } catch (const std::exception & exception) {
+        result.error = "invalid profile config JSON in " + config_path + ": " + exception.what();
+        return result;
+    }
+    if (!document.is_object()) {
+        result.error = "invalid profile config JSON: root must be an object";
+        return result;
+    }
+
+    int schema_version = 0;
+    std::string profile;
+    if (!read_required_profile_value(document, "root", "schema_version", schema_version, result.error) ||
+        !read_required_profile_value(document, "root", "profile", profile, result.error)) {
+        return result;
+    }
+    if (schema_version != 1) {
+        result.error = "unsupported profile config schema_version: " + std::to_string(schema_version);
+        return result;
+    }
+    if (profile != "auto") {
+        result.error = "profile config profile must be \"auto\"";
+        return result;
+    }
+
+    profile_json llm;
+    profile_json vision;
+    profile_json audio;
+    profile_json tts;
+    profile_json projector;
+    profile_json token2wav;
+    profile_json runtime;
+    if (!read_required_profile_object(document, "llm", llm, result.error) ||
+        !read_required_profile_object(document, "vision", vision, result.error) ||
+        !read_required_profile_object(document, "audio", audio, result.error) ||
+        !read_required_profile_object(document, "tts", tts, result.error) ||
+        !read_required_profile_object(document, "projector", projector, result.error) ||
+        !read_required_profile_object(document, "token2wav", token2wav, result.error) ||
+        !read_required_profile_object(document, "runtime", runtime, result.error)) {
+        return result;
+    }
+
+    std::string llm_configured_model;
+    std::string llm_quantization;
+    std::string llm_configured_device;
+    int32_t     n_gpu_layers = 0;
+    if (!read_required_profile_value(llm, "llm", "model", llm_configured_model, result.error) ||
+        !read_required_profile_value(llm, "llm", "quantization", llm_quantization, result.error) ||
+        !read_required_profile_value(llm, "llm", "device", llm_configured_device, result.error) ||
+        !read_required_profile_value(llm, "llm", "n_gpu_layers", n_gpu_layers, result.error)) {
+        return result;
+    }
+
+    std::string vision_configured_model;
+    std::string vision_configured_device;
+    std::string audio_configured_model;
+    std::string audio_configured_device;
+    std::string tts_configured_model;
+    std::string tts_configured_device;
+    std::string projector_configured_model;
+    std::string projector_configured_device;
+    int32_t     tts_gpu_layers = 0;
+    if (!read_required_profile_value(vision, "vision", "model", vision_configured_model, result.error) ||
+        !read_required_profile_value(vision, "vision", "device", vision_configured_device, result.error) ||
+        !read_required_profile_value(audio, "audio", "model", audio_configured_model, result.error) ||
+        !read_required_profile_value(audio, "audio", "device", audio_configured_device, result.error) ||
+        !read_required_profile_value(tts, "tts", "model", tts_configured_model, result.error) ||
+        !read_required_profile_value(tts, "tts", "device", tts_configured_device, result.error) ||
+        !read_required_profile_value(tts, "tts", "gpu_layers", tts_gpu_layers, result.error) ||
+        !read_required_profile_value(projector, "projector", "model", projector_configured_model, result.error) ||
+        !read_required_profile_value(projector, "projector", "device", projector_configured_device, result.error)) {
+        return result;
+    }
+
+    std::string token2wav_configured_dir;
+    std::string token2wav_configured_device;
+    int32_t     token2wav_threads = 0;
+    if (!read_required_profile_value(token2wav, "token2wav", "model_dir", token2wav_configured_dir, result.error) ||
+        !read_required_profile_value(token2wav, "token2wav", "device", token2wav_configured_device, result.error) ||
+        !read_required_profile_value(token2wav, "token2wav", "threads", token2wav_threads, result.error)) {
+        return result;
+    }
+
+    if (!require_non_empty_profile_value("llm", "model", llm_configured_model, result.error) ||
+        !require_non_empty_profile_value("llm", "quantization", llm_quantization, result.error) ||
+        !require_non_empty_profile_value("llm", "device", llm_configured_device, result.error) ||
+        !require_non_empty_profile_value("vision", "model", vision_configured_model, result.error) ||
+        !require_non_empty_profile_value("vision", "device", vision_configured_device, result.error) ||
+        !require_non_empty_profile_value("audio", "model", audio_configured_model, result.error) ||
+        !require_non_empty_profile_value("audio", "device", audio_configured_device, result.error) ||
+        !require_non_empty_profile_value("tts", "model", tts_configured_model, result.error) ||
+        !require_non_empty_profile_value("tts", "device", tts_configured_device, result.error) ||
+        !require_non_empty_profile_value("projector", "model", projector_configured_model, result.error) ||
+        !require_non_empty_profile_value("projector", "device", projector_configured_device, result.error) ||
+        !require_non_empty_profile_value("token2wav", "model_dir", token2wav_configured_dir, result.error) ||
+        !require_non_empty_profile_value("token2wav", "device", token2wav_configured_device, result.error)) {
+        return result;
+    }
+
+    if (!read_required_profile_value(runtime, "runtime", "n_ctx", result.config.n_ctx, result.error) ||
+        !read_required_profile_value(runtime, "runtime", "duplex", result.config.duplex_mode, result.error) ||
+        !read_required_profile_value(runtime, "runtime", "async", result.config.async_mode, result.error) ||
+        !read_required_profile_value(runtime, "runtime", "vpm_batch_encode", result.config.vpm_batch_encode,
+                                     result.error)) {
+        return result;
+    }
+    if (token2wav_threads <= 0 || result.config.n_ctx <= 0) {
+        result.error = "profile config runtime values must be positive";
+        return result;
+    }
+
+    result.config.llm_model        = resolve_profile_model_path(inventory.root, llm_configured_model);
+    result.config.llm_quantization = llm_quantization;
+    result.config.vision_model     = resolve_profile_model_path(inventory.root, vision_configured_model);
+    result.config.audio_model      = resolve_profile_model_path(inventory.root, audio_configured_model);
+    result.config.tts_model        = resolve_profile_model_path(inventory.root, tts_configured_model);
+    result.config.projector_model  = resolve_profile_model_path(inventory.root, projector_configured_model);
+    result.config.token2wav_model_dir = resolve_profile_model_path(inventory.root, token2wav_configured_dir);
+    result.config.n_gpu_layers     = n_gpu_layers;
+    result.config.tts_gpu_layers   = tts_gpu_layers;
+    result.config.token2wav_threads = token2wav_threads;
+
+    if (!require_profile_file("llm", result.config.llm_model, result.error) ||
+        !require_profile_file("vision", result.config.vision_model, result.error) ||
+        !require_profile_file("audio", result.config.audio_model, result.error) ||
+        !require_profile_file("tts", result.config.tts_model, result.error) ||
+        !require_profile_file("projector", result.config.projector_model, result.error) ||
+        !require_profile_directory("token2wav", result.config.token2wav_model_dir, result.error)) {
+        return result;
+    }
+
+    const std::vector<std::pair<const char *, const char *>> token2wav_files = {
+        { "encoder", "encoder.gguf" },
+        { "flow_matching", "flow_matching.gguf" },
+        { "flow_extra", "flow_extra.gguf" },
+        { "hifigan2", "hifigan2.gguf" },
+        { "prompt_cache", "prompt_cache.gguf" },
+    };
+    for (const auto & file_entry : token2wav_files) {
+        if (!require_profile_file("token2wav " + std::string(file_entry.first),
+                                  (std::filesystem::path(result.config.token2wav_model_dir) / file_entry.second).string(),
+                                  result.error)) {
+            return result;
+        }
+    }
+
+    const auto accelerators = accelerator_devices(hardware);
+    if (!accelerators.empty()) {
+        const auto * primary = accelerators.front();
+        result.config.primary_device_name         = primary->name;
+        result.config.primary_device_description  = primary->description;
+        result.config.primary_device_free_memory  = primary->free_memory;
+        result.config.primary_device_total_memory = primary->total_memory;
+    }
+
+    auto resolve_configured_device = [&](const std::string & requested,
+                                         const std::string & module,
+                                         std::string &       resolved) {
+        resolved = normalize_device(requested, hardware, module, result.error);
+        return result.error.empty();
+    };
+    std::string llm_device;
+    std::string vision_device;
+    std::string audio_device;
+    std::string tts_device;
+    std::string projector_device;
+    std::string token2wav_backend_device;
+    if (!resolve_configured_device(llm_configured_device, "llm", llm_device) ||
+        !resolve_configured_device(vision_configured_device, "vision", vision_device) ||
+        !resolve_configured_device(audio_configured_device, "audio", audio_device) ||
+        !resolve_configured_device(tts_configured_device, "tts", tts_device) ||
+        !resolve_configured_device(projector_configured_device, "projector", projector_device) ||
+        !resolve_configured_device(token2wav_configured_device, "token2wav", token2wav_backend_device)) {
+        return result;
+    }
+
+    result.config.llm_device     = llm_device;
+    result.config.vision_device  = vision_device;
+    result.config.audio_device   = audio_device;
+    result.config.tts_device     = tts_device;
+    result.config.token2wav_device = token2wav_backend_device == "cpu"
+                                         ? "cpu"
+                                         : token2wav_device_for(*find_device(hardware, token2wav_backend_device));
+    result.config.resolved_profile = "static_config";
+    result.config.reason = "loaded static profile config: " + config_path;
+
+    result.config.placements.clear();
+    add_module_placement(result.config, "llm", result.config.llm_model, result.config.llm_quantization,
+                         result.config.llm_device);
+    add_module_placement(result.config, "vision", result.config.vision_model, "F16", result.config.vision_device);
+    add_module_placement(result.config, "audio", result.config.audio_model, "F16", result.config.audio_device);
+    add_module_placement(result.config, "tts", result.config.tts_model, "F16", result.config.tts_device);
+    add_module_placement(result.config, "projector", result.config.projector_model, "F16",
+                         projector_device);
+    add_module_placement(result.config, "token2wav", result.config.token2wav_model_dir, "F16",
+                         token2wav_backend_device);
+
+    apply_overrides(result.config, overrides);
+    result.ok = true;
+    return result;
+}
+
+std::string format_effective_runtime_config(const effective_runtime_config & config) {
+    std::ostringstream output;
+    output << "profile=" << config.requested_profile << '\n';
+    output << "resolved_profile=" << config.resolved_profile << '\n';
+    output << "reason=" << config.reason << '\n';
+    if (!config.primary_device_name.empty()) {
+        output << "primary_device=" << config.primary_device_name;
+        if (!config.primary_device_description.empty()) {
+            output << " (" << config.primary_device_description << ')';
+        }
+        output << '\n';
+        output << "primary_device_free_memory_mib=" << config.primary_device_free_memory / (1024ULL * 1024ULL) << '\n';
+        output << "primary_device_total_memory_mib=" << config.primary_device_total_memory / (1024ULL * 1024ULL)
+               << '\n';
+    }
+    output << "llm_model=" << config.llm_model << '\n';
+    output << "llm_quantization=" << config.llm_quantization << '\n';
+    output << "llm_device=" << config.llm_device << '\n';
+    output << "llm_n_gpu_layers=" << config.n_gpu_layers << '\n';
+    output << "vision_model=" << config.vision_model << '\n';
+    output << "vision_device=" << config.vision_device << '\n';
+    output << "audio_model=" << config.audio_model << '\n';
+    output << "audio_device=" << config.audio_device << '\n';
+    output << "tts_model=" << config.tts_model << '\n';
+    output << "tts_device=" << config.tts_device << '\n';
+    output << "tts_gpu_layers=" << config.tts_gpu_layers << '\n';
+    output << "projector_model=" << config.projector_model << '\n';
+    output << "token2wav_model_dir=" << config.token2wav_model_dir << '\n';
+    output << "token2wav_device=" << config.token2wav_device << '\n';
+    output << "token2wav_threads=" << config.token2wav_threads << '\n';
+    output << "execution=" << (config.async_mode ? "async" : "sync") << ','
+           << (config.duplex_mode ? "duplex" : "simplex");
+    if (config.vpm_batch_encode) {
+        output << ",vpm_batch_encode";
+    }
+    output << ",ctx_size=" << config.n_ctx << '\n';
+    output << "placement_plan_count=" << config.placements.size() << '\n';
+    for (const auto & placement : config.placements) {
+        output << "placement=" << placement.module
+               << ",model=" << placement.model
+               << ",precision=" << placement.precision
+               << ",device=" << placement.device
+               << ",backend=" << placement.backend
+               << ",execution=" << placement.execution
+               << ",status=" << placement.status << '\n';
+    }
+    return output.str();
+}
+
+}  // namespace omni

--- a/tools/omni/runtime-profile.cpp
+++ b/tools/omni/runtime-profile.cpp
@@ -444,6 +444,13 @@ runtime_profile_result resolve_runtime_profile_from_config(const std::string &  
     result.config.tts_gpu_layers   = tts_gpu_layers;
     result.config.token2wav_threads = token2wav_threads;
 
+    const std::string detected_quantization = quantization_from_path(result.config.llm_model);
+    if (detected_quantization != "UNKNOWN" && detected_quantization != llm_quantization) {
+        result.error = "profile config llm.quantization " + llm_quantization +
+                       " does not match the LLM model filename (detected " + detected_quantization + ")";
+        return result;
+    }
+
     if (!require_profile_file("llm", result.config.llm_model, result.error) ||
         !require_profile_file("vision", result.config.vision_model, result.error) ||
         !require_profile_file("audio", result.config.audio_model, result.error) ||

--- a/tools/omni/runtime-profile.h
+++ b/tools/omni/runtime-profile.h
@@ -1,0 +1,115 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace omni {
+
+struct runtime_device {
+    std::string name;
+    std::string description;
+    bool        is_accelerator = false;
+    uint64_t    free_memory    = 0;
+    uint64_t    total_memory   = 0;
+    std::string type;
+};
+
+struct hardware_snapshot {
+    std::vector<runtime_device> devices;
+};
+
+struct model_inventory {
+    std::string root;
+    std::string llm_f16;
+    std::string llm_q8_0;
+    std::string llm_q4_k_m;
+    std::string vision;
+    std::string audio;
+    std::string tts;
+    std::string projector;
+    std::string token2wav_dir;
+    std::string token2wav_encoder;
+    std::string token2wav_flow_matching;
+    std::string token2wav_flow_extra;
+    std::string token2wav_hifigan;
+    std::string token2wav_prompt_cache;
+};
+
+struct module_placement {
+    std::string module;
+    std::string model;
+    std::string precision;
+    std::string device;
+    std::string backend;
+    std::string execution;
+    std::string status;
+};
+
+struct effective_runtime_config {
+    std::string              requested_profile;
+    std::string              resolved_profile;
+    std::string              reason;
+    std::string              primary_device_name;
+    std::string              primary_device_description;
+    uint64_t                 primary_device_free_memory  = 0;
+    uint64_t                 primary_device_total_memory = 0;
+    std::string              llm_model;
+    std::string              llm_quantization;
+    std::string              llm_device;
+    std::string              vision_model;
+    std::string              vision_device;
+    std::string              audio_model;
+    std::string              audio_device;
+    std::string              tts_model;
+    std::string              tts_device;
+    std::string              projector_model;
+    std::string              token2wav_model_dir;
+    int32_t                  n_gpu_layers     = 0;
+    int32_t                  tts_gpu_layers   = 0;
+    std::string              token2wav_device = "cpu";
+    int32_t                  token2wav_threads = 8;
+    int32_t                  n_ctx            = 0;
+    bool                     duplex_mode      = false;
+    bool                     async_mode       = false;
+    bool                     vpm_batch_encode = false;
+    std::vector<module_placement> placements;
+};
+
+struct runtime_profile_overrides {
+    std::optional<std::string> llm_model;
+    std::optional<std::string> llm_device;
+    std::optional<std::string> vision_device;
+    std::optional<std::string> audio_device;
+    std::optional<std::string> tts_device;
+    std::optional<std::string> projector_device;
+    std::optional<std::string> token2wav_device;
+    std::optional<int32_t>     token2wav_threads;
+    std::optional<int32_t>     n_gpu_layers;
+    std::optional<int32_t>     n_ctx;
+    std::optional<bool>        vpm_batch_encode;
+};
+
+struct runtime_profile_result {
+    bool                     ok = false;
+    effective_runtime_config config;
+    std::string              error;
+};
+
+model_inventory   discover_model_inventory(const std::string & model_root);
+hardware_snapshot detect_hardware_snapshot();
+
+runtime_profile_result resolve_runtime_profile(const std::string &               requested_profile,
+                                               const hardware_snapshot &         hardware,
+                                               const model_inventory &           inventory,
+                                               const runtime_profile_overrides & overrides = {});
+
+runtime_profile_result resolve_runtime_profile_from_config(const std::string &               config_path,
+                                                           const hardware_snapshot &         hardware,
+                                                           const model_inventory &           inventory,
+                                                           const runtime_profile_overrides & overrides = {});
+
+std::string format_effective_runtime_config(const effective_runtime_config & config);
+
+}  // namespace omni

--- a/tools/omni/test/test-head-code-layout.cpp
+++ b/tools/omni/test/test-head-code-layout.cpp
@@ -1,0 +1,87 @@
+#include "tts-weight-layout.h"
+
+#include <cstdio>
+#include <vector>
+
+namespace {
+
+bool expect_values(const char * name, const std::vector<float> & actual, const std::vector<float> & expected) {
+    if (actual == expected) {
+        return true;
+    }
+
+    std::fprintf(stderr, "%s: unexpected values\n", name);
+    for (size_t i = 0; i < actual.size(); ++i) {
+        std::fprintf(stderr, "  [%zu] actual=%.1f expected=%.1f\n", i, actual[i], expected[i]);
+    }
+    return false;
+}
+
+bool test_standard_gguf_layout_is_copied_without_transpose() {
+    constexpr int64_t hidden_size      = 3;
+    constexpr int64_t num_audio_tokens = 2;
+    const std::vector<float> source    = {10.0f, 11.0f, 12.0f, 20.0f, 21.0f, 22.0f};
+    const std::vector<float> expected  = source;
+    std::vector<float>       actual(source.size(), -1.0f);
+
+    if (!omni::copy_head_code_weight_to_output_major(
+            source.data(), hidden_size, num_audio_tokens, hidden_size, num_audio_tokens, actual.data())) {
+        std::fprintf(stderr, "standard GGUF layout was rejected\n");
+        return false;
+    }
+    return expect_values("standard GGUF layout", actual, expected);
+}
+
+bool test_legacy_gguf_layout_is_transposed() {
+    constexpr int64_t hidden_size      = 3;
+    constexpr int64_t num_audio_tokens = 2;
+    const std::vector<float> source    = {10.0f, 20.0f, 11.0f, 21.0f, 12.0f, 22.0f};
+    const std::vector<float> expected  = {10.0f, 11.0f, 12.0f, 20.0f, 21.0f, 22.0f};
+    std::vector<float>       actual(source.size(), -1.0f);
+
+    if (!omni::copy_head_code_weight_to_output_major(
+            source.data(), num_audio_tokens, hidden_size, hidden_size, num_audio_tokens, actual.data())) {
+        std::fprintf(stderr, "legacy GGUF layout was rejected\n");
+        return false;
+    }
+    return expect_values("legacy GGUF layout", actual, expected);
+}
+
+bool test_unexpected_shape_is_rejected() {
+    const std::vector<float> source(6, 1.0f);
+    std::vector<float>       actual(source.size(), -1.0f);
+
+    return !omni::copy_head_code_weight_to_output_major(source.data(), 1, 6, 3, 2, actual.data());
+}
+
+bool test_higher_rank_shape_is_rejected() {
+    return !omni::has_supported_head_code_weight_layout(3, 12, 3, 2, 3, 2);
+}
+
+bool test_wrong_element_count_is_rejected() {
+    return !omni::has_supported_head_code_weight_layout(2, 12, 3, 2, 3, 2);
+}
+
+} // namespace
+
+int main() {
+    if (!test_standard_gguf_layout_is_copied_without_transpose()) {
+        return 1;
+    }
+    if (!test_legacy_gguf_layout_is_transposed()) {
+        return 1;
+    }
+    if (!test_unexpected_shape_is_rejected()) {
+        std::fprintf(stderr, "unexpected GGUF layout was accepted\n");
+        return 1;
+    }
+    if (!test_higher_rank_shape_is_rejected()) {
+        std::fprintf(stderr, "higher-rank GGUF layout was accepted\n");
+        return 1;
+    }
+    if (!test_wrong_element_count_is_rejected()) {
+        std::fprintf(stderr, "GGUF layout with wrong element count was accepted\n");
+        return 1;
+    }
+    return 0;
+}

--- a/tools/omni/test/test-runtime-profile.cpp
+++ b/tools/omni/test/test-runtime-profile.cpp
@@ -1,0 +1,343 @@
+#include "arg.h"
+#include "common.h"
+#include "runtime-profile.h"
+#include "runtime-profile-session.h"
+
+#undef NDEBUG
+#include <cassert>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+static constexpr uint64_t GiB = 1024ULL * 1024ULL * 1024ULL;
+
+class temporary_model_tree {
+  public:
+    temporary_model_tree() {
+        const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+        root = std::filesystem::temp_directory_path() / ("omni-runtime-profile-test-" + std::to_string(unique));
+        std::filesystem::create_directories(root);
+    }
+
+    ~temporary_model_tree() {
+        std::error_code error;
+        std::filesystem::remove_all(root, error);
+    }
+
+    void touch(const std::filesystem::path & relative_path) const {
+        const auto path = root / relative_path;
+        std::filesystem::create_directories(path.parent_path());
+        std::ofstream file(path);
+        file << "test";
+    }
+
+    void write(const std::filesystem::path & relative_path, const std::string & contents) const {
+        const auto path = root / relative_path;
+        std::filesystem::create_directories(path.parent_path());
+        std::ofstream file(path);
+        file << contents;
+    }
+
+    std::filesystem::path root;
+};
+
+static void create_complete_model_tree(const temporary_model_tree & tree) {
+    for (const auto & relative_path : {
+             std::filesystem::path("MiniCPM-o-4_5-Q4_K_M.gguf"),
+             std::filesystem::path("vision/MiniCPM-o-4_5-vision-F16.gguf"),
+             std::filesystem::path("audio/MiniCPM-o-4_5-audio-F16.gguf"),
+             std::filesystem::path("tts/MiniCPM-o-4_5-tts-F16.gguf"),
+             std::filesystem::path("tts/MiniCPM-o-4_5-projector-F16.gguf"),
+             std::filesystem::path("token2wav-gguf/encoder.gguf"),
+             std::filesystem::path("token2wav-gguf/flow_matching.gguf"),
+             std::filesystem::path("token2wav-gguf/flow_extra.gguf"),
+             std::filesystem::path("token2wav-gguf/hifigan2.gguf"),
+             std::filesystem::path("token2wav-gguf/prompt_cache.gguf") }) {
+        tree.touch(relative_path);
+    }
+}
+
+static std::string complete_profile_config() {
+    return R"json({
+  "schema_version": 1,
+  "profile": "auto",
+  "llm": {
+    "model": "MiniCPM-o-4_5-Q4_K_M.gguf",
+    "quantization": "Q4_K_M",
+    "device": "CUDA0",
+    "n_gpu_layers": 37
+  },
+  "vision": {
+    "model": "vision/MiniCPM-o-4_5-vision-F16.gguf",
+    "device": "CUDA1"
+  },
+  "audio": {
+    "model": "audio/MiniCPM-o-4_5-audio-F16.gguf",
+    "device": "CUDA1"
+  },
+  "tts": {
+    "model": "tts/MiniCPM-o-4_5-tts-F16.gguf",
+    "device": "CUDA0",
+    "gpu_layers": -1
+  },
+  "projector": {
+    "model": "tts/MiniCPM-o-4_5-projector-F16.gguf",
+    "device": "CUDA1"
+  },
+  "token2wav": {
+    "model_dir": "token2wav-gguf",
+    "device": "CUDA0",
+    "threads": 12
+  },
+  "runtime": {
+    "n_ctx": 6144,
+    "duplex": true,
+    "async": false,
+    "vpm_batch_encode": true
+  }
+})json";
+}
+
+static omni::hardware_snapshot two_accelerators() {
+    omni::hardware_snapshot hardware;
+    hardware.devices.push_back({ "CUDA0", "NVIDIA H20", true, 24 * GiB, 96 * GiB, "GPU" });
+    hardware.devices.push_back({ "CUDA1", "NVIDIA H20", true, 24 * GiB, 96 * GiB, "GPU" });
+    return hardware;
+}
+
+static omni::runtime_profile_result resolve_from_tree(const temporary_model_tree & tree,
+                                                       const omni::hardware_snapshot & hardware) {
+    const auto inventory = omni::discover_model_inventory(tree.root.string());
+    return omni::resolve_runtime_profile_from_config(
+        (tree.root / "omni-runtime-profile.json").string(), hardware, inventory);
+}
+
+static void test_auto_requires_static_profile_config() {
+    omni::hardware_snapshot hardware;
+    hardware.devices.push_back({ "CUDA0", "NVIDIA H20", true, 24 * GiB, 96 * GiB, "GPU" });
+    omni::model_inventory inventory;
+    inventory.root = "/models/MiniCPM-o-4_5-gguf";
+
+    const auto result = omni::resolve_runtime_profile("auto", hardware, inventory);
+
+    assert(!result.ok);
+    assert(result.error.find("profile config") != std::string::npos);
+}
+
+static void test_static_profile_loads_values_and_maps_logical_devices() {
+    temporary_model_tree tree;
+    create_complete_model_tree(tree);
+    tree.write("omni-runtime-profile.json", complete_profile_config());
+
+    const auto result = resolve_from_tree(tree, two_accelerators());
+
+    assert(result.ok);
+    assert(result.config.requested_profile == "auto");
+    assert(result.config.resolved_profile == "static_config");
+    assert(result.config.llm_model == (tree.root / "MiniCPM-o-4_5-Q4_K_M.gguf").string());
+    assert(result.config.llm_quantization == "Q4_K_M");
+    assert(result.config.llm_device == "CUDA0");
+    assert(result.config.n_gpu_layers == 37);
+    assert(result.config.vision_device == "CUDA1");
+    assert(result.config.audio_device == "CUDA1");
+    assert(result.config.tts_device == "CUDA0");
+    assert(result.config.tts_gpu_layers == -1);
+    assert(result.config.token2wav_device == "gpu:0");
+    assert(result.config.token2wav_threads == 12);
+    assert(result.config.n_ctx == 6144);
+    assert(result.config.duplex_mode);
+    assert(!result.config.async_mode);
+    assert(result.config.vpm_batch_encode);
+}
+
+static void test_static_profile_reports_missing_config_file() {
+    temporary_model_tree tree;
+    create_complete_model_tree(tree);
+    const auto result = resolve_from_tree(tree, two_accelerators());
+
+    assert(!result.ok);
+    assert(result.error.find("profile config file") != std::string::npos);
+    assert(result.error.find("omni-runtime-profile.json") != std::string::npos);
+}
+
+static void test_static_profile_reports_invalid_json() {
+    temporary_model_tree tree;
+    create_complete_model_tree(tree);
+    tree.write("omni-runtime-profile.json", "{\"schema_version\":");
+
+    const auto result = resolve_from_tree(tree, two_accelerators());
+
+    assert(!result.ok);
+    assert(result.error.find("invalid profile config JSON") != std::string::npos);
+}
+
+static void test_static_profile_reports_missing_required_field() {
+    temporary_model_tree tree;
+    create_complete_model_tree(tree);
+    auto config = complete_profile_config();
+    const auto marker = std::string("  \"audio\": {\n    \"model\": \"audio/MiniCPM-o-4_5-audio-F16.gguf\",\n    \"device\": \"CUDA1\"\n  },\n");
+    config.replace(config.find(marker), marker.size(), "");
+    tree.write("omni-runtime-profile.json", config);
+
+    const auto result = resolve_from_tree(tree, two_accelerators());
+
+    assert(!result.ok);
+    assert(result.error.find("audio") != std::string::npos);
+    assert(result.error.find("required") != std::string::npos);
+}
+
+static void test_static_profile_reports_missing_model_file() {
+    temporary_model_tree tree;
+    create_complete_model_tree(tree);
+    auto config = complete_profile_config();
+    const auto marker = "MiniCPM-o-4_5-Q4_K_M.gguf";
+    config.replace(config.find(marker), std::string(marker).size(), "missing.gguf");
+    tree.write("omni-runtime-profile.json", config);
+
+    const auto result = resolve_from_tree(tree, two_accelerators());
+
+    assert(!result.ok);
+    assert(result.error.find("llm model") != std::string::npos);
+    assert(result.error.find("missing.gguf") != std::string::npos);
+}
+
+static void test_static_profile_reports_unavailable_logical_device() {
+    temporary_model_tree tree;
+    create_complete_model_tree(tree);
+    tree.write("omni-runtime-profile.json", complete_profile_config());
+
+    omni::hardware_snapshot hardware;
+    hardware.devices.push_back({ "CUDA0", "NVIDIA H20", true, 24 * GiB, 96 * GiB, "GPU" });
+    const auto result = resolve_from_tree(tree, hardware);
+
+    assert(!result.ok);
+    assert(result.error.find("CUDA1") != std::string::npos);
+    assert(result.error.find("vision") != std::string::npos);
+}
+
+static void test_static_profile_rejects_empty_device_value() {
+    temporary_model_tree tree;
+    create_complete_model_tree(tree);
+    auto config = complete_profile_config();
+    const auto marker = "\"device\": \"CUDA0\"";
+    config.replace(config.find(marker), std::string(marker).size(), "\"device\": \"\"");
+    tree.write("omni-runtime-profile.json", config);
+
+    const auto result = resolve_from_tree(tree, two_accelerators());
+
+    assert(!result.ok);
+    assert(result.error.find("llm.device") != std::string::npos);
+    assert(result.error.find("empty") != std::string::npos);
+}
+
+static void test_effective_config_reports_static_source() {
+    temporary_model_tree tree;
+    create_complete_model_tree(tree);
+    tree.write("omni-runtime-profile.json", complete_profile_config());
+
+    const auto result = resolve_from_tree(tree, two_accelerators());
+    assert(result.ok);
+    const auto output = omni::format_effective_runtime_config(result.config);
+    assert(output.find("resolved_profile=static_config\n") != std::string::npos);
+    assert(output.find("llm_quantization=Q4_K_M\n") != std::string::npos);
+}
+
+static void test_runtime_profile_controls_session_options_when_present() {
+    omni::effective_runtime_config config;
+    config.duplex_mode       = true;
+    config.tts_gpu_layers    = -1;
+    config.token2wav_device  = "gpu:0";
+    config.token2wav_threads = 32;
+
+    const auto profiled = omni::resolve_runtime_session_options(&config, false, 100, "cpu", 4);
+    assert(profiled.duplex_mode);
+    assert(profiled.tts_gpu_layers == -1);
+    assert(profiled.token2wav_device == "gpu:0");
+    assert(profiled.token2wav_threads == 32);
+    assert(profiled.strict_runtime_config);
+
+    const auto legacy = omni::resolve_runtime_session_options(nullptr, false, 100, "cpu", 4);
+    assert(!legacy.duplex_mode);
+    assert(legacy.tts_gpu_layers == 100);
+    assert(legacy.token2wav_device == "cpu");
+    assert(legacy.token2wav_threads == 4);
+    assert(!legacy.strict_runtime_config);
+}
+
+static void test_model_inventory_only_reports_files_that_exist() {
+    temporary_model_tree tree;
+    tree.touch("MiniCPM-o-4_5-F16.gguf");
+    tree.touch("vision/MiniCPM-o-4_5-vision-F16.gguf");
+
+    const auto inventory = omni::discover_model_inventory(tree.root.string());
+
+    assert(inventory.root == tree.root.string());
+    assert(inventory.llm_f16 == (tree.root / "MiniCPM-o-4_5-F16.gguf").string());
+    assert(inventory.llm_q8_0.empty());
+    assert(inventory.llm_q4_k_m.empty());
+    assert(inventory.vision == (tree.root / "vision/MiniCPM-o-4_5-vision-F16.gguf").string());
+    assert(inventory.token2wav_prompt_cache.empty());
+}
+
+static bool parse_omni_server_arguments(std::vector<std::string> arguments) {
+    common_params        params;
+    std::vector<char *> argv;
+    for (auto & argument : arguments) {
+        argv.push_back(argument.data());
+    }
+    return common_params_parse(static_cast<int>(argv.size()), argv.data(), params, LLAMA_EXAMPLE_OMNI_SERVER);
+}
+
+static void test_omni_runtime_profile_arguments_are_parsed() {
+    common_params            params;
+    std::vector<std::string> arguments = {
+        "llama-omni-server", "--profile", "auto", "--model-dir", "/models/MiniCPM-o-4_5-gguf",
+        "--profile-config", "/models/profile.json", "--token2wav-threads", "32", "--print-effective-config",
+    };
+    std::vector<char *> argv;
+    for (auto & argument : arguments) {
+        argv.push_back(argument.data());
+    }
+
+    const bool parsed =
+        common_params_parse(static_cast<int>(argv.size()), argv.data(), params, LLAMA_EXAMPLE_OMNI_SERVER);
+
+    assert(parsed);
+    assert(params.omni_runtime_profile.profile == "auto");
+    assert(params.omni_runtime_profile.model_dir == "/models/MiniCPM-o-4_5-gguf");
+    assert(params.omni_runtime_profile.profile_config == "/models/profile.json");
+    assert(params.omni_runtime_profile.token2wav_threads == 32);
+    assert(params.omni_runtime_profile.print_effective_config);
+}
+
+static void test_omni_runtime_profile_argument_ranges_are_validated() {
+    assert(!parse_omni_server_arguments({ "llama-omni-server", "--token2wav-threads", "0" }));
+}
+
+static void test_omni_runtime_profile_rejects_autotune_arguments() {
+    assert(!parse_omni_server_arguments({ "llama-omni-server", "--profile", "auto", "--autotune", "refresh" }));
+    assert(!parse_omni_server_arguments({ "llama-omni-server", "--profile", "auto", "--autotune-cache",
+                                          "/tmp/omni-autotune.json" }));
+    assert(!parse_omni_server_arguments({ "llama-omni-server", "--profile", "auto", "--autotune-rounds", "3" }));
+}
+
+int main() {
+    test_auto_requires_static_profile_config();
+    test_static_profile_loads_values_and_maps_logical_devices();
+    test_static_profile_reports_missing_config_file();
+    test_static_profile_reports_invalid_json();
+    test_static_profile_reports_missing_required_field();
+    test_static_profile_reports_missing_model_file();
+    test_static_profile_reports_unavailable_logical_device();
+    test_static_profile_rejects_empty_device_value();
+    test_effective_config_reports_static_source();
+    test_runtime_profile_controls_session_options_when_present();
+    test_model_inventory_only_reports_files_that_exist();
+    test_omni_runtime_profile_arguments_are_parsed();
+    test_omni_runtime_profile_argument_ranges_are_validated();
+    test_omni_runtime_profile_rejects_autotune_arguments();
+    return 0;
+}

--- a/tools/omni/test/test-runtime-profile.cpp
+++ b/tools/omni/test/test-runtime-profile.cpp
@@ -204,6 +204,21 @@ static void test_static_profile_reports_missing_model_file() {
     assert(result.error.find("missing.gguf") != std::string::npos);
 }
 
+static void test_static_profile_rejects_quantization_filename_mismatch() {
+    temporary_model_tree tree;
+    create_complete_model_tree(tree);
+    auto config = complete_profile_config();
+    const auto marker = "\"quantization\": \"Q4_K_M\"";
+    config.replace(config.find(marker), std::string(marker).size(), "\"quantization\": \"F16\"");
+    tree.write("omni-runtime-profile.json", config);
+
+    const auto result = resolve_from_tree(tree, two_accelerators());
+
+    assert(!result.ok);
+    assert(result.error.find("quantization") != std::string::npos);
+    assert(result.error.find("Q4_K_M") != std::string::npos);
+}
+
 static void test_static_profile_reports_unavailable_logical_device() {
     temporary_model_tree tree;
     create_complete_model_tree(tree);
@@ -254,6 +269,7 @@ static void test_runtime_profile_controls_session_options_when_present() {
 
     const auto profiled = omni::resolve_runtime_session_options(&config, false, 100, "cpu", 4);
     assert(profiled.duplex_mode);
+    assert(!profiled.async_mode);
     assert(profiled.tts_gpu_layers == -1);
     assert(profiled.token2wav_device == "gpu:0");
     assert(profiled.token2wav_threads == 32);
@@ -261,6 +277,7 @@ static void test_runtime_profile_controls_session_options_when_present() {
 
     const auto legacy = omni::resolve_runtime_session_options(nullptr, false, 100, "cpu", 4);
     assert(!legacy.duplex_mode);
+    assert(legacy.async_mode);
     assert(legacy.tts_gpu_layers == 100);
     assert(legacy.token2wav_device == "cpu");
     assert(legacy.token2wav_threads == 4);
@@ -331,6 +348,7 @@ int main() {
     test_static_profile_reports_invalid_json();
     test_static_profile_reports_missing_required_field();
     test_static_profile_reports_missing_model_file();
+    test_static_profile_rejects_quantization_filename_mismatch();
     test_static_profile_reports_unavailable_logical_device();
     test_static_profile_rejects_empty_device_value();
     test_effective_config_reports_static_source();

--- a/tools/omni/token2wav/token2wav-impl.cpp
+++ b/tools/omni/token2wav/token2wav-impl.cpp
@@ -6578,7 +6578,8 @@ void hg_t1b_to_bt1(const std::vector<float> & t1b, int64_t T, int64_t B, std::ve
 }  // namespace
 bool voc_hg2_model::voc_hg2_model_init_from_gguf(const std::string & gguf_path_in,
                                                  const std::string & device,
-                                                 int32_t             num_threads_in) {
+                                                 int32_t             num_threads_in,
+                                                 bool                allow_backend_fallback) {
     voc_hg2_model_free();
     gguf_path   = gguf_path_in;
     num_threads = num_threads_in > 0 ? num_threads_in : 1;
@@ -6597,12 +6598,19 @@ bool voc_hg2_model::voc_hg2_model_init_from_gguf(const std::string & gguf_path_i
         backend = ggml_backend_cuda_init(gpu_idx);
 #endif
         if (!backend) {
+#ifdef GGML_USE_CUDA
+            if (!allow_backend_fallback) {
+                LOG_ERROR("voc_hg2_model: requested CUDA device %d is unavailable\n", gpu_idx);
+                voc_hg2_model_free();
+                return false;
+            }
+#endif
             backend = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_GPU, nullptr);
         }
         if (!backend) {
             backend = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_IGPU, nullptr);
         }
-        if (!backend) {
+        if (!backend && allow_backend_fallback) {
             backend = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr);
         }
         std::fprintf(stderr, "voc_hg2_model: init_backend device=%s, gpu_idx=%d, backend=%s\n",
@@ -7184,12 +7192,12 @@ ggml_backend_t flow_loader_init_backend_cpu(std::string & backend_name_out) {
     }
     return backend;
 }
-ggml_backend_t flow_loader_init_backend_gpu_first(std::string & backend_name_out) {
+ggml_backend_t flow_loader_init_backend_gpu_first(std::string & backend_name_out, bool allow_backend_fallback) {
     ggml_backend_t backend = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_GPU, nullptr);
     if (!backend) {
         backend = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_IGPU, nullptr);
     }
-    if (!backend) {
+    if (!backend && allow_backend_fallback) {
         backend = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr);
     }
     if (backend) {
@@ -7217,7 +7225,7 @@ void flowGGUFModelLoader::reset() {
     backend_name_.clear();
     encoder_pre_lookahead_len_ = 3;
 }
-bool flowGGUFModelLoader::init_backend(const std::string & device) {
+bool flowGGUFModelLoader::init_backend(const std::string & device, bool allow_backend_fallback) {
     if (backend_) {
         return true;
     }
@@ -7237,7 +7245,13 @@ bool flowGGUFModelLoader::init_backend(const std::string & device) {
         backend_ = ggml_backend_cuda_init(gpu_idx);
 #endif
         if (!backend_) {
-            backend_ = flow_loader_init_backend_gpu_first(backend_name_);
+#ifdef GGML_USE_CUDA
+            if (!allow_backend_fallback) {
+                LOG_ERROR("flowGGUFModelLoader: requested CUDA device %d is unavailable\n", gpu_idx);
+                return false;
+            }
+#endif
+            backend_ = flow_loader_init_backend_gpu_first(backend_name_, allow_backend_fallback);
         }
         if (backend_) {
             backend_name_ = ggml_backend_name(backend_);
@@ -7278,9 +7292,10 @@ bool flowGGUFModelLoader::bind_all() {
 bool flowGGUFModelLoader::load_from_gguf(const std::string & encoder_gguf_path,
                                          const std::string & flow_matching_gguf_path,
                                          const std::string & flow_extra_gguf_path,
-                                         const std::string & device) {
+                                         const std::string & device,
+                                         bool                  allow_backend_fallback) {
     reset();
-    if (!init_backend(device)) {
+    if (!init_backend(device, allow_backend_fallback)) {
         return false;
     }
     encoder_weights_ = std::make_unique<upsample_encoder_v2::ueUpsampleEncoderModelLoaderGGUF>();
@@ -7599,9 +7614,11 @@ void flowGGUFModelRunner::reset() {
 bool flowGGUFModelRunner::load_from_gguf(const std::string & encoder_gguf_path,
                                          const std::string & flow_matching_gguf_path,
                                          const std::string & flow_extra_gguf_path,
-                                         const std::string & device) {
+                                         const std::string & device,
+                                         bool                  allow_backend_fallback) {
     reset();
-    if (!loader_.load_from_gguf(encoder_gguf_path, flow_matching_gguf_path, flow_extra_gguf_path, device)) {
+    if (!loader_.load_from_gguf(encoder_gguf_path, flow_matching_gguf_path, flow_extra_gguf_path, device,
+                                allow_backend_fallback)) {
         return false;
     }
     set_num_threads(num_threads_);
@@ -8690,6 +8707,10 @@ bool t2m_load_prompt_cache_gguf(const std::string &               gguf_path,
 
 }  // namespace
 
+bool token2wav_device_fallback_allowed(bool strict_runtime_config) {
+    return !strict_runtime_config;
+}
+
 Token2Mel::~Token2Mel() {
 #if defined(ENABLE_COREML) && defined(__APPLE__)
     if (ane_handle_) {
@@ -8704,12 +8725,14 @@ bool Token2Mel::load_model(const std::string & encoder_gguf,
                            const std::string & flow_extra_gguf,
                            const std::string & device,
                            int                 threads,
-                           const std::string & coreml_model_path) {
-    // 用于加载三段GGUF并初始化runner(失败时回退到cpu)
+                           const std::string & coreml_model_path,
+                           bool                allow_device_fallback) {
+    // Load the three GGUF files and keep the requested device when strict mode is active.
     reset_stream();
     runner_.set_num_threads(threads);
-    if (!runner_.load_from_gguf(encoder_gguf, flow_matching_gguf, flow_extra_gguf, device)) {
-        if (device != "cpu") {
+    if (!runner_.load_from_gguf(encoder_gguf, flow_matching_gguf, flow_extra_gguf, device,
+                                allow_device_fallback)) {
+        if (device != "cpu" && allow_device_fallback) {
             LOG_ERROR( "Token2Mel.load_model: load_from_gguf(%s) failed, fallback to cpu\n", device.c_str());
             if (!runner_.load_from_gguf(encoder_gguf, flow_matching_gguf, flow_extra_gguf, "cpu")) {
                 LOG_ERROR( "Token2Mel.load_model: fallback cpu failed\n");
@@ -9478,10 +9501,12 @@ bool Token2MelSession::init_from_prompt_bundle(const std::string & encoder_gguf,
                                                int                 threads,
                                                const std::string & prompt_bundle_dir,
                                                int                 n_timesteps,
-                                               float               temperature) {
+                                               float               temperature,
+                                               bool                allow_device_fallback) {
     // 初始化会话方式1：读取prompt_bundle并执行setup_cache，用于后续feed_*流式推理。
     reset();
-    if (!t2m.load_model(encoder_gguf, flow_matching_gguf, flow_extra_gguf, device, threads)) {
+    if (!t2m.load_model(encoder_gguf, flow_matching_gguf, flow_extra_gguf, device, threads, "",
+                        allow_device_fallback)) {
         return false;
     }
 
@@ -9504,10 +9529,12 @@ bool Token2MelSession::init_from_prompt_cache_gguf(const std::string & encoder_g
                                                    int                 threads,
                                                    const std::string & prompt_cache_gguf_path,
                                                    int                 n_timesteps,
-                                                   float               temperature) {
+                                                   float               temperature,
+                                                   bool                allow_device_fallback) {
     // 初始化会话方式2（从方式1或方式2选自其中一个即可，推荐方式2直接加载gguf）：从prompt_cache.gguf恢复缓存并开始流式推理，跳过prompt_bundle与setup_cache计算。
     reset();
-    if (!t2m.load_model(encoder_gguf, flow_matching_gguf, flow_extra_gguf, device, threads)) {
+    if (!t2m.load_model(encoder_gguf, flow_matching_gguf, flow_extra_gguf, device, threads, "",
+                        allow_device_fallback)) {
         return false;
     }
     if (!t2m.start_stream_with_prompt_cache_gguf(prompt_cache_gguf_path, n_timesteps, temperature)) {
@@ -9652,17 +9679,18 @@ bool Token2Wav::load_models(const std::string & encoder_gguf,
                             const std::string & vocoder_gguf,
                             const std::string & device_token2mel,
                             const std::string & device_vocoder,
-                            const std::string & coreml_model_path) {
+                            const std::string & coreml_model_path,
+                            int                 threads,
+                            bool                allow_device_fallback) {
     reset_stream();
 
-    constexpr int kDefaultThreads = 8;
-    if (!t2m_.load_model(encoder_gguf, flow_matching_gguf, flow_extra_gguf, device_token2mel, kDefaultThreads,
-                         coreml_model_path)) {
+    if (!t2m_.load_model(encoder_gguf, flow_matching_gguf, flow_extra_gguf, device_token2mel, threads,
+                         coreml_model_path, allow_device_fallback)) {
         LOG_ERROR( "Token2Wav.load_models: Token2Mel.load_model failed\n");
         models_loaded_ = false;
         return false;
     }
-    if (!voc_model_.voc_hg2_model_init_from_gguf(vocoder_gguf, device_vocoder, kDefaultThreads)) {
+    if (!voc_model_.voc_hg2_model_init_from_gguf(vocoder_gguf, device_vocoder, threads, allow_device_fallback)) {
         LOG_ERROR( "Token2Wav.load_models: voc_hg2_model_init_from_gguf failed\n");
         models_loaded_ = false;
         return false;

--- a/tools/omni/token2wav/token2wav-impl.h
+++ b/tools/omni/token2wav/token2wav-impl.h
@@ -1589,7 +1589,8 @@ class flowGGUFModelLoader {
     bool load_from_gguf(const std::string & encoder_gguf_path,
                         const std::string & flow_matching_gguf_path,
                         const std::string & flow_extra_gguf_path,
-                        const std::string & device = "cpu");
+                        const std::string & device = "cpu",
+                        bool                  allow_backend_fallback = true);
     std::shared_ptr<upsample_encoder_v2::ueUpsampleConformerEncoderV2> encoder() const { return encoder_model_; }
     std::shared_ptr<flow_matching::fmDiT> estimator() const { return estimator_; }
     std::shared_ptr<flow_matching::fmCausalConditionalCFM> decoder() const { return decoder_; }
@@ -1603,7 +1604,7 @@ class flowGGUFModelLoader {
     }
   private:
     void reset();
-    bool init_backend(const std::string & device);
+    bool init_backend(const std::string & device, bool allow_backend_fallback);
     bool bind_all();
   private:
     ggml_backend_t backend_ = nullptr;
@@ -1657,7 +1658,8 @@ class flowGGUFModelRunner {
     bool load_from_gguf(const std::string & encoder_gguf_path,
                         const std::string & flow_matching_gguf_path,
                         const std::string & flow_extra_gguf_path,
-                        const std::string & device);
+                        const std::string & device,
+                        bool                  allow_backend_fallback = true);
     void set_num_threads(int n_threads);
     const std::string & backend_name() const { return loader_.backend_name(); }
     void set_export_caches_to_host(bool enable) { export_caches_to_host_ = enable; }
@@ -2001,7 +2003,8 @@ struct voc_hg2_model {
     ~voc_hg2_model() { voc_hg2_model_free(); }
     bool voc_hg2_model_init_from_gguf(const std::string & gguf_path_in,
                                       const std::string & device,
-                                      int32_t             num_threads_in);
+                                      int32_t             num_threads_in,
+                                      bool                allow_backend_fallback = true);
     void voc_hg2_model_free();
 };
 struct voc_hg2_runner {
@@ -2031,6 +2034,9 @@ struct voc_hg2_runner {
 namespace omni {
 namespace flow {
 
+// Profile serving must fail closed when a requested device cannot be initialized.
+bool token2wav_device_fallback_allowed(bool strict_runtime_config);
+
 class Token2Mel {
   public:
     struct PromptBundle {
@@ -2056,7 +2062,8 @@ class Token2Mel {
                     const std::string & flow_extra_gguf,
                     const std::string & device              = "gpu",
                     int                 threads             = 8,
-                    const std::string & coreml_model_path  = "");
+                    const std::string & coreml_model_path  = "",
+                    bool                allow_device_fallback = true);
 
     static bool load_prompt_bundle_dir(const std::string & dir, PromptBundle & out);
 
@@ -2140,7 +2147,8 @@ struct Token2MelSession {
                                  int                 threads,
                                  const std::string & prompt_bundle_dir,
                                  int                 n_timesteps = 10,
-                                 float               temperature = 1.0f);
+                                 float               temperature = 1.0f,
+                                 bool                allow_device_fallback = true);
 
     bool init_from_prompt_cache_gguf(const std::string & encoder_gguf,
                                      const std::string & flow_matching_gguf,
@@ -2149,7 +2157,8 @@ struct Token2MelSession {
                                      int                 threads,
                                      const std::string & prompt_cache_gguf_path,
                                      int                 n_timesteps = -1,
-                                     float               temperature = -1.0f);
+                                     float               temperature = -1.0f,
+                                     bool                allow_device_fallback = true);
 
     bool feed_tokens(const int32_t * tokens, int64_t n_tokens, bool is_final, std::vector<float> & mel_bct_out);
 
@@ -2206,7 +2215,9 @@ class Token2Wav {
                      const std::string & vocoder_gguf,
                      const std::string & device_token2mel    = "gpu",
                      const std::string & device_vocoder      = "gpu",
-                     const std::string & coreml_model_path  = "");
+                     const std::string & coreml_model_path  = "",
+                     int                 threads             = 8,
+                     bool                allow_device_fallback = true);
 
     bool start_stream_with_prompt_cache_gguf(const std::string & prompt_cache_gguf_path,
                                              int                 n_timesteps = -1,
@@ -2264,7 +2275,9 @@ struct Token2WavSession {
                                      const std::string & device_vocoder      = "gpu",
                                      int                 n_timesteps         = 10,
                                      float               temperature         = 1.0f,
-                                     const std::string & coreml_model_path  = "");
+                                     const std::string & coreml_model_path  = "",
+                                     int                 threads             = 8,
+                                     bool                allow_device_fallback = true);
 
     bool init_from_prompt_bundle(const std::string & encoder_gguf,
                                  const std::string & flow_matching_gguf,
@@ -2275,7 +2288,9 @@ struct Token2WavSession {
                                  const std::string & device_vocoder      = "gpu",
                                  int                 n_timesteps         = 10,
                                  float               temperature         = 1.0f,
-                                 const std::string & coreml_model_path  = "");
+                                 const std::string & coreml_model_path  = "",
+                                 int                 threads             = 8,
+                                 bool                allow_device_fallback = true);
 
     bool feed_tokens(const int32_t * tokens, int64_t n_tokens, bool is_final, std::vector<float> & wave_bt_out);
 

--- a/tools/omni/token2wav/token2wav.cpp
+++ b/tools/omni/token2wav/token2wav.cpp
@@ -16,12 +16,14 @@ bool Token2WavSession::init_from_prompt_cache_gguf(const std::string & encoder_g
                                                    const std::string & device_vocoder,
                                                    int                 n_timesteps,
                                                    float               temperature,
-                                                   const std::string & coreml_model_path) {
+                                                   const std::string & coreml_model_path,
+                                                   int                 threads,
+                                                   bool                allow_device_fallback) {
     // 初始化方式第一种，仅需使用此方式即可，加载模型所有的gguf内容
     const auto t0 = std::chrono::steady_clock::now();
     reset();
     if (!t2w.load_models(encoder_gguf, flow_matching_gguf, flow_extra_gguf, vocoder_gguf, device_token2mel,
-                         device_vocoder, coreml_model_path)) {
+                         device_vocoder, coreml_model_path, threads, allow_device_fallback)) {
         return false;
     }
     if (!t2w.start_stream_with_prompt_cache_gguf(prompt_cache_gguf_path, n_timesteps, temperature)) {
@@ -46,11 +48,13 @@ bool Token2WavSession::init_from_prompt_bundle(const std::string & encoder_gguf,
                                                const std::string & device_vocoder,
                                                int                 n_timesteps,
                                                float               temperature,
-                                               const std::string & coreml_model_path) {
+                                               const std::string & coreml_model_path,
+                                               int                 threads,
+                                               bool                allow_device_fallback) {
     // 初始化方式第二种（如要更换示例音频使用此接口作为备用）
     reset();
     if (!t2w.load_models(encoder_gguf, flow_matching_gguf, flow_extra_gguf, vocoder_gguf, device_token2mel,
-                         device_vocoder, coreml_model_path)) {
+                         device_vocoder, coreml_model_path, threads, allow_device_fallback)) {
         return false;
     }
     Token2Mel::PromptBundle pb;

--- a/tools/omni/tts-weight-layout.cpp
+++ b/tools/omni/tts-weight-layout.cpp
@@ -1,0 +1,48 @@
+#include "tts-weight-layout.h"
+
+#include <algorithm>
+
+namespace omni {
+
+bool has_supported_head_code_weight_layout(int64_t n_dims,
+                                           int64_t n_elements,
+                                           int64_t dim0,
+                                           int64_t dim1,
+                                           int64_t hidden_size,
+                                           int64_t num_audio_tokens) {
+    if (n_dims != 2 || hidden_size <= 0 || num_audio_tokens <= 0 ||
+        n_elements != hidden_size * num_audio_tokens) {
+        return false;
+    }
+
+    return (dim0 == hidden_size && dim1 == num_audio_tokens) ||
+           (dim0 == num_audio_tokens && dim1 == hidden_size);
+}
+
+bool copy_head_code_weight_to_output_major(const float * source,
+                                           int64_t       dim0,
+                                           int64_t       dim1,
+                                           int64_t       hidden_size,
+                                           int64_t       num_audio_tokens,
+                                           float *       destination) {
+    if (source == nullptr || destination == nullptr ||
+        !has_supported_head_code_weight_layout(
+            2, hidden_size * num_audio_tokens, dim0, dim1, hidden_size, num_audio_tokens)) {
+        return false;
+    }
+
+    const bool has_standard_layout = dim0 == hidden_size;
+    if (has_standard_layout) {
+        std::copy_n(source, hidden_size * num_audio_tokens, destination);
+        return true;
+    }
+
+    for (int64_t token = 0; token < num_audio_tokens; ++token) {
+        for (int64_t hidden = 0; hidden < hidden_size; ++hidden) {
+            destination[token * hidden_size + hidden] = source[hidden * num_audio_tokens + token];
+        }
+    }
+    return true;
+}
+
+} // namespace omni

--- a/tools/omni/tts-weight-layout.h
+++ b/tools/omni/tts-weight-layout.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cstdint>
+
+namespace omni {
+
+bool has_supported_head_code_weight_layout(int64_t n_dims,
+                                           int64_t n_elements,
+                                           int64_t dim0,
+                                           int64_t dim1,
+                                           int64_t hidden_size,
+                                           int64_t num_audio_tokens);
+
+bool copy_head_code_weight_to_output_major(const float * source,
+                                           int64_t       dim0,
+                                           int64_t       dim1,
+                                           int64_t       hidden_size,
+                                           int64_t       num_audio_tokens,
+                                           float *       destination);
+
+} // namespace omni

--- a/tools/omni/vision.cpp
+++ b/tools/omni/vision.cpp
@@ -228,10 +228,17 @@ struct vision_ctx {
             throw std::runtime_error("failed to initialize CPU backend");
         }
         if (ctx_params.use_gpu) {
-            auto backend_name = std::getenv("Omni_BACKEND_DEVICE");
+            const char * backend_name = ctx_params.backend_device;
+            const bool explicit_backend = backend_name != nullptr && std::strlen(backend_name) > 0;
+            if (backend_name == nullptr || std::strlen(backend_name) == 0) {
+                backend_name = std::getenv("Omni_BACKEND_DEVICE");
+            }
             if (backend_name != nullptr) {
                 backend = ggml_backend_init_by_name(backend_name, nullptr);
                 if (!backend) {
+                    if (explicit_backend) {
+                        throw std::runtime_error(std::string("failed to initialize requested vision backend: ") + backend_name);
+                    }
                     LOG_WRN("%s: Warning: Failed to initialize \"%s\" backend, falling back to default GPU backend\n", __func__, backend_name);
                 }
             }

--- a/tools/omni/vision.h
+++ b/tools/omni/vision.h
@@ -75,6 +75,7 @@ struct vision_context_params {
     bool use_gpu;
     enum ggml_log_level verbosity;
     const char * coreml_model_path; // path to CoreML model (.mlmodelc) for ANE acceleration
+    const char * backend_device = nullptr;
 };
 
 

--- a/tools/server/CMakeLists.txt
+++ b/tools/server/CMakeLists.txt
@@ -57,6 +57,18 @@ target_compile_features(${TARGET_OMNI} PRIVATE cxx_std_17)
 target_include_directories(${TARGET_OMNI} PRIVATE ${CMAKE_SOURCE_DIR})
 target_include_directories(${TARGET_OMNI} PRIVATE ${CMAKE_SOURCE_DIR}/vendor/cpp-httplib)
 target_include_directories(${TARGET_OMNI} PRIVATE ${CMAKE_SOURCE_DIR}/vendor)
+target_compile_definitions(${TARGET_OMNI} PRIVATE OMNI_ASSET_DIR="${CMAKE_SOURCE_DIR}/tools/omni/assets")
+
+if (LLAMA_BUILD_TESTS)
+    add_test(
+        NAME test-omni-server-runtime-profile
+        COMMAND ${CMAKE_COMMAND}
+            -DOMNI_SERVER=$<TARGET_FILE:${TARGET_OMNI}>
+            -DTEST_ROOT=${CMAKE_CURRENT_BINARY_DIR}/runtime-profile-smoke-models
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/test-runtime-profile-server.cmake
+    )
+    set_tests_properties(test-omni-server-runtime-profile PROPERTIES LABELS "main;omni")
+endif()
 
 # llama-tts-server executable (standalone VoxCPM2 TTS HTTP API)
 

--- a/tools/server/server-omni.cpp
+++ b/tools/server/server-omni.cpp
@@ -2,6 +2,8 @@
 // Based on the old server.cpp omni handlers, adapted for the new llama.cpp APIs
 
 #include "omni.h"
+#include "runtime-profile-session.h"
+#include "runtime-profile.h"
 #include "llama.h"
 #include "common.h"
 #include "log.h"
@@ -12,10 +14,11 @@
 
 #include <mutex>
 #include <thread>
-#include <queue>
-#include <condition_variable>
+#include <chrono>
 #include <fstream>
+#include <optional>
 #include <string>
+#include <vector>
 
 #include "httplib.h"
 #include <nlohmann/json.hpp>
@@ -91,7 +94,7 @@ int main(int argc, char ** argv) {
 
     common_init();
 
-    if (!common_params_parse(argc, argv, params, LLAMA_EXAMPLE_SERVER)) {
+    if (!common_params_parse(argc, argv, params, LLAMA_EXAMPLE_OMNI_SERVER)) {
         return 1;
     }
 
@@ -105,6 +108,74 @@ int main(int argc, char ** argv) {
 
     llama_backend_init();
     llama_numa_init(params.numa);
+
+    std::optional<omni::effective_runtime_config> runtime_config;
+    if (!params.omni_runtime_profile.profile.empty()) {
+        std::string model_root = params.omni_runtime_profile.model_dir;
+        if (model_root.empty() && !params.model.path.empty()) {
+            model_root = parent_dir(params.model.path);
+        }
+        if (model_root.empty()) {
+            LOG_ERR("--profile auto requires --model-dir or --model to locate the model tree and static profile config\n");
+            llama_backend_free();
+            return 1;
+        }
+        if (params.omni_runtime_profile.model_explicit) {
+            std::ifstream explicit_model(params.model.path, std::ios::binary);
+            if (!explicit_model.good()) {
+                LOG_ERR("missing explicit LLM model: %s\n", params.model.path.c_str());
+                llama_backend_free();
+                return 1;
+            }
+        }
+
+        const auto inventory = omni::discover_model_inventory(model_root);
+        const auto hardware = omni::detect_hardware_snapshot();
+        omni::runtime_profile_overrides overrides;
+        if (params.omni_runtime_profile.model_explicit) {
+            overrides.llm_model = params.model.path;
+        }
+        if (params.omni_runtime_profile.n_gpu_layers_explicit) {
+            overrides.n_gpu_layers = params.n_gpu_layers;
+        }
+        if (params.omni_runtime_profile.n_ctx_explicit) {
+            overrides.n_ctx = params.n_ctx;
+        }
+        if (params.omni_runtime_profile.token2wav_threads_explicit) {
+            overrides.token2wav_threads = params.omni_runtime_profile.token2wav_threads;
+        }
+
+        const std::string profile_config = params.omni_runtime_profile.profile_config.empty()
+                                                ? model_root + "/omni-runtime-profile.json"
+                                                : params.omni_runtime_profile.profile_config;
+        auto resolved = params.omni_runtime_profile.profile == "auto"
+                            ? omni::resolve_runtime_profile_from_config(profile_config, hardware, inventory, overrides)
+                            : omni::resolve_runtime_profile(params.omni_runtime_profile.profile, hardware, inventory,
+                                                            overrides);
+        if (!resolved.ok) {
+            LOG_ERR("failed to resolve Omni runtime profile: %s\n", resolved.error.c_str());
+            llama_backend_free();
+            return 1;
+        }
+
+        runtime_config = std::move(resolved.config);
+
+        std::string apply_error;
+        if (!omni::apply_effective_runtime_config(params, *runtime_config, apply_error)) {
+            LOG_ERR("%s\n", apply_error.c_str());
+            llama_backend_free();
+            return 1;
+        }
+
+        const std::string effective_config = omni::format_effective_runtime_config(*runtime_config);
+        if (params.omni_runtime_profile.print_effective_config) {
+            std::fputs(effective_config.c_str(), stdout);
+            std::fflush(stdout);
+            llama_backend_free();
+            return 0;
+        }
+        LOG_INF("Resolved Omni runtime configuration:\n%s", effective_config.c_str());
+    }
 
     LOG_INF("Omni HTTP server starting...\n");
 
@@ -146,9 +217,16 @@ int main(int argc, char ** argv) {
 
         int media_type = data.value("msg_type", data.value("media_type", 2));
         bool use_tts   = data.value("use_tts", true);
-        bool duplex_mode = data.value("duplex_mode", false);
-        int tts_gpu_layers = data.value("tts_gpu_layers", 100);
-        std::string token2wav_device = data.value("token2wav_device", "gpu:0");
+        const auto session_options = omni::resolve_runtime_session_options(
+            runtime_config ? &*runtime_config : nullptr,
+            data.value("duplex_mode", false),
+            data.value("tts_gpu_layers", 100),
+            data.value("token2wav_device", "gpu:0"),
+            data.value("token2wav_threads", params.omni_runtime_profile.token2wav_threads));
+        bool duplex_mode = session_options.duplex_mode;
+        int tts_gpu_layers = session_options.tts_gpu_layers;
+        std::string token2wav_device = session_options.token2wav_device;
+        int token2wav_threads = session_options.token2wav_threads;
         std::string output_dir = data.value("output_dir", "./tools/omni/output");
         std::string voice_audio = data.value("voice_audio", "");
 
@@ -188,7 +266,9 @@ int main(int argc, char ** argv) {
 
         omni_context * octx = omni_init(&params, media_type, use_tts, params.tts_bin_dir, tts_gpu_layers,
                                          token2wav_device, duplex_mode,
-                                         /*existing_model=*/nullptr, /*existing_ctx=*/nullptr, output_dir);
+                                         /*existing_model=*/nullptr, /*existing_ctx=*/nullptr, output_dir,
+                                         runtime_config ? &*runtime_config : nullptr,
+                                         session_options.strict_runtime_config, token2wav_threads);
         if (!octx) {
             res_error(res, format_error_response("omni_init failed"));
             return;
@@ -197,6 +277,15 @@ int main(int argc, char ** argv) {
         // voice clone / assistant prompt
         if (data.contains("voice_clone_prompt")) octx->omni_voice_clone_prompt = data["voice_clone_prompt"];
         if (data.contains("assistant_prompt")) octx->omni_assistant_prompt = data["assistant_prompt"];
+        octx->ref_audio_path = voice_audio;
+
+        // The HTTP contract reserves cnt=0 for session initialization. Complete
+        // that prefill here so the first client frame can start at cnt=1.
+        if (!stream_prefill(octx, voice_audio, /*img_fname=*/"", /*index=*/0)) {
+            omni_free(octx);
+            res_error(res, format_error_response("omni_init failed to initialize the streaming session"));
+            return;
+        }
 
         {
             std::lock_guard<std::mutex> lock(state.octx_mutex);
@@ -339,6 +428,10 @@ int main(int argc, char ** argv) {
                 // send done
                 static const std::string ev_done = "data: [DONE]\n\n";
                 sink.write(ev_done.data(), ev_done.size());
+                // Mark the chunked response complete. Returning false here
+                // skips cpp-httplib's terminating chunk and makes clients
+                // report an incomplete transfer.
+                sink.done();
                 return true;
             });
     });
@@ -368,7 +461,8 @@ int main(int argc, char ** argv) {
     svr.WebSocket("/backend", [&](const httplib::Request &, httplib::ws::WebSocket & ws) {
         handle_ws_backend(ws, state.session_mgr, params,
                           /*model*/nullptr, /*ctx*/nullptr,
-                          state.octx, state.octx_mutex);
+                          state.octx, state.octx_mutex,
+                          runtime_config ? &*runtime_config : nullptr);
     });
 
     svr.Post("/sessions/:session_id/close", [&](const httplib::Request & req, httplib::Response & res) {

--- a/tools/server/test-runtime-profile-server.cmake
+++ b/tools/server/test-runtime-profile-server.cmake
@@ -1,0 +1,140 @@
+file(REMOVE_RECURSE "${TEST_ROOT}")
+file(MAKE_DIRECTORY
+    "${TEST_ROOT}/vision"
+    "${TEST_ROOT}/audio"
+    "${TEST_ROOT}/tts"
+    "${TEST_ROOT}/token2wav-gguf"
+)
+
+foreach(relative_path IN ITEMS
+    MiniCPM-o-4_5-F16.gguf
+    MiniCPM-o-4_5-Q8_0.gguf
+    MiniCPM-o-4_5-Q4_K_M.gguf
+    vision/MiniCPM-o-4_5-vision-F16.gguf
+    audio/MiniCPM-o-4_5-audio-F16.gguf
+    tts/MiniCPM-o-4_5-tts-F16.gguf
+    tts/MiniCPM-o-4_5-projector-F16.gguf
+    token2wav-gguf/encoder.gguf
+    token2wav-gguf/flow_matching.gguf
+    token2wav-gguf/flow_extra.gguf
+    token2wav-gguf/hifigan2.gguf
+    token2wav-gguf/prompt_cache.gguf
+)
+    file(WRITE "${TEST_ROOT}/${relative_path}" "test")
+endforeach()
+
+# Keep this smoke fixture backend-portable; primary resolves to the first
+# visible accelerator on CUDA, Metal, and other GGML backends.
+file(WRITE "${TEST_ROOT}/omni-runtime-profile.json" [=[
+{
+  "schema_version": 1,
+  "profile": "auto",
+  "llm": {
+    "model": "MiniCPM-o-4_5-F16.gguf",
+    "quantization": "F16",
+    "device": "primary",
+    "n_gpu_layers": -2
+  },
+  "vision": {
+    "model": "vision/MiniCPM-o-4_5-vision-F16.gguf",
+    "device": "primary"
+  },
+  "audio": {
+    "model": "audio/MiniCPM-o-4_5-audio-F16.gguf",
+    "device": "primary"
+  },
+  "tts": {
+    "model": "tts/MiniCPM-o-4_5-tts-F16.gguf",
+    "device": "primary",
+    "gpu_layers": -1
+  },
+  "projector": {
+    "model": "tts/MiniCPM-o-4_5-projector-F16.gguf",
+    "device": "primary"
+  },
+  "token2wav": {
+    "model_dir": "token2wav-gguf",
+    "device": "primary",
+    "threads": 8
+  },
+  "runtime": {
+    "n_ctx": 8192,
+    "duplex": true,
+    "async": true,
+    "vpm_batch_encode": true
+  }
+}
+]=])
+
+execute_process(
+    COMMAND "${OMNI_SERVER}"
+        --profile auto
+        --model-dir "${TEST_ROOT}"
+        --print-effective-config
+    RESULT_VARIABLE result
+    OUTPUT_VARIABLE stdout
+    ERROR_VARIABLE stderr
+    TIMEOUT 20
+)
+
+if(NOT result EQUAL 0)
+    message(FATAL_ERROR "llama-omni-server profile resolution failed (${result})\nstdout:\n${stdout}\nstderr:\n${stderr}")
+endif()
+
+if(NOT stdout MATCHES "profile=auto")
+    message(FATAL_ERROR "effective config did not contain profile=auto\nstdout:\n${stdout}")
+endif()
+if(NOT stdout MATCHES "resolved_profile=static_config")
+    message(FATAL_ERROR "effective config did not identify the static profile config\nstdout:\n${stdout}")
+endif()
+if(NOT stdout MATCHES "token2wav_model_dir=${TEST_ROOT}/token2wav-gguf")
+    message(FATAL_ERROR "effective config did not contain the Token2Wav model directory\nstdout:\n${stdout}")
+endif()
+if(NOT stdout MATCHES "placement_plan_count=6")
+    message(FATAL_ERROR "effective config did not contain all six module placements\nstdout:\n${stdout}")
+endif()
+if(NOT stdout MATCHES "placement=llm,")
+    message(FATAL_ERROR "effective config did not contain the LLM placement\nstdout:\n${stdout}")
+endif()
+if(NOT stdout MATCHES "placement=token2wav,")
+    message(FATAL_ERROR "effective config did not contain the Token2Wav placement\nstdout:\n${stdout}")
+endif()
+
+file(REMOVE "${TEST_ROOT}/omni-runtime-profile.json")
+execute_process(
+    COMMAND "${OMNI_SERVER}"
+        --profile auto
+        --model-dir "${TEST_ROOT}"
+        --print-effective-config
+    RESULT_VARIABLE missing_config_result
+    OUTPUT_VARIABLE missing_config_stdout
+    ERROR_VARIABLE missing_config_stderr
+    TIMEOUT 20
+)
+if(missing_config_result EQUAL 0)
+    message(FATAL_ERROR "missing profile config was accepted\nstdout:\n${missing_config_stdout}\nstderr:\n${missing_config_stderr}")
+endif()
+if(NOT missing_config_stderr MATCHES "profile config file")
+    message(FATAL_ERROR "missing profile config error was not actionable\nstderr:\n${missing_config_stderr}")
+endif()
+
+execute_process(
+    COMMAND "${OMNI_SERVER}"
+        --profile auto
+        --model-dir "${TEST_ROOT}"
+        --model "${TEST_ROOT}/missing-explicit-model.gguf"
+        --print-effective-config
+    RESULT_VARIABLE missing_result
+    OUTPUT_VARIABLE missing_stdout
+    ERROR_VARIABLE missing_stderr
+    TIMEOUT 20
+)
+
+file(REMOVE_RECURSE "${TEST_ROOT}")
+
+if(missing_result EQUAL 0)
+    message(FATAL_ERROR "a missing explicit LLM model was accepted\nstdout:\n${missing_stdout}\nstderr:\n${missing_stderr}")
+endif()
+if(NOT missing_stderr MATCHES "missing explicit LLM model")
+    message(FATAL_ERROR "missing explicit LLM model error was not actionable\nstderr:\n${missing_stderr}")
+endif()

--- a/tools/server/ws_handler.cpp
+++ b/tools/server/ws_handler.cpp
@@ -14,6 +14,8 @@
 #include "session.h"
 #include "protocol.h"
 #include "omni.h"
+#include "runtime-profile.h"
+#include "runtime-profile-session.h"
 #include "common.h"
 #include "llama.h"
 #include "log.h"
@@ -520,7 +522,8 @@ static void configure_turn_based_prompt(omni_context * octx,
 static omni_context * create_session_octx(common_params & params, const ParsedSessionInit & init,
                                           llama_model * model, llama_context * ctx,
                                           omni_context *& shared_octx,
-                                          const std::string & output_dir) {
+                                          const std::string & output_dir,
+                                          const omni::effective_runtime_config * runtime_config) {
     int media_type = 2; // omni
     bool duplex_mode = (init.mode == "full_duplex");
     bool use_tts = init.use_tts;
@@ -545,9 +548,16 @@ static omni_context * create_session_octx(common_params & params, const ParsedSe
         shared_octx = nullptr;
     }
 
-    omni_context * octx = omni_init(&p, media_type, use_tts, p.tts_bin_dir, /*tts_gpu_layers*/99,
-                                     /*token2wav_device*/"gpu:0", duplex_mode,
-                                     model, ctx, output_dir);
+    const auto session_options = omni::resolve_runtime_session_options(
+            runtime_config, duplex_mode, /*requested_tts_gpu_layers=*/99, /*requested_token2wav_device=*/"gpu:0",
+            params.omni_runtime_profile.token2wav_threads);
+    const int tts_gpu_layers = session_options.tts_gpu_layers;
+    const std::string token2wav_device = session_options.token2wav_device;
+    const int token2wav_threads = session_options.token2wav_threads;
+    omni_context * octx = omni_init(&p, media_type, use_tts, p.tts_bin_dir, tts_gpu_layers,
+                                     token2wav_device, duplex_mode,
+                                     model, ctx, output_dir, runtime_config,
+                                     session_options.strict_runtime_config, token2wav_threads);
     if (!octx) {
         LOG_ERR("create_session_octx: omni_init failed\n");
         return nullptr;
@@ -578,7 +588,8 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
                         llama_model * model,
                         llama_context * ctx,
                         omni_context *& shared_octx,
-                        std::mutex & octx_mutex) {
+                        std::mutex & octx_mutex,
+                        const omni::effective_runtime_config * runtime_config) {
     const std::string temp_dir = (fs::temp_directory_path() / "omni_ws").string();
     fs::create_directories(temp_dir);
     int msg_counter = 0;
@@ -646,7 +657,8 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
     omni_context * octx = nullptr;
     {
         std::lock_guard<std::mutex> lock(octx_mutex);
-        octx = create_session_octx(params_base, parsed_init, model, ctx, shared_octx, session_output_dir);
+        octx = create_session_octx(
+                params_base, parsed_init, model, ctx, shared_octx, session_output_dir, runtime_config);
     }
     if (!octx) {
         fail_fast(session_id, "omni_init_failed");

--- a/tools/server/ws_handler.cpp
+++ b/tools/server/ws_handler.cpp
@@ -174,11 +174,11 @@ static void stop_reusable_octx_threads(omni_context * octx) {
 // clear LLM/TTS/whisper KV caches, so the next session starts clean on the same
 // loaded model. Used by the shared-octx reuse path in create_session_octx.
 static void reset_octx_for_session(omni_context * octx, const ParsedSessionInit & init,
-                                   const std::string & output_dir) {
+                                   const std::string & output_dir,
+                                   bool duplex_mode, bool async_mode) {
     stop_reusable_octx_threads(octx);
 
-    const bool duplex_mode = (init.mode == "full_duplex");
-    octx->async = true;
+    octx->async = async_mode;
     octx->duplex_mode = duplex_mode;
     octx->base_output_dir = output_dir;
 
@@ -525,8 +525,11 @@ static omni_context * create_session_octx(common_params & params, const ParsedSe
                                           const std::string & output_dir,
                                           const omni::effective_runtime_config * runtime_config) {
     int media_type = 2; // omni
-    bool duplex_mode = (init.mode == "full_duplex");
     bool use_tts = init.use_tts;
+    const auto session_options = omni::resolve_runtime_session_options(
+            runtime_config, init.mode == "full_duplex", /*requested_tts_gpu_layers=*/99,
+            /*requested_token2wav_device=*/"gpu:0", params.omni_runtime_profile.token2wav_threads);
+    const bool duplex_mode = session_options.duplex_mode;
 
     // Build params for omni_init
     auto & p = params;
@@ -536,7 +539,7 @@ static omni_context * create_session_octx(common_params & params, const ParsedSe
     // Reuse the server-owned context if it matches this session's mode (avoids
     // reloading the model); otherwise tear it down and build a fresh one.
     if (shared_octx && shared_octx->duplex_mode == duplex_mode && shared_octx->use_tts == use_tts) {
-        reset_octx_for_session(shared_octx, init, output_dir);
+        reset_octx_for_session(shared_octx, init, output_dir, duplex_mode, session_options.async_mode);
         apply_session_config(p, shared_octx, init);
         LOG_INF("create_session_octx: reused shared octx, duplex=%d, output_dir=%s\n",
                 duplex_mode, output_dir.c_str());
@@ -548,9 +551,6 @@ static omni_context * create_session_octx(common_params & params, const ParsedSe
         shared_octx = nullptr;
     }
 
-    const auto session_options = omni::resolve_runtime_session_options(
-            runtime_config, duplex_mode, /*requested_tts_gpu_layers=*/99, /*requested_token2wav_device=*/"gpu:0",
-            params.omni_runtime_profile.token2wav_threads);
     const int tts_gpu_layers = session_options.tts_gpu_layers;
     const std::string token2wav_device = session_options.token2wav_device;
     const int token2wav_threads = session_options.token2wav_threads;
@@ -563,7 +563,7 @@ static omni_context * create_session_octx(common_params & params, const ParsedSe
         return nullptr;
     }
 
-    octx->async = true;
+    octx->async = session_options.async_mode;
     octx->duplex_mode = duplex_mode;
     apply_session_config(p, octx, init);
 
@@ -667,7 +667,7 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
 
     // Full-duplex requires index=0 prefill before the first frame. This
     // initializes the system prompt and starts the duplex encoder/LLM pipeline.
-    if (parsed_init.mode == "full_duplex" || !parsed_init.ref_audio_b64.empty()) {
+    if (octx->duplex_mode || !parsed_init.ref_audio_b64.empty()) {
         std::string voice_wav;
         if (!parsed_init.ref_audio_b64.empty()) {
             voice_wav = TempMediaFiles::write_audio_wav(parsed_init.ref_audio_b64, temp_dir, msg_counter++);
@@ -706,9 +706,10 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
     }
 
     // Send session.created
-    send_event(make_session_created(session_id, parsed_init.mode, make_runtime_metrics(octx)));
+    const std::string effective_mode = octx->duplex_mode ? "full_duplex" : "turn_based";
+    send_event(make_session_created(session_id, effective_mode, make_runtime_metrics(octx)));
 
-    LOG_INF("WS /backend: session %s activated, mode=%s\n", session_id.c_str(), parsed_init.mode.c_str());
+    LOG_INF("WS /backend: session %s activated, mode=%s\n", session_id.c_str(), effective_mode.c_str());
 
     // ================================================================
     // Setup audio output callback — sends audio_delta events via WS
@@ -815,7 +816,7 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
         // session mode (schema §7.4 / network §7): turn_based MUST carry
         // `messages`, full_duplex MUST NOT. A mismatch is a fatal protocol
         // violation, not a recoverable branch.
-        if (parsed_init.mode == "turn_based") {
+        if (!octx->duplex_mode) {
             // ================================================================
             // Turn-based input processing
             // ================================================================

--- a/tools/server/ws_handler.h
+++ b/tools/server/ws_handler.h
@@ -12,6 +12,10 @@ struct llama_model;
 struct llama_context;
 class SessionManager;
 
+namespace omni {
+struct effective_runtime_config;
+}
+
 namespace httplib {
 namespace ws { class WebSocket; }
 }
@@ -26,7 +30,8 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
                        llama_model * model,
                        llama_context * ctx,
                        omni_context *& shared_octx,  // server-owned, reused across sessions
-                       std::mutex & octx_mutex);
+                       std::mutex & octx_mutex,
+                       const omni::effective_runtime_config * runtime_config = nullptr);
 
 // ============================================================================
 // Helpers: base64 audio/JPEG → temp files


### PR DESCRIPTION
## Overview

Add a static JSON-backed runtime profile for `llama-omni-server`.

`--profile auto` now reads `<model-dir>/omni-runtime-profile.json`, or the path supplied by `--profile-config`. The file explicitly names the LLM, Vision, Audio, TTS, Projector, and Token2Wav assets, GGML backend devices, quantization, GPU layer settings, and runtime options. The resolver validates every required field, model asset, Token2Wav asset, and requested device before loading weights. Missing or invalid configuration fails closed instead of selecting a built-in profile or fallback device.

The server accepts fixed GGML device names such as `CUDA0`, `CUDA1`, and `cpu`, while retaining `primary` and `secondary` as compatibility aliases. Profile-controlled session settings cannot be replaced by request fields. The PR also adds the profile example and focused parser/server tests.

## Validation

- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DLLAMA_BUILD_TESTS=ON -DGGML_METAL=ON -DGGML_CUDA=OFF`
- `cmake --build build --target llama-omni-server test-runtime-profile test-head-code-layout -j4`
- `ctest --test-dir build --output-on-failure -R 'test-runtime-profile|test-head-code-layout|test-omni-server-runtime-profile'`
- Result: `3/3` tests passed.
- `git diff --check`

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. AI assistance was used for code review, mechanical edits, and test orchestration. The contributor reviewed the resulting changes and is responsible for the submission.

