### PR TITLE
VoxCPM2: apply --threads to inference backends

### DIFF
--- a/tools/omni/voxcpm2/voxcpm2_runtime.cpp
+++ b/tools/omni/voxcpm2/voxcpm2_runtime.cpp
@@ -1,6 +1,7 @@
 #include "voxcpm2_runtime.h"
 
 #include "ggml-alloc.h"
+#include "ggml-cpu.h"
 #include "gguf.h"
 #include "log.h"
 
@@ -689,6 +690,18 @@ bool VoxCPM2Runtime::init(const std::string & base_lm_path,
     reset_state();
     LOG_INF("VoxCPM2Runtime: initialized (embedding_scale=%.3f)\n", embedding_scale);
     return true;
+}
+
+void VoxCPM2Runtime::set_n_threads(int n_threads) {
+    if (n_threads < 1) {
+        return;
+    }
+    if (base_lm.ctx) {
+        llama_set_n_threads(base_lm.ctx, n_threads, n_threads);
+    }
+    if (backend && ggml_backend_is_cpu(backend)) {
+        ggml_backend_cpu_set_n_threads(backend, n_threads);
+    }
 }
 
 bool VoxCPM2Runtime::build_text_tokenizer_metadata(const std::string & base_lm_path) {

--- a/tools/omni/voxcpm2/voxcpm2_runtime.h
+++ b/tools/omni/voxcpm2/voxcpm2_runtime.h
@@ -173,6 +173,7 @@ struct VoxCPM2Runtime {
                                                               const VoxCPM2GenerateParams &     params = {});
 
     void reset_state();
+    void set_n_threads(int n_threads);
     void free();
 
     bool initialized() const { return is_initialized; }

--- a/tools/server/server-voxcpm2.cpp
+++ b/tools/server/server-voxcpm2.cpp
@@ -259,6 +259,7 @@ int main(int argc, char ** argv) {
                 res_error(res, format_error_response("VoxCPM2 init failed: " + err, "server_error"));
                 return;
             }
+            rt->set_n_threads(params.cpuparams.n_threads);
             state.runtime = rt;
         }
 
@@ -511,6 +512,7 @@ int main(int argc, char ** argv) {
             llama_backend_free();
             return 1;
         }
+        rt->set_n_threads(params.cpuparams.n_threads);
         state.runtime = rt;
         LOG_INF("VoxCPM2 loaded, sample_rate=%d\n", rt->sample_rate());
     }


### PR DESCRIPTION
## Overview

Apply --threads to both VoxCPM2 inference backends after runtime initialization. This covers startup and POST /v1/voxcpm2/init.

Fixes #103

## Additional information

Verified with a Windows x64 Release build of llama-tts-server and a --help smoke run.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO