### PR TITLE
feat(omni): add native C++ GGUF voice cloning

### DIFF
--- a/tools/omni/CMakeLists.txt
+++ b/tools/omni/CMakeLists.txt
@@ -239,4 +239,15 @@ if (LLAMA_BUILD_TESTS)
     target_compile_features(${TARGET_T2W_FRONTEND_TEST} PRIVATE cxx_std_17)
     add_test(NAME ${TARGET_T2W_FRONTEND_TEST} COMMAND ${TARGET_T2W_FRONTEND_TEST})
     set_tests_properties(${TARGET_T2W_FRONTEND_TEST} PROPERTIES LABELS "main;omni;tts")
+
+    set(TARGET_T2W_SESSION_TEST test-token2wav-session)
+    add_executable(${TARGET_T2W_SESSION_TEST} test/test-token2wav-session.cpp)
+    target_link_libraries(${TARGET_T2W_SESSION_TEST} PRIVATE omni)
+    target_include_directories(${TARGET_T2W_SESSION_TEST} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/token2wav)
+    target_compile_features(${TARGET_T2W_SESSION_TEST} PRIVATE cxx_std_17)
+    add_test(NAME ${TARGET_T2W_SESSION_TEST} COMMAND ${TARGET_T2W_SESSION_TEST})
+    set_tests_properties(${TARGET_T2W_SESSION_TEST} PROPERTIES
+        SKIP_RETURN_CODE 77
+        LABELS "main;omni;tts"
+    )
 endif()

--- a/tools/omni/CMakeLists.txt
+++ b/tools/omni/CMakeLists.txt
@@ -19,6 +19,10 @@ add_library(omni
             vision.cpp
             vision.h
             omni-impl.h
+            token2wav/token2wav-frontend.cpp
+            token2wav/token2wav-frontend.h
+            token2wav/token2wav-frontend-gguf.cpp
+            token2wav/token2wav-frontend-gguf.h
             token2wav/token2wav-impl.cpp
             token2wav/token2wav-impl.h
             token2wav/token2wav.cpp
@@ -225,4 +229,14 @@ if(ENABLE_COREML)
     set_target_properties  (${TARGET_T2W_ANE_E2E} PROPERTIES OUTPUT_NAME llama-omni-test-t2w-ane-end2end)
     target_link_libraries  (${TARGET_T2W_ANE_E2E} PRIVATE llama-common omni Threads::Threads)
     target_compile_features(${TARGET_T2W_ANE_E2E} PRIVATE cxx_std_17)
+endif()
+
+if (LLAMA_BUILD_TESTS)
+    set(TARGET_T2W_FRONTEND_TEST test-token2wav-frontend)
+    add_executable(${TARGET_T2W_FRONTEND_TEST} test/test-token2wav-frontend.cpp)
+    target_link_libraries(${TARGET_T2W_FRONTEND_TEST} PRIVATE omni)
+    target_include_directories(${TARGET_T2W_FRONTEND_TEST} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/token2wav)
+    target_compile_features(${TARGET_T2W_FRONTEND_TEST} PRIVATE cxx_std_17)
+    add_test(NAME ${TARGET_T2W_FRONTEND_TEST} COMMAND ${TARGET_T2W_FRONTEND_TEST})
+    set_tests_properties(${TARGET_T2W_FRONTEND_TEST} PROPERTIES LABELS "main;omni;tts")
 endif()

--- a/tools/omni/CMakeLists.txt
+++ b/tools/omni/CMakeLists.txt
@@ -250,4 +250,11 @@ if (LLAMA_BUILD_TESTS)
         SKIP_RETURN_CODE 77
         LABELS "main;omni;tts"
     )
+
+    set(TARGET_TTS_QUALITY_CONTRACT_TEST test-tts-quality-contract)
+    add_executable(${TARGET_TTS_QUALITY_CONTRACT_TEST} test/test-tts-quality-contract.cpp)
+    target_link_libraries(${TARGET_TTS_QUALITY_CONTRACT_TEST} PRIVATE omni)
+    target_compile_features(${TARGET_TTS_QUALITY_CONTRACT_TEST} PRIVATE cxx_std_17)
+    add_test(NAME ${TARGET_TTS_QUALITY_CONTRACT_TEST} COMMAND ${TARGET_TTS_QUALITY_CONTRACT_TEST})
+    set_tests_properties(${TARGET_TTS_QUALITY_CONTRACT_TEST} PROPERTIES LABELS "main;omni;tts")
 endif()

--- a/tools/omni/omni.cpp
+++ b/tools/omni/omni.cpp
@@ -1415,6 +1415,159 @@ static std::mt19937* get_sampler_rng(struct common_sampler * smpl) {
     return static_cast<std::mt19937*>(rng_ptr);
 }
 
+// Apply the upstream distribution sampler without the persistent penalty and
+// filter stages. Python skips those processors for the first audio token of a
+// generation chunk but still applies temperature and multinomial sampling.
+static llama_token sample_with_distribution_only(struct common_sampler * sampler,
+                                                 llama_token_data_array * candidates,
+                                                 float temperature) {
+    llama_sampler * chain = common_sampler_get(sampler);
+    if (!chain || !candidates) {
+        return LLAMA_TOKEN_NULL;
+    }
+
+    const int n_samplers = llama_sampler_chain_n(chain);
+    if (n_samplers <= 0) {
+        return LLAMA_TOKEN_NULL;
+    }
+
+    std::vector<llama_sampler *> stages;
+    stages.reserve(n_samplers);
+    for (int i = 0; i < n_samplers; ++i) {
+        stages.push_back(llama_sampler_chain_get(chain, i));
+    }
+    for (int i = n_samplers - 1; i >= 0; --i) {
+        llama_sampler_chain_remove(chain, i);
+    }
+
+    llama_token sampled = LLAMA_TOKEN_NULL;
+    llama_sampler * temperature_sampler = llama_sampler_init_temp(temperature);
+    llama_sampler * distribution_sampler = stages.back();
+    if (temperature_sampler && distribution_sampler &&
+        std::strcmp(llama_sampler_name(distribution_sampler), "dist") == 0) {
+        llama_sampler_apply(temperature_sampler, candidates);
+        llama_sampler_apply(distribution_sampler, candidates);
+        if (candidates->selected >= 0 &&
+            candidates->selected < static_cast<int>(candidates->size)) {
+            sampled = candidates->data[candidates->selected].id;
+        }
+    }
+    llama_sampler_free(temperature_sampler);
+
+    for (llama_sampler * stage : stages) {
+        llama_sampler_chain_add(chain, stage);
+    }
+    return sampled;
+}
+
+static void apply_python_repetition_penalty(std::vector<float> & logits,
+                                            const std::vector<llama_token> * history,
+                                            float repetition_penalty,
+                                            int repetition_window,
+                                            int audio_bos_token_id) {
+    if (!history || history->empty() || repetition_penalty == 1.0f ||
+        repetition_window <= 0) {
+        return;
+    }
+
+    const int start = std::max(
+        0, static_cast<int>(history->size()) - repetition_window);
+    std::vector<int> frequency(logits.size(), 0);
+    for (int i = start; i < static_cast<int>(history->size()); ++i) {
+        const int relative = (*history)[i] - audio_bos_token_id;
+        if (relative >= 0 && relative < static_cast<int>(frequency.size())) {
+            frequency[relative]++;
+        }
+    }
+
+    for (size_t i = 0; i < logits.size(); ++i) {
+        if (frequency[i] == 0) {
+            continue;
+        }
+        const float alpha = std::pow(
+            repetition_penalty, static_cast<float>(frequency[i]));
+        logits[i] = logits[i] < 0.0f ? logits[i] * alpha : logits[i] / alpha;
+    }
+}
+
+static common_params_sampling make_python_tts_sampling(
+        const common_params_sampling & base, float temperature) {
+    common_params_sampling result = base;
+    result.temp = temperature;
+    result.top_p = 0.85f;
+    result.top_k = 25;
+    result.min_p = 0.0f;
+    result.min_keep = 3;
+    result.penalty_last_n = 0;
+    result.penalty_repeat = 1.0f;
+    result.penalty_freq = 0.0f;
+    result.penalty_present = 0.0f;
+    result.mirostat = 0;
+    result.samplers = {
+        COMMON_SAMPLER_TYPE_TEMPERATURE,
+        COMMON_SAMPLER_TYPE_TOP_P,
+        COMMON_SAMPLER_TYPE_TOP_K,
+    };
+    return result;
+}
+
+static llama_token sample_tts_from_logits(
+        struct common_sampler * sampler,
+        struct omni_context * ctx_omni,
+        std::vector<float> logits,
+        const std::vector<llama_token> * history,
+        bool skip_processors,
+        bool force_no_eos,
+        int audio_bos_token_id,
+        int num_audio_tokens) {
+    if (!sampler || !ctx_omni ||
+        static_cast<int>(logits.size()) < num_audio_tokens) {
+        return LLAMA_TOKEN_NULL;
+    }
+
+    const float temperature = ctx_omni->tts_temperature;
+    if (!skip_processors) {
+        apply_python_repetition_penalty(
+            logits, history, 1.05f, 16, audio_bos_token_id);
+    }
+    if (force_no_eos && !logits.empty()) {
+        logits[num_audio_tokens - 1] = -std::numeric_limits<float>::infinity();
+    }
+
+    std::vector<llama_token_data> candidates;
+    candidates.reserve(num_audio_tokens);
+    for (int i = 0; i < num_audio_tokens; ++i) {
+        candidates.push_back({
+            audio_bos_token_id + i, logits[i], 0.0f
+        });
+    }
+    llama_token_data_array candidate_array = {
+        candidates.data(), candidates.size(), -1, false
+    };
+
+    llama_token sampled = LLAMA_TOKEN_NULL;
+    llama_sampler * chain = common_sampler_get(sampler);
+    if (chain) {
+        if (!skip_processors) {
+            llama_sampler_apply(chain, &candidate_array);
+            if (candidate_array.selected >= 0 &&
+                candidate_array.selected < static_cast<int>(candidate_array.size)) {
+                sampled = candidate_array.data[candidate_array.selected].id;
+            }
+        } else {
+            sampled = sample_with_distribution_only(
+                sampler, &candidate_array, temperature);
+        }
+    }
+    if (sampled == LLAMA_TOKEN_NULL) {
+        return LLAMA_TOKEN_NULL;
+    }
+
+    // Advance the persistent upstream sampler exactly once per selected token.
+    common_sampler_accept(sampler, sampled, true);
+    return sampled;
+}
+
 // ==============================================================================
 // Projector Semantic 实现 (精度验证版本)
 // 使用 ggml 后端进行计算，支持 CUDA 加速
@@ -1977,43 +2130,8 @@ bool load_tts_weights_from_gguf(struct omni_context * ctx_omni, const char * tts
                 return false;
             }
             
-            // CRITICAL FIX: The conversion script transposes head_code weight to [768, 6562] before saving,
-            // but the GGUF metadata shape may still be [6562, 768] due to how add_tensor works.
-            // We need to detect the actual data format by testing both layouts.
-            // 
-            // Strategy: Try both formats and see which one produces correct logits.
-            // But a simpler approach: Since the conversion script always transposes to [768, 6562],
-            // and the actual data is stored in that format, we should always use the data as-is
-            // (treating it as [768, 6562]) regardless of metadata shape.
-            //
-            // However, to be safe, we'll check: if metadata says [6562, 768], the data might be
-            // in that format (old conversion) or already transposed (new conversion).
-            // We'll use a heuristic: check if the first few values match what we expect.
-            
-            const float * src_data = (const float *)head_code_tensor->data;
-            bool need_transpose = false;
-            
-            // CRITICAL FIX: Based on conversion script analysis, the script always transposes
-            // head_code to [768, 6562] before saving. So the actual data is always [768, 6562],
-            // regardless of metadata shape. We should NOT transpose based on metadata.
-            //
-            // However, if metadata says [6562, 768], it might be an old conversion that didn't transpose.
-            // We'll use a simple heuristic: if metadata says [6562, 768], assume data needs transpose.
-            // If metadata says [768, 6562], assume data is already correct.
-            
-            if (dim0 == expected_hidden_size && dim1 == expected_num_audio_tokens) {
-                // Metadata says (768, 6562) - data should already be in correct format
-                need_transpose = false;
-            } else if (dim0 == expected_num_audio_tokens && dim1 == expected_hidden_size) {
-                // Metadata says (6562, 768) - but conversion script may have already transposed the data
-                // We need to check: if conversion script transposed, data is actually [768, 6562] and we should NOT transpose
-                // If conversion script didn't transpose, data is [6562, 768] and we SHOULD transpose
-                //
-                // Since the conversion script ALWAYS transposes (line 351: W_transposed = W.T),
-                // the data is always [768, 6562] regardless of metadata.
-                // So we should NOT transpose.
-                need_transpose = false;  // CRITICAL FIX: Don't transpose, data is already [768, 6562]
-            } else {
+            if (!((dim0 == expected_hidden_size && dim1 == expected_num_audio_tokens) ||
+                  (dim0 == expected_num_audio_tokens && dim1 == expected_hidden_size))) {
                 LOG_ERR("TTS: head_code.0.weight has unexpected shape [%ld, %ld], expected [%d, %d] or [%d, %d]\n",
                        dim0, dim1, expected_hidden_size, expected_num_audio_tokens, expected_num_audio_tokens, expected_hidden_size);
                 // Clean up
@@ -2034,32 +2152,37 @@ bool load_tts_weights_from_gguf(struct omni_context * ctx_omni, const char * tts
                 return false;
             }
             
-            // Check tensor type and copy/convert accordingly
-            // ⚡ 优化：转置存储为 [6562, 768]，使每个output token的权重连续存储
-            // 这样在计算logits时可以用高效的向量点积
-            // 原始: weight[j * 6562 + i] = W[j, i]  (j=hidden, i=output)
-            // 转置后: weight[i * 768 + j] = W[i, j] (i=output, j=hidden)
+            // convert_tts.py writes a [6562, 768] row-major array. GGUF
+            // metadata may expose reversed dimensions, but the raw payload
+            // is already in the layout consumed by the dot-product below.
             enum ggml_type tensor_type = head_code_tensor->type;
-            int64_t total_elements = expected_hidden_size * expected_num_audio_tokens;
-            
-            print_with_timestamp("TTS: head_code shape: dim0=%ld, dim1=%ld, will transpose to [%ld, %ld]\n", 
+            print_with_timestamp("TTS: head_code shape: dim0=%ld, dim1=%ld, using row-major [%ld, %ld]\n",
                                 dim0, dim1, expected_num_audio_tokens, expected_hidden_size);
-            
-            // Transpose: [hidden, audio_tokens] -> [audio_tokens, hidden]
+
             if (tensor_type == GGML_TYPE_F32) {
                 const float * src_data = (const float *)head_code_tensor->data;
-                for (int64_t i = 0; i < expected_num_audio_tokens; ++i) {
-                    for (int64_t j = 0; j < expected_hidden_size; ++j) {
-                        ctx_omni->head_code_weight[i * expected_hidden_size + j] = src_data[j * expected_num_audio_tokens + i];
-                    }
+                if (!omni_copy_head_code_row_major(
+                        src_data, dim0, dim1, expected_hidden_size,
+                        expected_num_audio_tokens, ctx_omni->head_code_weight)) {
+                    LOG_ERR("TTS: failed to copy F32 head_code row-major payload\n");
+                    free(ctx_omni->head_code_weight);
+                    ctx_omni->head_code_weight = nullptr;
+                    ggml_free(ctx_meta);
+                    gguf_free(ctx_gguf);
+                    return false;
                 }
             } else {
                 std::vector<float> tmp(expected_hidden_size * expected_num_audio_tokens);
                 ggml_tensor_to_f32(head_code_tensor, tmp.data(), expected_hidden_size * expected_num_audio_tokens);
-                for (int64_t i = 0; i < expected_num_audio_tokens; ++i) {
-                    for (int64_t j = 0; j < expected_hidden_size; ++j) {
-                        ctx_omni->head_code_weight[i * expected_hidden_size + j] = tmp[j * expected_num_audio_tokens + i];
-                    }
+                if (!omni_copy_head_code_row_major(
+                        tmp.data(), dim0, dim1, expected_hidden_size,
+                        expected_num_audio_tokens, ctx_omni->head_code_weight)) {
+                    LOG_ERR("TTS: failed to copy converted head_code row-major payload\n");
+                    free(ctx_omni->head_code_weight);
+                    ctx_omni->head_code_weight = nullptr;
+                    ggml_free(ctx_meta);
+                    gguf_free(ctx_gguf);
+                    return false;
                 }
             }
             
@@ -2843,102 +2966,26 @@ static llama_token sample_tts_token_simplex(struct common_sampler * smpl, struct
         audio_logits[i] = sum;
     }
     
-    std::mt19937* rng = get_sampler_rng(smpl);
-    std::mt19937 local_rng;
-    if (rng == nullptr) {
-        local_rng = std::mt19937(std::random_device{}());
-        rng = &local_rng;
+    const llama_token id = sample_tts_from_logits(
+        smpl,
+        ctx_omni,
+        std::move(audio_logits),
+        all_generated_tokens,
+        is_audio_bos,
+        force_no_eos,
+        audio_bos_token_id,
+        num_audio_tokens);
+    if (id == LLAMA_TOKEN_NULL) {
+        LOG_ERR("TTS simplex: sampler failed to select an audio token\n");
+        return 0;
     }
-    
-    // 单工版本：使用 all_generated_tokens 做 repetition penalty
-    std::vector<int> decoded_tokens_relative;
-    if (all_generated_tokens != nullptr) {
-        for (llama_token tid : *all_generated_tokens) {
-            int relative_idx = tid - audio_bos_token_id;
-            if (relative_idx >= 0 && relative_idx < num_audio_tokens) {
-                decoded_tokens_relative.push_back(relative_idx);
-            }
-        }
-    }
-    
-    // 🔧 [与 Python streaming 对齐] TTS 采样参数
-    // Python tts_streaming_generate.py 使用：
-    // - temperature (从 TTSSamplingParams 传入，默认 0.8)
-    // - repetition_penalty = 1.05
-    // - window = 8 (recent_ids = logits_token[:, -8:])
-    // - multinomial 采样 (无 top-p/top-k)
-    float temperature = 0.8f;
-    float repetition_penalty = 1.05f;
-    int win_size = 8;  // 🔧 [与 Python 对齐] Python: recent_ids = logits_token[:, -8:]
-    
-    bool use_argmax = (params->sampling.temp <= 0.0f);
-    
-    int selected_relative_idx;
-    if (use_argmax) {
-        float max_logit = audio_logits[0];
-        selected_relative_idx = 0;
-        for (int i = 1; i < num_audio_tokens; ++i) {
-            if (audio_logits[i] > max_logit) {
-                max_logit = audio_logits[i];
-                selected_relative_idx = i;
-            }
-        }
-    } else {
-        // Step 1: 应用 temperature
-        // Python: logits /= self.temperature
-        for (int i = 0; i < num_audio_tokens; ++i) {
-            audio_logits[i] /= temperature;
-        }
-        
-        // Step 2: 只有 t > 0 时才应用 repetition penalty
-        // Python: if t > 0: ... recent_ids = logits_token[:, -8:]
-        if (!is_audio_bos && !decoded_tokens_relative.empty()) {
-            // 🔧 [与 Python 对齐] 获取最近 win_size 个 tokens
-            int start_idx = std::max(0, (int)decoded_tokens_relative.size() - win_size);
-            
-            // 🔧 [与 Python 对齐] 使用 bool mask 而不是频率计数
-            // Python: occurred = F.one_hot(recent_ids, ...).sum(dim=1).bool()
-            std::vector<bool> occurred(num_audio_tokens, false);
-            for (int i = start_idx; i < (int)decoded_tokens_relative.size(); ++i) {
-                int tok = decoded_tokens_relative[i];
-                if (tok >= 0 && tok < num_audio_tokens) {
-                    occurred[tok] = true;
-                }
-            }
-            
-            // 🔧 [与 Python 对齐] 应用 repetition penalty
-            // Python: logits = torch.where(occurred & (logits >= 0), logits / penalty, logits)
-            //         logits = torch.where(occurred & (logits < 0), logits * penalty, logits)
-            for (int i = 0; i < num_audio_tokens; ++i) {
-                if (occurred[i]) {
-                    if (audio_logits[i] >= 0) {
-                        audio_logits[i] /= repetition_penalty;
-                    } else {
-                        audio_logits[i] *= repetition_penalty;
-                    }
-                }
-            }
-        }
-        
-        // Step 3: 如果 force_no_eos=true，将 EOS logit 设为 -inf
-        if (force_no_eos) {
-            audio_logits[eos_relative_idx] = -std::numeric_limits<float>::infinity();
-        }
-        
-        // Step 4: 🔧 [与 Python 对齐] 使用 multinomial 采样 (无 top-p/top-k)
-        // Python: scores = F.softmax(logits, dim=-1)
-        //         next_token = torch.multinomial(scores, num_samples=1)
-        selected_relative_idx = random_sampling_tts(audio_logits.data(), num_audio_tokens, *rng);
-    }
+    int selected_relative_idx = static_cast<int>(id - audio_bos_token_id);
     
     if (selected_relative_idx < 0 || selected_relative_idx >= num_audio_tokens) {
         selected_relative_idx = 0;
     }
     
-    const llama_token id = audio_bos_token_id + selected_relative_idx;
     int relative_idx = selected_relative_idx;
-    
-    common_sampler_accept(smpl, id, true);
     
     // 🔧 [与 Python 对齐] 检测是否采样到 EOS
     bool is_eos = (relative_idx == eos_relative_idx);
@@ -2984,7 +3031,7 @@ static llama_token sample_tts_token_simplex(struct common_sampler * smpl, struct
     return id;
 }
 
-llama_token sample_tts_token(struct common_sampler * smpl, struct omni_context * ctx_omni, common_params* params, int * n_past_tts, const std::vector<llama_token> * all_generated_tokens, const std::vector<llama_token> * chunk_generated_tokens, int token_index_in_chunk, bool force_no_eos, bool is_final_text_chunk = false) {
+llama_token sample_tts_token(struct common_sampler * smpl, struct omni_context * ctx_omni, common_params* params, int * n_past_tts, const std::vector<llama_token> * all_generated_tokens, const std::vector<llama_token> * chunk_generated_tokens, int token_index_in_chunk, bool force_no_eos, bool is_final_text_chunk) {
     // Debug: Save logits directory (set via environment variable)
     const char* logits_debug_dir = getenv("TTS_LOGITS_DEBUG_DIR");
     
@@ -3147,103 +3194,27 @@ llama_token sample_tts_token(struct common_sampler * smpl, struct omni_context *
         }
     }
     
-    // 4. 采样流程 - 与 Python MiniCPMTTS.generate() 完全对齐
-    // Python 采样流程:
-    //   1. logits /= temperature (默认 0.8)
-    //   2. if not audio_bos: apply repetition_penalty (penalty=1.05, past_window=16)
-    //   3. if not audio_bos: apply TopP (0.85) + TopK (25) warper (min_tokens_to_keep=3)
-    //   4. softmax + multinomial
-    
-    // Get RNG from sampler
-    std::mt19937* rng = get_sampler_rng(smpl);
-    std::mt19937 local_rng;
-    if (rng == nullptr) {
-        // Fallback to local RNG
-        LOG_WRN("TTS: sampler RNG not available, using local RNG\n");
-        local_rng = std::mt19937(std::random_device{}());
-        rng = &local_rng;
+    // Apply the same upstream sampler chain used by the TTS model. The
+    // repetition processor is applied explicitly because the candidates use
+    // relative audio logits while the persistent sampler tracks absolute IDs.
+    const std::vector<llama_token> * tokens_for_penalty =
+        ctx_omni->duplex_mode
+            ? (chunk_generated_tokens ? chunk_generated_tokens : all_generated_tokens)
+            : all_generated_tokens;
+    const llama_token id = sample_tts_from_logits(
+        smpl,
+        ctx_omni,
+        std::move(audio_logits),
+        tokens_for_penalty,
+        skip_processors,
+        ctx_omni->duplex_mode && force_no_eos,
+        audio_bos_token_id,
+        num_audio_tokens);
+    if (id == LLAMA_TOKEN_NULL) {
+        LOG_ERR("TTS: sampler failed to select an audio token\n");
+        return 0;
     }
-    
-    // 🔧 [单双工适配] Collect decoded tokens (relative indices) for repetition penalty
-    // - 双工模式：使用 chunk_generated_tokens（当前 chunk 内的 tokens）
-    //   Python generate_chunk: input_ids_sliced = new_tokens[:, 0:t]
-    // - 单工模式：使用 all_generated_tokens（所有生成的 tokens）
-    //   Python TTSStreamingGenerator: self.all_generated_tokens
-    std::vector<int> decoded_tokens_relative;
-    const std::vector<llama_token> * tokens_for_penalty;
-    if (ctx_omni->duplex_mode) {
-        // 双工模式：优先使用当前 chunk 的 tokens
-        tokens_for_penalty = chunk_generated_tokens ? chunk_generated_tokens : all_generated_tokens;
-    } else {
-        // 单工模式：使用所有生成的 tokens
-        tokens_for_penalty = all_generated_tokens;
-    }
-    if (tokens_for_penalty != nullptr) {
-        for (llama_token tid : *tokens_for_penalty) {
-            // Convert absolute token ID to relative index
-            int relative_idx = tid - audio_bos_token_id;
-            if (relative_idx >= 0 && relative_idx < num_audio_tokens) {
-                decoded_tokens_relative.push_back(relative_idx);
-            }
-        }
-    }
-    
-    // 🔧 [与 Python TTSSamplingParams 对齐] (modeling_minicpmo.py line 69-76)
-    float temperature = 0.8f;       // TTSSamplingParams.temperature = 0.8
-    float top_p = 0.85f;            // TTSSamplingParams.top_p = 0.85
-    int top_k = 25;                 // TTSSamplingParams.top_k = 25
-    float repetition_penalty = 1.05f; // TTSSamplingParams.repetition_penalty = 1.05
-    int win_size = 16;              // TTSSamplingParams.win_size = 16
-    float tau_r = 0.1f;             // TTSSamplingParams.tau_r = 0.1
-    int min_tokens_to_keep = 3;     // Python: TopPLogitsWarper/TopKLogitsWarper default
-    
-    // Get temperature from params if specified (for argmax mode)
-    bool use_argmax = (params->sampling.temp <= 0.0f);
-    
-    int selected_relative_idx;
-    if (use_argmax) {
-        // Deterministic sampling: select argmax (highest logit)
-        float max_logit = audio_logits[0];
-        selected_relative_idx = 0;
-        for (int i = 1; i < num_audio_tokens; ++i) {
-            if (audio_logits[i] > max_logit) {
-                max_logit = audio_logits[i];
-                selected_relative_idx = i;
-            }
-        }
-    } else {
-        // Step 1: Apply temperature
-        for (int i = 0; i < num_audio_tokens; ++i) {
-            audio_logits[i] /= temperature;
-        }
-        
-        // 🔧 [单双工适配] Step 2 & 3: Apply repetition penalty and TopP/TopK
-        // - 双工模式：每个 chunk 的第一个 token 跳过
-        // - 单工模式：只有整个生成过程的第一个 token 跳过
-        if (!skip_processors && !decoded_tokens_relative.empty()) {
-            // Apply repetition penalty (matching Python's CustomRepetitionPenaltyLogitsProcessorRepeat)
-            apply_repetition_penalty_tts(audio_logits.data(), num_audio_tokens, 
-                                        decoded_tokens_relative, repetition_penalty, win_size);
-        }
-        
-        // 🔧 [差异1修复] 在采样前阻止 EOS token 被采样
-        // Python generate_chunk: if force_no_stop or t < min_new_tokens: logits[:, eos_token] = -torch.inf
-        // 这样可以确保在达到 min_new_tokens 之前不会生成 EOS
-        if (ctx_omni->duplex_mode && force_no_eos) {
-            int eos_relative_idx = num_audio_tokens - 1;  // EOS token relative index: 6561
-            audio_logits[eos_relative_idx] = -std::numeric_limits<float>::infinity();
-        }
-        
-        // Step 4: Nucleus sampling with min_tokens_to_keep (matching Python's warpers)
-        selected_relative_idx = nucleus_sampling_with_min_keep_tts(
-            audio_logits.data(), 
-            num_audio_tokens, 
-            top_p,
-            top_k,
-            min_tokens_to_keep,
-            *rng
-        );
-    }
+    int selected_relative_idx = static_cast<int>(id - audio_bos_token_id);
     
     // 5. 验证采样结果在有效范围内
     if (selected_relative_idx < 0 || selected_relative_idx >= num_audio_tokens) {
@@ -3254,10 +3225,7 @@ llama_token sample_tts_token(struct common_sampler * smpl, struct omni_context *
     }
     
     // Convert relative index to absolute token ID
-    const llama_token id = audio_bos_token_id + selected_relative_idx;
     int relative_idx = selected_relative_idx;
-    
-    common_sampler_accept(smpl, id, true);
     
     // 🔧 [与 Python 对齐] 检测是否采样到 EOS
     int eos_relative_idx_check = num_audio_tokens - 1;  // EOS token relative index: 6561
@@ -4165,20 +4133,13 @@ struct omni_context * omni_init(struct common_params * params, int media_type, b
             return NULL;
         }
         
-        // 创建 TTS 的采样器
-        // 🔧 TTS流式采样参数 - 与 Python ras_sampling 对齐：
-        // Python TTSSamplingParams 默认 temperature=0.8 (modeling_minicpmo.py line 75)
-        common_params_sampling tts_sampling = params->sampling;
-        tts_sampling.temp = ctx_omni->tts_temperature;  // [与 Python 对齐] TTSSamplingParams.temperature
-        tts_sampling.top_p = 0.85f;  // 🔧 [与 Python 对齐] TTSSamplingParams.top_p=0.85             // 🔧 [与 Python streaming 对齐] top_p=0.8
-        tts_sampling.top_k = 25;               // top_k = 25 (ras_sampling 参数)
-        tts_sampling.penalty_repeat = 1.05f;   // repetition_penalty = 1.05
-        tts_sampling.min_p = 0.01f;            // min_p = 0.01
-        // Python: CustomRepetitionPenaltyLogitsProcessorRepeat(repetition_penalty, num_code, 16)
-        tts_sampling.penalty_last_n = 16;      // past_window = 16 (与Python对齐)
+        // Build the persistent TTS sampler with the Python base order. The
+        // repetition processor is applied explicitly to relative audio logits.
+        common_params_sampling tts_sampling =
+            make_python_tts_sampling(params->sampling, ctx_omni->tts_temperature);
         struct common_sampler * tts_sampler = common_sampler_init(tts_model, tts_sampling);
         print_with_timestamp("TTS sampler: temp=%.2f, top_p=%.2f, top_k=%d, rep_penalty=%.2f\n",
-                            tts_sampling.temp, tts_sampling.top_p, tts_sampling.top_k, tts_sampling.penalty_repeat);
+                            tts_sampling.temp, tts_sampling.top_p, tts_sampling.top_k, 1.05f);
         
         ctx_omni->model_tts = tts_model;
         ctx_omni->ctx_tts_llama = ctx_tts_llama;
@@ -5301,33 +5262,36 @@ static bool generate_audio_tokens_local_simplex(
         return false;
     }
     
-    // 🔧 [修复] 在 prefill 之前动态添加 audio_bos embedding
-    // Python 中 audio_bos 是在 TTS 类内部（TTSStreamingGenerator.generate_with_buffer）添加的
-    // 每个 chunk 都会加 audio_bos: condition = torch.cat([condition, self.audio_bos_embeds], dim=1)
-    std::vector<float> condition_with_bos = merged_embeddings;  // 复制一份
-    int extra_tokens = 0;  // 额外添加的 tokens 数量
-    
-    // 🔧 [修复 text_eos_embed 时机] text_eos_embed 不再在 condition 构建阶段添加
-    // 原因：一个 text chunk 会生成多个 audio chunk，text_eos_embed 放在 condition 中
-    // 会导致所有 audio chunk 都受到影响。正确做法是在第一轮 audio 生成结束（EOS）后，
-    // 再注入 text_eos_embed + audio_bos 做第二轮生成，这样只影响最后一批 audio tokens。
-    const int text_eos_token_id = 151692;  // TTS 的 text_eos_token_id
-    
-    // 🔧 [与 Python 对齐] 只添加 audio_bos（总是添加）
-    // Python: condition = torch.cat([condition, self.audio_bos_embeds], dim=1)
+    // Python appends text_eos only for the final text chunk, then appends
+    // audio_bos for every chunk before the TTS prefill.
+    std::vector<float> condition_with_bos = merged_embeddings;
+    int extra_tokens = 0;
+    const int text_eos_token_id = 151692;
+
+    if (is_final_text_chunk) {
+        std::vector<float> text_eos_embed(tts_n_embd, 0.0f);
+        if (tts_emb_text(ctx_omni, text_eos_token_id,
+                         text_eos_embed.data(), tts_n_embd)) {
+            condition_with_bos.insert(condition_with_bos.end(),
+                                      text_eos_embed.begin(), text_eos_embed.end());
+            extra_tokens++;
+        } else {
+            LOG_ERR("TTS Simplex: failed to get text_eos embedding\n");
+        }
+    }
+
     std::vector<float> audio_bos_embed(tts_n_embd, 0.0f);
     if (tts_emb_text(ctx_omni, audio_bos_token_id, audio_bos_embed.data(), tts_n_embd)) {
-        condition_with_bos.insert(condition_with_bos.end(), 
+        condition_with_bos.insert(condition_with_bos.end(),
                                   audio_bos_embed.begin(), audio_bos_embed.end());
         extra_tokens++;
-        print_with_timestamp("TTS Simplex: 在 prefill 前添加 audio_bos (chunk_idx=%d, new_size=%zu)\n", 
+        print_with_timestamp("TTS Simplex: added audio_bos before prefill (chunk_idx=%d, new_size=%zu)\n",
                             chunk_idx, condition_with_bos.size() / tts_n_embd);
     } else {
         LOG_ERR("TTS Simplex: failed to get audio_bos embedding\n");
     }
-    int n_tokens_with_bos = n_tokens + extra_tokens;  // 包含 audio_bos
-    
-    // Save condition embeddings (包含 audio_bos)
+    int n_tokens_with_bos = n_tokens + extra_tokens;
+
     ctx_omni->tts_condition_embeddings = condition_with_bos;
     ctx_omni->tts_condition_length = n_tokens_with_bos;
     ctx_omni->tts_condition_n_embd = tts_n_embd;
@@ -5359,22 +5323,17 @@ static bool generate_audio_tokens_local_simplex(
     }
     print_with_timestamp("TTS Simplex: prefill completed, n_past_tts=%d\n", n_past_tts);
     
-    // Create sampler - matching Python TTSStreamingGenerator
-    // Create sampler - matching Python TTSStreamingGenerator
-    // Python TTSSamplingParams 默认 temperature=0.8 (modeling_minicpmo.py line 75)
-    common_params_sampling tts_sampling = params->sampling;
-    tts_sampling.temp = ctx_omni->tts_temperature;  // [与 Python 对齐] TTSSamplingParams.temperature
-    tts_sampling.top_k = 25;
-    tts_sampling.penalty_repeat = 1.05f;
-    tts_sampling.min_p = 0.01f;
-    tts_sampling.penalty_last_n = 16;
-    
-    struct common_sampler * tts_sampler = common_sampler_init(ctx_omni->model_tts, tts_sampling);
+    // Reuse the sampler created with the TTS model so its distribution RNG
+    // remains continuous across text chunks.
+    struct common_sampler * tts_sampler = ctx_omni->ctx_tts_sampler;
     if (!tts_sampler) {
-        LOG_ERR("TTS Simplex: failed to create sampler\n");
+        LOG_ERR("TTS Simplex: persistent sampler is not initialized\n");
         return false;
     }
-    print_with_timestamp("TTS Simplex: sampler created\n");
+    if (chunk_idx == 0) {
+        common_sampler_reset(tts_sampler);
+    }
+    print_with_timestamp("TTS Simplex: using persistent sampler\n");
     
     output_audio_tokens.clear();
     
@@ -5402,7 +5361,8 @@ static bool generate_audio_tokens_local_simplex(
         // 🔧 [修复过早EOS] 如果还没达到 min_new_tokens，阻止 EOS 被采样
         bool force_no_eos = (t < min_new_tokens);
         
-        // Phase 1 始终使用 is_final_text_chunk=false：EOS 不 prefill，保持 KV cache 干净
+        // The final text chunk already contains text_eos_embed in its
+        // condition, so its EOS follows the normal final-chunk path.
         llama_token sampled_token_abs = sample_tts_token_simplex(
             tts_sampler,
             ctx_omni,
@@ -5411,7 +5371,7 @@ static bool generate_audio_tokens_local_simplex(
             &ctx_omni->tts_all_generated_tokens,
             t,
             force_no_eos,
-            false  // Phase 1: 不 prefill EOS，留给 Phase 2 处理
+            is_final_text_chunk
         );
         
         if (sampled_token_abs == 0) {
@@ -5434,10 +5394,8 @@ static bool generate_audio_tokens_local_simplex(
             print_with_timestamp("TTS Simplex Phase1: EOS token at step %d\n", t + 1);
             output_audio_tokens.pop_back();
             ctx_omni->tts_all_generated_tokens.pop_back();
-            // 如果是最后一个 text chunk，需要进入 Phase 2
             if (is_final_text_chunk) {
-                need_phase2 = true;
-                print_with_timestamp("TTS Simplex: is_final_text_chunk=true, will enter Phase 2 for text_eos_embed\n");
+                print_with_timestamp("TTS Simplex: final text chunk reached EOS\n");
             }
         } else {
             // 🔧 [与 Python 对齐] 非 EOS token 加入 tts_token_buffer
@@ -5608,8 +5566,6 @@ static bool generate_audio_tokens_local_simplex(
         ctx_omni->t2w_thread_info->cv.notify_one();
         print_with_timestamp("TTS Simplex: 发送 is_chunk_end=true 信号\n");
     }
-    
-    common_sampler_free(tts_sampler);
     
     print_with_timestamp("TTS Simplex: generated %zu audio tokens for chunk %d\n",
                         output_audio_tokens.size(), chunk_idx);
@@ -5792,21 +5748,14 @@ static bool generate_audio_tokens_local(
     }
     print_with_timestamp("TTS Local: prefill completed, n_past_tts=%d\n", n_past_tts);
     
-    // 2. Create sampler for TTS with correct TTS sampling parameters
-    // 🔧 TTS流式采样参数 - 与 Python TTSStreamingGenerator 对齐
-    // Python TTSSamplingParams 默认 temperature=0.8 (modeling_minicpmo.py line 75)
-    common_params_sampling tts_sampling = params->sampling;
-    tts_sampling.temp = ctx_omni->tts_temperature;  // [与 Python 对齐] TTSSamplingParams.temperature
-    tts_sampling.top_p = 0.85f;  // 🔧 [与 Python 对齐] TTSSamplingParams.top_p=0.85             // 🔧 [与 Python streaming 对齐] top_p=0.8
-    tts_sampling.top_k = 25;               // top_k = 25
-    tts_sampling.penalty_repeat = 1.05f;   // repetition_penalty = 1.05
-    tts_sampling.min_p = 0.01f;            // min_p = 0.01
-    tts_sampling.penalty_last_n = 16;      // past_window = 16 (与Python对齐)
-    
-    struct common_sampler * tts_sampler = common_sampler_init(ctx_omni->model_tts, tts_sampling);
+    // 2. Reuse the persistent sampler created with the TTS model.
+    struct common_sampler * tts_sampler = ctx_omni->ctx_tts_sampler;
     if (!tts_sampler) {
-        LOG_ERR("TTS Local: failed to create sampler\n");
+        LOG_ERR("TTS Local: persistent sampler is not initialized\n");
         return false;
+    }
+    if (chunk_idx == 0) {
+        common_sampler_reset(tts_sampler);
     }
     
     // 3. Generate audio tokens with streaming to T2W queue
@@ -5818,16 +5767,10 @@ static bool generate_audio_tokens_local(
     // Python generate_chunk: input_ids_sliced = new_tokens[:, 0:t]  # 只用当前 chunk 内的 tokens
     std::vector<llama_token> chunk_generated_tokens;
     
-    // 🔧 [单双工适配] min_new_tokens 逻辑
-    // - 双工模式: 与 Python streaming_generate 对齐
-    //   max_token_per_chunk = 25 + 1  # 26
-    //   min_token_per_chunk = 25 + 1  # 26
-    //   if end_of_turn: min_token_per_chunk = 0
-    // - 单工模式: 设置最小 100 个 tokens，防止 TTS 过早生成 EOS
-    //   10 个中文字约需要 100-150 个 audio tokens (每字 10-15 tokens)
-    const int min_new_tokens = ctx_omni->duplex_mode ? 
-        (is_end_of_turn ? 0 : 26) : 
-        100;  // 🔧 单工模式：至少生成 100 个 tokens 防止过早 EOS
+    // Python only forces a per-chunk minimum in duplex mode. Turn-based
+    // generation lets the TTS model stop at its EOS token.
+    const int min_new_tokens =
+        ctx_omni->duplex_mode && !is_end_of_turn ? 26 : 0;
     
     // 🚀 流水线优化：Token2Wav需要28个tokens (25+3 lookahead)才能输出音频
     // 首批28个tokens后推送，后续每25个tokens推送一次
@@ -5947,9 +5890,6 @@ static bool generate_audio_tokens_local(
         }
         ctx_omni->t2w_thread_info->cv.notify_one();
     }
-    
-    // Cleanup sampler
-    common_sampler_free(tts_sampler);
     
     // 🔧 更新累计 n_past，用于下一个 chunk 的 KV cache 位置
     // Python: self.text_start_pos += condition_length + len(chunk_generated_tokens)
@@ -10955,6 +10895,10 @@ bool stream_decode(struct omni_context * ctx_omni, std::string debug_dir, int ro
     tts_output.resize(1/* batch_size */ * (ctx_omni->params->n_ctx /* seq_len */ * 2) * 256);
     bool llm_finish = false;
     bool llm_first_token_logged = false;
+    bool has_pending_tts_token = false;
+    llama_token pending_tts_token = LLAMA_TOKEN_NULL;
+    std::vector<float> pending_tts_hidden_state;
+    std::string pending_tts_piece;
     
     // 🔧 [修复双工缺字问题] 记录当前 chunk 是否是 turn 的结束
     // 此变量随 LLMOut 一起传递给 TTS 线程，避免全局状态的时序问题
@@ -10976,13 +10920,27 @@ bool stream_decode(struct omni_context * ctx_omni, std::string debug_dir, int ro
         // 打断逻辑通过 need_speek 或其他机制处理。
         fflush(stdout);
         
-        int jl = 0;  // 计数有效的 TTS token 数量
         int total_tokens_generated = 0;  // 计数总共生成的 token 数量（包括被过滤的）
         // 收集当前chunk的token IDs和hidden states用于TTS条件生成
         // 🔧 [优化] 只收集有效的 TTS token，确保每次给 TTS 的都是 step_size 个有效 token
         std::vector<llama_token> chunk_token_ids;
         std::vector<float> chunk_hidden_states;
         int llm_n_embd = llama_n_embd(llama_get_model(ctx_omni->ctx_llama));
+
+        const OmniTextChunkPlan chunk_plan =
+            omni_text_chunk_plan(step_size, has_pending_tts_token);
+        if (has_pending_tts_token) {
+            chunk_token_ids.push_back(pending_tts_token);
+            chunk_hidden_states = pending_tts_hidden_state;
+            response = pending_tts_piece;
+            pending_tts_token = LLAMA_TOKEN_NULL;
+            pending_tts_hidden_state.clear();
+            pending_tts_piece.clear();
+            has_pending_tts_token = false;
+        }
+        int condition_tokens_collected = chunk_plan.prefix_tokens;
+        bool need_lookahead = !ctx_omni->duplex_mode &&
+                              chunk_plan.generated_tokens > chunk_plan.condition_tokens;
         
         // 🔧 [修复双工缺字问题] 每个 chunk 开始时重置 is_end_of_turn 状态
         // 只有当检测到 TURN_EOS/TTS_EOS/EOS 时才会在下面设置为 true
@@ -10995,10 +10953,13 @@ bool stream_decode(struct omni_context * ctx_omni, std::string debug_dir, int ro
         bool chunk_limit_reached = (max_chunk_tokens > 0 && current_chunk_tokens >= max_chunk_tokens);
         {
             fflush(stdout);
-            // 🔧 [重要] 循环直到收集到 step_size 个有效 token，而不是生成 step_size 个 token
+            // Python generates one lookahead token at every non-final chunk
+            // boundary. The lookahead is fed into the LLM cache, but its text
+            // and hidden state are emitted with the next TTS condition.
             // 🔧 [P0-打断检测] 检测 break_event，支持双工模式下的打断
             // 🔧 [P2-chunk限制] 检测 max_new_speak_tokens_per_chunk，便于及时响应打断
-            while (jl < step_size && !llm_finish && !ctx_omni->break_event.load() && !chunk_limit_reached) {
+            while ((condition_tokens_collected < step_size || need_lookahead) &&
+                   !llm_finish && !ctx_omni->break_event.load() && !chunk_limit_reached) {
                 // streaming llm
                 const char * tmp = nullptr;
                 float * hidden_states = nullptr;
@@ -11016,19 +10977,28 @@ bool stream_decode(struct omni_context * ctx_omni, std::string debug_dir, int ro
                 // 特殊 token（如 <think>, </think>, 换行等）不计入 step_size
                 if (tmp != nullptr && hidden_states != nullptr) {
                     if (is_valid_tts_token(sampled_token)) {
-                        // 有效 token：收集并计入计数
-                        chunk_token_ids.push_back(sampled_token);
-                        chunk_hidden_states.insert(chunk_hidden_states.end(), hidden_states, hidden_states + llm_n_embd);
-                        jl++;  // 只有有效 token 才增加计数
-                        
-                        // 🔧 [调试] 打印收集的 token 和 hidden states 摘要
-                        
-                        // 🔧 [P2-chunk限制] 更新当前 chunk 的 token 计数
-                        current_chunk_tokens++;
-                        
-                        // 检查是否达到 chunk 限制
-                        if (max_chunk_tokens > 0 && current_chunk_tokens >= max_chunk_tokens) {
-                            chunk_limit_reached = true;
+                        if (!ctx_omni->duplex_mode &&
+                            need_lookahead &&
+                            condition_tokens_collected >= step_size) {
+                            pending_tts_token = sampled_token;
+                            pending_tts_hidden_state.assign(
+                                hidden_states, hidden_states + llm_n_embd);
+                            pending_tts_piece = tmp;
+                            has_pending_tts_token = true;
+                            need_lookahead = false;
+                        } else {
+                            chunk_token_ids.push_back(sampled_token);
+                            chunk_hidden_states.insert(
+                                chunk_hidden_states.end(),
+                                hidden_states, hidden_states + llm_n_embd);
+                            condition_tokens_collected++;
+
+                            // 🔧 [P2-chunk限制] 更新当前 chunk 的 token 计数
+                            current_chunk_tokens++;
+                            if (max_chunk_tokens > 0 &&
+                                current_chunk_tokens >= max_chunk_tokens) {
+                                chunk_limit_reached = true;
+                            }
                         }
                     } else {
                         // 🔧 [调试] 打印被过滤的 token
@@ -11058,6 +11028,7 @@ bool stream_decode(struct omni_context * ctx_omni, std::string debug_dir, int ro
                 }
                 if (tmp == nullptr) {
                     LOG_ERR("llama_loop returned nullptr!");
+                    free(hidden_states);
                     break;
                 }
                 
@@ -11142,12 +11113,14 @@ bool stream_decode(struct omni_context * ctx_omni, std::string debug_dir, int ro
                     }
                     
                     // Don't add end tokens to response
+                    free(hidden_states);
                     break;
                 }
 
                 // Copy tmp to a local string immediately to avoid issues with static string
                 std::string tmp_str(tmp);
                 response += tmp_str;
+                free(hidden_states);
                 fflush(stdout);
             }
             fflush(stdout);

--- a/tools/omni/omni.cpp
+++ b/tools/omni/omni.cpp
@@ -1492,12 +1492,13 @@ static void apply_python_repetition_penalty(std::vector<float> & logits,
 
 static common_params_sampling make_python_tts_sampling(
         const common_params_sampling & base, float temperature) {
+    const OmniTtsPythonBaseConfig config = omni_tts_python_base_config();
     common_params_sampling result = base;
     result.temp = temperature;
-    result.top_p = 0.85f;
-    result.top_k = 25;
+    result.top_p = config.top_p;
+    result.top_k = config.top_k;
     result.min_p = 0.0f;
-    result.min_keep = 3;
+    result.min_keep = config.min_tokens_to_keep;
     result.penalty_last_n = 0;
     result.penalty_repeat = 1.0f;
     result.penalty_freq = 0.0f;
@@ -1525,10 +1526,12 @@ static llama_token sample_tts_from_logits(
         return LLAMA_TOKEN_NULL;
     }
 
-    const float temperature = ctx_omni->tts_temperature;
+    const OmniTtsPythonBaseConfig config = omni_tts_python_base_config();
+    const float temperature = config.tts_temperature;
     if (!skip_processors) {
         apply_python_repetition_penalty(
-            logits, history, 1.05f, 16, audio_bos_token_id);
+            logits, history, config.repetition_penalty,
+            config.repetition_window, audio_bos_token_id);
     }
     if (force_no_eos && !logits.empty()) {
         logits[num_audio_tokens - 1] = -std::numeric_limits<float>::infinity();
@@ -4135,8 +4138,9 @@ struct omni_context * omni_init(struct common_params * params, int media_type, b
         
         // Build the persistent TTS sampler with the Python base order. The
         // repetition processor is applied explicitly to relative audio logits.
+        const OmniTtsPythonBaseConfig tts_config = omni_tts_python_base_config();
         common_params_sampling tts_sampling =
-            make_python_tts_sampling(params->sampling, ctx_omni->tts_temperature);
+            make_python_tts_sampling(params->sampling, tts_config.tts_temperature);
         struct common_sampler * tts_sampler = common_sampler_init(tts_model, tts_sampling);
         print_with_timestamp("TTS sampler: temp=%.2f, top_p=%.2f, top_k=%d, rep_penalty=%.2f\n",
                             tts_sampling.temp, tts_sampling.top_p, tts_sampling.top_k, 1.05f);
@@ -4363,14 +4367,17 @@ struct omni_context * omni_init(struct common_params * params, int media_type, b
                 print_with_timestamp("Token2Wav: CoreML model = %s\n", coreml_model_path.c_str());
             }
 
+            const OmniTtsPythonBaseConfig tts_config = omni_tts_python_base_config();
             init_ok = ctx_omni->token2wav_session->init_from_prompt_cache_gguf(
                     encoder_gguf, flow_matching_gguf, flow_extra_gguf, prompt_cache_gguf,
-                    vocoder_gguf, device_token2mel, device_vocoder, 5, 1.0f, coreml_model_path);
+                    vocoder_gguf, device_token2mel, device_vocoder,
+                    /*n_timesteps=*/-1, tts_config.token2wav_temperature, coreml_model_path);
             if (!init_ok && use_prompt_bundle) {
                 print_with_timestamp("Token2Wav: prompt_cache failed, fallback to prompt_bundle from %s\n", prompt_bundle_dir.c_str());
                 init_ok = ctx_omni->token2wav_session->init_from_prompt_bundle(
                         encoder_gguf, flow_matching_gguf, flow_extra_gguf, prompt_bundle_dir,
-                        vocoder_gguf, device_token2mel, device_vocoder, 5, 1.0f);
+                        vocoder_gguf, device_token2mel, device_vocoder,
+                        tts_config.n_timesteps, tts_config.token2wav_temperature);
             }
             // Fallback to CPU
             if (!init_ok) {
@@ -4379,7 +4386,8 @@ struct omni_context * omni_init(struct common_params * params, int media_type, b
                 ctx_omni->token2wav_session = std::make_unique<omni::flow::Token2WavSession>();
                 init_ok = ctx_omni->token2wav_session->init_from_prompt_cache_gguf(
                         encoder_gguf, flow_matching_gguf, flow_extra_gguf, prompt_cache_gguf,
-                        vocoder_gguf, "cpu", "cpu", 5, 1.0f);
+                        vocoder_gguf, "cpu", "cpu",
+                        /*n_timesteps=*/-1, tts_config.token2wav_temperature);
             }
             
             if (init_ok) {
@@ -5244,7 +5252,8 @@ static bool generate_audio_tokens_local_simplex(
     const int num_audio_tokens = 6562;
     // 🔧 [与 Python 对齐] Python: max_new_token=500，每个 LLM condition 生成直到 EOS
     // 然后每 25 个 tokens yield 一次
-    const int max_audio_tokens = 500;
+    const OmniTtsPythonBaseConfig config = omni_tts_python_base_config();
+    const int max_audio_tokens = config.max_audio_tokens;
     
     if (!ctx_omni->ctx_tts_llama || !ctx_omni->model_tts) {
         LOG_ERR("TTS Simplex: TTS model not loaded\n");
@@ -5339,7 +5348,7 @@ static bool generate_audio_tokens_local_simplex(
     
     // 🔧 [与 Python 对齐] 统一使用 tts_token_buffer 管理，和 Python _token_buffer 一致
     // Python chunk_size=25，每凑够 25 个才 yield
-    const int CHUNK_SIZE = 25;  // 与 Python TTSStreamingGenerator.chunk_size=25 对齐
+    const int CHUNK_SIZE = config.chunk_size;
     
     // 🔧 [与 Python 对齐] 不强制最小生成数量，让 TTS 自然决定何时结束
     const int min_new_tokens = 0;
@@ -5651,7 +5660,9 @@ static bool generate_audio_tokens_local(
     // 🔧 [单双工适配] max_audio_tokens:
     // - 双工模式: 26 (与 Python 对齐，max_token_per_chunk = 25 + 1)
     // - 单工模式: 500 (允许更长的生成，靠 EOS 结束)
-    const int max_audio_tokens = ctx_omni->duplex_mode ? 26 : 500;
+    const OmniTtsPythonBaseConfig config = omni_tts_python_base_config();
+    const int max_audio_tokens =
+        ctx_omni->duplex_mode ? config.chunk_size + 1 : config.max_audio_tokens;
     print_with_timestamp("TTS Local: mode=%s, max_audio_tokens=%d\n", 
                          ctx_omni->duplex_mode ? "duplex" : "simplex", max_audio_tokens);
     
@@ -5772,10 +5783,11 @@ static bool generate_audio_tokens_local(
     const int min_new_tokens =
         ctx_omni->duplex_mode && !is_end_of_turn ? 26 : 0;
     
-    // 🚀 流水线优化：Token2Wav需要28个tokens (25+3 lookahead)才能输出音频
-    // 首批28个tokens后推送，后续每25个tokens推送一次
-    const int STREAM_CHUNK_SIZE = 25;
-    const int FIRST_CHUNK_SIZE = 28;  // 首批推送阈值，减少首响时间
+    // The turn-based path sends 25 generated audio tokens and lets
+    // Token2Mel add its fixed-graph padding. Full-duplex keeps the existing
+    // 28-token window so its one-second playback cadence is unchanged.
+    const int STREAM_CHUNK_SIZE = config.chunk_size;
+    const int FIRST_CHUNK_SIZE = config.chunk_size + config.prelook_size;
     bool first_chunk_pushed = false;
     std::vector<int32_t> stream_buffer;
     
@@ -8562,13 +8574,14 @@ bool omni_set_tts_reference_audio(struct omni_context * ctx_omni,
         ctx_omni->token2wav_model_dir + "/speech_tokenizer_v2_25hz.gguf";
     const std::string campplus_gguf =
         ctx_omni->token2wav_model_dir + "/campplus.gguf";
+    const OmniTtsPythonBaseConfig tts_config = omni_tts_python_base_config();
     if (!ctx_omni->token2wav_session->set_prompt_wav(
             tts_ref_audio_path,
             speech_tokenizer_gguf,
             campplus_gguf,
             /*frontend_threads=*/1,
-            /*n_timesteps=*/5,
-            /*temperature=*/1.0f)) {
+            tts_config.n_timesteps,
+            tts_config.token2wav_temperature)) {
         LOG_ERR("omni_set_tts_reference_audio: native GGUF frontend failed\n");
         return false;
     }
@@ -8595,8 +8608,9 @@ bool omni_reset_tts_reference_audio(struct omni_context * ctx_omni) {
 
     const std::string prompt_cache_gguf =
         ctx_omni->token2wav_model_dir + "/prompt_cache.gguf";
+    const OmniTtsPythonBaseConfig tts_config = omni_tts_python_base_config();
     if (!ctx_omni->token2wav_session->reset_to_prompt_cache_gguf(
-            prompt_cache_gguf, /*n_timesteps=*/5, /*temperature=*/1.0f)) {
+            prompt_cache_gguf, /*n_timesteps=*/-1, tts_config.token2wav_temperature)) {
         LOG_ERR("omni_reset_tts_reference_audio: failed to restore default voice\n");
         return false;
     }
@@ -8906,14 +8920,17 @@ void t2w_thread_func_cpp(struct omni_context * ctx_omni, common_params *params) 
     auto& mtx = ctx_omni->t2w_thread_info->mtx;
     auto& cv = ctx_omni->t2w_thread_info->cv;
     
-    // Token2Wav sliding window parameters
-    constexpr int32_t CHUNK_SIZE = 25;      // Main chunk size (25 tokens = 1s audio)
-    constexpr int32_t PRE_LOOKAHEAD = 3;    // Lookahead for overlap
-    constexpr int32_t WINDOW_SIZE = CHUNK_SIZE + PRE_LOOKAHEAD;  // 28
-    
-    // Buffer to accumulate tokens (for sliding window)
-    // Python: buffer = [4218] * 3  # 预先放入3个前缀静音token
-    std::vector<int32_t> token_buffer = {4218, 4218, 4218};
+    constexpr int32_t CHUNK_SIZE = 25;
+    constexpr int32_t PRE_LOOKAHEAD = 3;
+    constexpr int32_t WINDOW_SIZE = CHUNK_SIZE + PRE_LOOKAHEAD;
+    std::vector<int32_t> token_buffer;
+    auto reset_token_buffer = [&]() {
+        token_buffer.clear();
+        if (ctx_omni->duplex_mode) {
+            token_buffer.assign(PRE_LOOKAHEAD, 4218);
+        }
+    };
+    reset_token_buffer();
     
     // 🔧 [多实例支持] 使用可配置的 base_output_dir
     const std::string& base_output_dir = ctx_omni->base_output_dir;
@@ -8953,7 +8970,7 @@ void t2w_thread_func_cpp(struct omni_context * ctx_omni, common_params *params) 
             }
             // 重置 break_event 后继续等待新任务
             ctx_omni->break_event = false;
-            token_buffer = {4218, 4218, 4218};  // 重置 buffer
+            reset_token_buffer();
             wav_idx = 0;  // 重置 wav index
             
             // 🔧 [修复竞态条件] 在 T2W 线程处理完打断后递增 wav_turn_base
@@ -9039,7 +9056,7 @@ void t2w_thread_func_cpp(struct omni_context * ctx_omni, common_params *params) 
             // 重置轮次相关状态
             wav_idx = 0;                                                    // WAV 文件编号从 0 开始
             ctx_omni->wav_turn_base = effective_round_idx * 1000;           // 更新全局 WAV 编号基数
-            token_buffer = {4218, 4218, 4218};                              // 重置 token buffer（3个静音前缀）
+            reset_token_buffer();
             
             print_with_timestamp("T2W线程(C++): 新输出目录 %s\n", tts_wav_output_dir.c_str());
             
@@ -9077,7 +9094,8 @@ void t2w_thread_func_cpp(struct omni_context * ctx_omni, common_params *params) 
         
         // 处理逻辑（单工/双工分开）
         bool need_flush = false;
-        size_t min_process_threshold = WINDOW_SIZE;
+        const size_t min_process_threshold =
+            ctx_omni->duplex_mode ? WINDOW_SIZE : CHUNK_SIZE;
         
         if (!ctx_omni->duplex_mode) {
             need_flush = is_final || is_chunk_end;
@@ -9091,10 +9109,10 @@ void t2w_thread_func_cpp(struct omni_context * ctx_omni, common_params *params) 
         int process_count = 0;
         while (token_buffer.size() >= min_process_threshold || (need_flush && !token_buffer.empty())) {
             // Determine how many tokens to process
-            size_t process_size = std::min(token_buffer.size(), (size_t)WINDOW_SIZE);
+            size_t process_size = std::min(token_buffer.size(), min_process_threshold);
             // 🔧 is_last_window: 只有 is_final 才算轮次真正的"最后窗口"（触发 token2wav 终结 + buffer 重置）
             // 双工 chunk_end 不能视为 last_window，否则 token2wav 会被重置、丢失跨 chunk 的状态
-            bool is_last_window = is_final && (token_buffer.size() <= WINDOW_SIZE);
+            bool is_last_window = is_final && (token_buffer.size() <= min_process_threshold);
             
             std::vector<int32_t> window(token_buffer.begin(), token_buffer.begin() + process_size);
             
@@ -9171,38 +9189,24 @@ void t2w_thread_func_cpp(struct omni_context * ctx_omni, common_params *params) 
                 LOG_ERR("T2W线程: feed_window 失败\n");
             }
             
-            // Slide window by CHUNK_SIZE (25), keep last PRE_LOOKAHEAD (3) for overlap
-            size_t buffer_before_slide = token_buffer.size();
-            
             if (!ctx_omni->duplex_mode) {
-                // 🔧 [单工模式] 保持原有逻辑，绝对不改动
-                // Slide window by CHUNK_SIZE (25), keep last PRE_LOOKAHEAD (3) for overlap
                 if (token_buffer.size() > CHUNK_SIZE) {
                     token_buffer.erase(token_buffer.begin(), token_buffer.begin() + CHUNK_SIZE);
                 } else {
                     token_buffer.clear();
                 }
             } else {
-                // 🔧 [双工模式-与 Python 对齐]
-                // Python: self.token2wav_buffer = self.token2wav_buffer[min(CHUNK_SIZE, chunk_to_process - self.pre_lookahead):]
-                size_t slide_amount;
+                size_t slide_amount = 0;
                 if (is_last_window) {
-                    // 最后一个 window，清空 buffer
                     slide_amount = token_buffer.size();
                 } else if (token_buffer.size() > CHUNK_SIZE) {
-                    // 正常情况：滑动 CHUNK_SIZE
                     slide_amount = CHUNK_SIZE;
                 } else if (token_buffer.size() > PRE_LOOKAHEAD) {
-                    // 有 chunk_eos 时，保留 pre_lookahead
                     slide_amount = token_buffer.size() - PRE_LOOKAHEAD;
-                } else {
-                    slide_amount = 0;  // 太少了，不滑动
                 }
-                
-                if (slide_amount > 0 && slide_amount <= token_buffer.size()) {
-                    token_buffer.erase(token_buffer.begin(), token_buffer.begin() + slide_amount);
-                } else if (slide_amount > token_buffer.size()) {
-                    token_buffer.clear();
+                if (slide_amount > 0) {
+                    token_buffer.erase(
+                        token_buffer.begin(), token_buffer.begin() + slide_amount);
                 }
             }
             process_count++;
@@ -9229,8 +9233,7 @@ void t2w_thread_func_cpp(struct omni_context * ctx_omni, common_params *params) 
                     // 🔧 [关键] 不调用 Token2WavSession::reset()
                     // 原因：reset() 会把 stream_started_=false，导致下一轮 feed_window 失败
                     // 单工和双工模式都只重置 token_buffer，保持 Token2Wav 的 stream 状态
-                    // 重新初始化buffer（3个静音token作为前缀）
-                    token_buffer = {4218, 4218, 4218};
+                    reset_token_buffer();
                     
                     // 🔧 [修复竞态条件] 在 T2W 线程处理完 is_final 后递增 wav_turn_base
                     // 原因：确保当前轮次的所有 wav 文件使用旧的编号，然后再切换到新编号

--- a/tools/omni/omni.cpp
+++ b/tools/omni/omni.cpp
@@ -3,6 +3,7 @@
 #include "audition.h"
 #include "omni.h"
 #include "token2wav/token2wav-impl.h"
+#include "token2wav/token2wav-frontend.h"
 
 #include "llama.h"
 #include "common/common.h"
@@ -37,6 +38,7 @@
 #include <future>
 #include <unordered_map>
 #include <fstream>
+#include <filesystem>
 #include <iomanip>
 #include <chrono>
 #include <cmath>
@@ -4821,6 +4823,12 @@ void omni_free(struct omni_context * ctx_omni) {
             projector_free(ctx_omni->projector);
         }
     }
+
+    if (ctx_omni->tts_ref_audio_owned && !ctx_omni->tts_ref_audio_path.empty()) {
+        std::remove(ctx_omni->tts_ref_audio_path.c_str());
+        ctx_omni->tts_ref_audio_path.clear();
+        ctx_omni->tts_ref_audio_owned = false;
+    }
     
     // 🔧 [单双工适配] 只有在拥有模型时才释放 LLM model 和 context
     // 如果是外部传入的模型（模型复用），则不释放
@@ -8577,6 +8585,89 @@ static bool reset_python_t2w_cache(struct omni_context * ctx_omni) {
     }
     return response.find("\"status\":\"ok\"") != std::string::npos ||
            response.find("\"status\": \"ok\"") != std::string::npos;
+}
+
+bool omni_set_tts_reference_audio(struct omni_context * ctx_omni,
+                                  const std::string & tts_ref_audio_path) {
+    if (!ctx_omni) {
+        LOG_ERR("omni_set_tts_reference_audio: context is null\n");
+        return false;
+    }
+    if (tts_ref_audio_path.empty() || !ctx_omni->use_tts) {
+        return true;
+    }
+
+    std::error_code file_error;
+    const std::filesystem::file_status file_status =
+        std::filesystem::status(tts_ref_audio_path, file_error);
+    const uintmax_t file_size =
+        file_error || !std::filesystem::is_regular_file(file_status)
+            ? 0
+            : std::filesystem::file_size(tts_ref_audio_path, file_error);
+    if (file_error || !std::filesystem::is_regular_file(file_status) ||
+        file_size < 12 ||
+        file_size > omni::flow::Token2WavFrontend::kMaxReferenceWavBytes) {
+        LOG_ERR("omni_set_tts_reference_audio: reference audio is not a bounded regular WAV: %s\n",
+                tts_ref_audio_path.c_str());
+        return false;
+    }
+
+    std::lock_guard<std::mutex> voice_lock(ctx_omni->tts_voice_mtx);
+    if (!ctx_omni->token2wav_initialized || !ctx_omni->token2wav_session) {
+        LOG_ERR("omni_set_tts_reference_audio: native Token2Wav is not initialized\n");
+        return false;
+    }
+
+    const std::string speech_tokenizer_gguf =
+        ctx_omni->token2wav_model_dir + "/speech_tokenizer_v2_25hz.gguf";
+    const std::string campplus_gguf =
+        ctx_omni->token2wav_model_dir + "/campplus.gguf";
+    if (!ctx_omni->token2wav_session->set_prompt_wav(
+            tts_ref_audio_path,
+            speech_tokenizer_gguf,
+            campplus_gguf,
+            /*frontend_threads=*/1,
+            /*n_timesteps=*/5,
+            /*temperature=*/1.0f)) {
+        LOG_ERR("omni_set_tts_reference_audio: native GGUF frontend failed\n");
+        return false;
+    }
+
+    ctx_omni->tts_ref_audio_path = tts_ref_audio_path;
+    ctx_omni->token2wav_buffer = {4218, 4218, 4218};
+    return true;
+}
+
+bool omni_reset_tts_reference_audio(struct omni_context * ctx_omni) {
+    if (!ctx_omni) {
+        LOG_ERR("omni_reset_tts_reference_audio: context is null\n");
+        return false;
+    }
+    if (!ctx_omni->use_tts) {
+        return true;
+    }
+
+    std::lock_guard<std::mutex> voice_lock(ctx_omni->tts_voice_mtx);
+    if (!ctx_omni->token2wav_initialized || !ctx_omni->token2wav_session) {
+        LOG_ERR("omni_reset_tts_reference_audio: native Token2Wav is not initialized\n");
+        return false;
+    }
+
+    const std::string prompt_cache_gguf =
+        ctx_omni->token2wav_model_dir + "/prompt_cache.gguf";
+    if (!ctx_omni->token2wav_session->reset_to_prompt_cache_gguf(
+            prompt_cache_gguf, /*n_timesteps=*/5, /*temperature=*/1.0f)) {
+        LOG_ERR("omni_reset_tts_reference_audio: failed to restore default voice\n");
+        return false;
+    }
+
+    if (ctx_omni->tts_ref_audio_owned && !ctx_omni->tts_ref_audio_path.empty()) {
+        std::remove(ctx_omni->tts_ref_audio_path.c_str());
+    }
+    ctx_omni->tts_ref_audio_path.clear();
+    ctx_omni->tts_ref_audio_owned = false;
+    ctx_omni->token2wav_buffer = {4218, 4218, 4218};
+    return true;
 }
 
 // ======================= Token2Wav 线程函数 =======================

--- a/tools/omni/omni.cpp
+++ b/tools/omni/omni.cpp
@@ -4368,16 +4368,29 @@ struct omni_context * omni_init(struct common_params * params, int media_type, b
             }
 
             const OmniTtsPythonBaseConfig tts_config = omni_tts_python_base_config();
+            ctx_omni->token2wav_default_prompt_source =
+                omni_context::TtsDefaultPromptSource::NONE;
+            ctx_omni->token2wav_default_prompt_path.clear();
             init_ok = ctx_omni->token2wav_session->init_from_prompt_cache_gguf(
                     encoder_gguf, flow_matching_gguf, flow_extra_gguf, prompt_cache_gguf,
                     vocoder_gguf, device_token2mel, device_vocoder,
                     /*n_timesteps=*/-1, tts_config.token2wav_temperature, coreml_model_path);
+            if (init_ok) {
+                ctx_omni->token2wav_default_prompt_source =
+                    omni_context::TtsDefaultPromptSource::PROMPT_CACHE_GGUF;
+                ctx_omni->token2wav_default_prompt_path = prompt_cache_gguf;
+            }
             if (!init_ok && use_prompt_bundle) {
                 print_with_timestamp("Token2Wav: prompt_cache failed, fallback to prompt_bundle from %s\n", prompt_bundle_dir.c_str());
                 init_ok = ctx_omni->token2wav_session->init_from_prompt_bundle(
                         encoder_gguf, flow_matching_gguf, flow_extra_gguf, prompt_bundle_dir,
                         vocoder_gguf, device_token2mel, device_vocoder,
                         tts_config.n_timesteps, tts_config.token2wav_temperature);
+                if (init_ok) {
+                    ctx_omni->token2wav_default_prompt_source =
+                        omni_context::TtsDefaultPromptSource::PROMPT_BUNDLE;
+                    ctx_omni->token2wav_default_prompt_path = prompt_bundle_dir;
+                }
             }
             // Fallback to CPU
             if (!init_ok) {
@@ -4388,6 +4401,11 @@ struct omni_context * omni_init(struct common_params * params, int media_type, b
                         encoder_gguf, flow_matching_gguf, flow_extra_gguf, prompt_cache_gguf,
                         vocoder_gguf, "cpu", "cpu",
                         /*n_timesteps=*/-1, tts_config.token2wav_temperature);
+                if (init_ok) {
+                    ctx_omni->token2wav_default_prompt_source =
+                        omni_context::TtsDefaultPromptSource::PROMPT_CACHE_GGUF;
+                    ctx_omni->token2wav_default_prompt_path = prompt_cache_gguf;
+                }
             }
             
             if (init_ok) {
@@ -5758,7 +5776,7 @@ static bool generate_audio_tokens_local(
         return false;
     }
     print_with_timestamp("TTS Local: prefill completed, n_past_tts=%d\n", n_past_tts);
-    
+
     // 2. Reuse the persistent sampler created with the TTS model.
     struct common_sampler * tts_sampler = ctx_omni->ctx_tts_sampler;
     if (!tts_sampler) {
@@ -5782,7 +5800,7 @@ static bool generate_audio_tokens_local(
     // generation lets the TTS model stop at its EOS token.
     const int min_new_tokens =
         ctx_omni->duplex_mode && !is_end_of_turn ? 26 : 0;
-    
+
     // The turn-based path sends 25 generated audio tokens and lets
     // Token2Mel add its fixed-graph padding. Full-duplex keeps the existing
     // 28-token window so its one-second playback cadence is unchanged.
@@ -8606,11 +8624,24 @@ bool omni_reset_tts_reference_audio(struct omni_context * ctx_omni) {
         return false;
     }
 
-    const std::string prompt_cache_gguf =
-        ctx_omni->token2wav_model_dir + "/prompt_cache.gguf";
     const OmniTtsPythonBaseConfig tts_config = omni_tts_python_base_config();
-    if (!ctx_omni->token2wav_session->reset_to_prompt_cache_gguf(
-            prompt_cache_gguf, /*n_timesteps=*/-1, tts_config.token2wav_temperature)) {
+    bool restored = false;
+    if (ctx_omni->token2wav_default_prompt_source ==
+            omni_context::TtsDefaultPromptSource::PROMPT_BUNDLE &&
+        !ctx_omni->token2wav_default_prompt_path.empty()) {
+        restored = ctx_omni->token2wav_session->reset_to_prompt_bundle(
+            ctx_omni->token2wav_default_prompt_path,
+            tts_config.n_timesteps,
+            tts_config.token2wav_temperature);
+    } else {
+        const std::string prompt_cache_gguf =
+            ctx_omni->token2wav_default_prompt_path.empty()
+                ? ctx_omni->token2wav_model_dir + "/prompt_cache.gguf"
+                : ctx_omni->token2wav_default_prompt_path;
+        restored = ctx_omni->token2wav_session->reset_to_prompt_cache_gguf(
+            prompt_cache_gguf, /*n_timesteps=*/-1, tts_config.token2wav_temperature);
+    }
+    if (!restored) {
         LOG_ERR("omni_reset_tts_reference_audio: failed to restore default voice\n");
         return false;
     }
@@ -8920,14 +8951,13 @@ void t2w_thread_func_cpp(struct omni_context * ctx_omni, common_params *params) 
     auto& mtx = ctx_omni->t2w_thread_info->mtx;
     auto& cv = ctx_omni->t2w_thread_info->cv;
     
-    constexpr int32_t CHUNK_SIZE = 25;
-    constexpr int32_t PRE_LOOKAHEAD = 3;
-    constexpr int32_t WINDOW_SIZE = CHUNK_SIZE + PRE_LOOKAHEAD;
+    const int32_t pre_lookahead =
+        omni_tts_python_base_config().prelook_size;
     std::vector<int32_t> token_buffer;
     auto reset_token_buffer = [&]() {
         token_buffer.clear();
         if (ctx_omni->duplex_mode) {
-            token_buffer.assign(PRE_LOOKAHEAD, 4218);
+            token_buffer.assign(pre_lookahead, 4218);
         }
     };
     reset_token_buffer();
@@ -9065,7 +9095,6 @@ void t2w_thread_func_cpp(struct omni_context * ctx_omni, common_params *params) 
         }
         
         // Add new tokens to buffer
-        size_t buffer_before = token_buffer.size();
         token_buffer.insert(token_buffer.end(), new_tokens.begin(), new_tokens.end());
         const double queue_wait_ms = have_enqueue_time
             ? std::chrono::duration<double, std::milli>(dequeue_time - oldest_enqueue_time).count()
@@ -9092,29 +9121,19 @@ void t2w_thread_func_cpp(struct omni_context * ctx_omni, common_params *params) 
             continue;
         }
         
-        // 处理逻辑（单工/双工分开）
-        bool need_flush = false;
-        const size_t min_process_threshold =
-            ctx_omni->duplex_mode ? WINDOW_SIZE : CHUNK_SIZE;
-        
-        if (!ctx_omni->duplex_mode) {
-            need_flush = is_final || is_chunk_end;
-        } else {
-            // 双工：只在 is_final（LISTEN→SPEAK 切换时 LLM 线程设置）时 flush。
-            // chunk_end 保持原语义"累积等下个 chunk"，避免把一轮 turn 切成多段 wav 产生播放 gap。
-            need_flush = is_final;
-        }
-        
-        // Process windows using sliding window
-        int process_count = 0;
-        while (token_buffer.size() >= min_process_threshold || (need_flush && !token_buffer.empty())) {
-            // Determine how many tokens to process
-            size_t process_size = std::min(token_buffer.size(), min_process_threshold);
-            // 🔧 is_last_window: 只有 is_final 才算轮次真正的"最后窗口"（触发 token2wav 终结 + buffer 重置）
-            // 双工 chunk_end 不能视为 last_window，否则 token2wav 会被重置、丢失跨 chunk 的状态
-            bool is_last_window = is_final && (token_buffer.size() <= min_process_threshold);
-            
-            std::vector<int32_t> window(token_buffer.begin(), token_buffer.begin() + process_size);
+        // Process only complete fixed-graph windows. is_chunk_end wakes the
+        // worker, but it is not a stream-final signal and must not force a
+        // short non-final window through the 28-token graph.
+        while (true) {
+            const OmniTtsWindowPlan window_plan =
+                omni_tts_window_plan(token_buffer.size(), is_final);
+            if (!window_plan.ready) {
+                break;
+            }
+
+            std::vector<int32_t> window(token_buffer.begin(),
+                                        token_buffer.begin() + window_plan.process_size);
+            const bool is_last_window = window_plan.is_last_window;
             
             // Time the inference
             auto t2w_start = std::chrono::high_resolution_clock::now();
@@ -9189,28 +9208,11 @@ void t2w_thread_func_cpp(struct omni_context * ctx_omni, common_params *params) 
                 LOG_ERR("T2W线程: feed_window 失败\n");
             }
             
-            if (!ctx_omni->duplex_mode) {
-                if (token_buffer.size() > CHUNK_SIZE) {
-                    token_buffer.erase(token_buffer.begin(), token_buffer.begin() + CHUNK_SIZE);
-                } else {
-                    token_buffer.clear();
-                }
-            } else {
-                size_t slide_amount = 0;
-                if (is_last_window) {
-                    slide_amount = token_buffer.size();
-                } else if (token_buffer.size() > CHUNK_SIZE) {
-                    slide_amount = CHUNK_SIZE;
-                } else if (token_buffer.size() > PRE_LOOKAHEAD) {
-                    slide_amount = token_buffer.size() - PRE_LOOKAHEAD;
-                }
-                if (slide_amount > 0) {
-                    token_buffer.erase(
-                        token_buffer.begin(), token_buffer.begin() + slide_amount);
-                }
+            if (window_plan.slide_amount > 0) {
+                token_buffer.erase(
+                    token_buffer.begin(),
+                    token_buffer.begin() + window_plan.slide_amount);
             }
-            process_count++;
-            
             if (is_last_window) {
                 // 🔧 [与 Python 对齐] 只有 is_final（轮次结束）时才重置
                 // Python: if is_last_chunk: stream(..., last_chunk=True); buffer = []
@@ -10955,6 +10957,7 @@ bool stream_decode(struct omni_context * ctx_omni, std::string debug_dir, int ro
         int max_chunk_tokens = ctx_omni->duplex_mode ? ctx_omni->max_new_speak_tokens_per_chunk : 0;
         bool chunk_limit_reached = (max_chunk_tokens > 0 && current_chunk_tokens >= max_chunk_tokens);
         {
+            bool defer_response_piece = false;
             fflush(stdout);
             // Python generates one lookahead token at every non-final chunk
             // boundary. The lookahead is fed into the LLM cache, but its text
@@ -10988,6 +10991,7 @@ bool stream_decode(struct omni_context * ctx_omni, std::string debug_dir, int ro
                                 hidden_states, hidden_states + llm_n_embd);
                             pending_tts_piece = tmp;
                             has_pending_tts_token = true;
+                            defer_response_piece = true;
                             need_lookahead = false;
                         } else {
                             chunk_token_ids.push_back(sampled_token);
@@ -11122,7 +11126,9 @@ bool stream_decode(struct omni_context * ctx_omni, std::string debug_dir, int ro
 
                 // Copy tmp to a local string immediately to avoid issues with static string
                 std::string tmp_str(tmp);
-                response += tmp_str;
+                if (!defer_response_piece) {
+                    response += tmp_str;
+                }
                 free(hidden_states);
                 fflush(stdout);
             }

--- a/tools/omni/omni.h
+++ b/tools/omni/omni.h
@@ -150,6 +150,26 @@ struct projector_model {
     bool initialized = false;
 };
 
+// Runtime values used by the Python base Token2Wav path. The native path
+// keeps these fixed so model quality does not depend on per-request defaults.
+struct OmniTtsPythonBaseConfig {
+    int   n_timesteps = 10;
+    int   chunk_size = 25;
+    int   prelook_size = 3;
+    float token2wav_temperature = 1.0f;
+    float tts_temperature = 0.8f;
+    float top_p = 0.85f;
+    int   top_k = 25;
+    int   min_tokens_to_keep = 3;
+    float repetition_penalty = 1.05f;
+    int   repetition_window = 16;
+    int   max_audio_tokens = 500;
+};
+
+inline OmniTtsPythonBaseConfig omni_tts_python_base_config() {
+    return {};
+}
+
 // The GGUF converter writes head_code as contiguous [audio_token, hidden]
 // rows. GGUF metadata may expose the reversed dimensions, but the payload
 // remains row-major and must be copied without another transpose.

--- a/tools/omni/omni.h
+++ b/tools/omni/omni.h
@@ -209,6 +209,45 @@ inline OmniTextChunkPlan omni_text_chunk_plan(int chunk_size, bool has_pending_t
     };
 }
 
+struct OmniTtsWindowPlan {
+    bool   ready = false;
+    size_t process_size = 0;
+    size_t slide_amount = 0;
+    bool   is_last_window = false;
+};
+
+inline OmniTtsWindowPlan omni_tts_window_plan(size_t buffer_size, bool is_final) {
+    const OmniTtsPythonBaseConfig config = omni_tts_python_base_config();
+    const size_t chunk_size = static_cast<size_t>(config.chunk_size);
+    const size_t window_size = chunk_size + static_cast<size_t>(config.prelook_size);
+
+    if (buffer_size == 0 || (!is_final && buffer_size < window_size)) {
+        return {};
+    }
+
+    OmniTtsWindowPlan plan;
+    plan.ready = true;
+    plan.process_size = std::min(buffer_size, window_size);
+    plan.is_last_window = is_final && buffer_size <= window_size;
+
+    if (plan.is_last_window) {
+        plan.slide_amount = buffer_size;
+    } else if (buffer_size > chunk_size) {
+        plan.slide_amount = chunk_size;
+    } else if (buffer_size > static_cast<size_t>(config.prelook_size)) {
+        plan.slide_amount = buffer_size - static_cast<size_t>(config.prelook_size);
+    }
+
+    return plan;
+}
+
+inline bool omni_tts_should_defer_text_piece(bool simplex_mode,
+                                             bool need_lookahead,
+                                             int  condition_tokens_collected,
+                                             int  step_size) {
+    return simplex_mode && need_lookahead && condition_tokens_collected >= step_size;
+}
+
 inline int omni_duplex_tts_output_token_count_for_budget(int max_new_tokens) {
     return max_new_tokens > 0 ? max_new_tokens - 1 : 0;
 }
@@ -490,6 +529,13 @@ struct omni_context {
     std::unique_ptr<omni::flow::Token2WavSession> token2wav_session;
     bool token2wav_initialized = false;
     std::string token2wav_model_dir;  // Directory containing token2wav GGUF models
+    enum class TtsDefaultPromptSource {
+        NONE,
+        PROMPT_CACHE_GGUF,
+        PROMPT_BUNDLE,
+    };
+    TtsDefaultPromptSource token2wav_default_prompt_source = TtsDefaultPromptSource::NONE;
+    std::string token2wav_default_prompt_path;
     std::mutex tts_voice_mtx;
     
     // 🔧 [Python Token2Wav] 使用 Python stepaudio2 库实现的 Token2Wav

--- a/tools/omni/omni.h
+++ b/tools/omni/omni.h
@@ -330,6 +330,8 @@ struct omni_context {
     int use_tts = false;
     std::string tts_bin_dir = "";
     std::string ref_audio_path = "";  // 参考音频路径（用于音色克隆）
+    std::string tts_ref_audio_path = "";  // Native Token2Wav reference WAV
+    bool tts_ref_audio_owned = false;     // Server owns and removes temporary WAV
     
     // 🔧 [高清/高刷模式] 
     // high_image: 高清模式，max_slice_nums 设置为 2，vision 可以看到更多细节
@@ -423,6 +425,7 @@ struct omni_context {
     std::unique_ptr<omni::flow::Token2WavSession> token2wav_session;
     bool token2wav_initialized = false;
     std::string token2wav_model_dir;  // Directory containing token2wav GGUF models
+    std::mutex tts_voice_mtx;
     
     // 🔧 [Python Token2Wav] 使用 Python stepaudio2 库实现的 Token2Wav
     // 设置为 true 时使用 Python 实现（精度更高），false 时使用 C++ 实现
@@ -491,6 +494,12 @@ struct omni_context * omni_init(struct common_params * params, int media_type, b
                                 const std::string & base_output_dir = "./tools/omni/output");
 
 void omni_free(struct omni_context * ctx_omni);
+// Install a session-level voice prompt from a reference WAV using the native
+// GGUF speech tokenizer and CAM++ frontend models.
+bool omni_set_tts_reference_audio(struct omni_context * ctx_omni,
+                                  const std::string & tts_ref_audio_path);
+// Restore the model-directory default Token2Wav prompt cache for context reuse.
+bool omni_reset_tts_reference_audio(struct omni_context * ctx_omni);
 // Stop/join inference threads and clear queues so the same context can serve a
 // new session, without tearing down the loaded model (unlike omni_free).
 void omni_prepare_for_reuse(struct omni_context * ctx_omni);

--- a/tools/omni/omni.h
+++ b/tools/omni/omni.h
@@ -2,6 +2,8 @@
 #include "llama.h"
 #include "tts-condition-graph.h"
 
+#include <algorithm>
+#include <cstdint>
 #include <thread>
 #include <memory>
 #include <vector>
@@ -147,6 +149,49 @@ struct projector_model {
     ggml_backend_buffer_type_t buf_type = nullptr;
     bool initialized = false;
 };
+
+// The GGUF converter writes head_code as contiguous [audio_token, hidden]
+// rows. GGUF metadata may expose the reversed dimensions, but the payload
+// remains row-major and must be copied without another transpose.
+inline bool omni_copy_head_code_row_major(const float * source,
+                                          int64_t       dim0,
+                                          int64_t       dim1,
+                                          int           hidden_size,
+                                          int           num_audio_tokens,
+                                          float *       destination) {
+    if (source == nullptr || destination == nullptr ||
+        hidden_size <= 0 || num_audio_tokens <= 0) {
+        return false;
+    }
+    if (!((dim0 == hidden_size && dim1 == num_audio_tokens) ||
+          (dim0 == num_audio_tokens && dim1 == hidden_size))) {
+        return false;
+    }
+    std::copy(source,
+              source + static_cast<size_t>(hidden_size) * num_audio_tokens,
+              destination);
+    return true;
+}
+
+struct OmniTextChunkPlan {
+    int prefix_tokens = 0;
+    int condition_tokens = 0;
+    int generated_tokens = 0;
+};
+
+inline OmniTextChunkPlan omni_text_chunk_plan(int chunk_size, bool has_pending_token) {
+    const int prefix_tokens = has_pending_token ? 1 : 0;
+    const int condition_tokens = std::max(0, chunk_size - prefix_tokens);
+    return {
+        prefix_tokens,
+        condition_tokens,
+        condition_tokens + 1,
+    };
+}
+
+inline int omni_duplex_tts_output_token_count_for_budget(int max_new_tokens) {
+    return max_new_tokens > 0 ? max_new_tokens - 1 : 0;
+}
 
 // ============================================================================
 // Audio output callback type
@@ -392,7 +437,7 @@ struct omni_context {
     
     // head_code: Linear layer (hidden_size=768 -> num_audio_tokens=6562)
     // Note: num_vq=1, so we only need one head_code layer
-    float * head_code_weight = nullptr;  // (768, 6562) - stored as (hidden_size, num_audio_tokens)
+    float * head_code_weight = nullptr;  // (6562, 768) - one row per audio token
     int head_code_hidden_size = 0;  // 768
     int head_code_num_audio_tokens = 0;  // 6562
     
@@ -613,7 +658,7 @@ bool prefill_with_emb_tts(struct omni_context* ctx_omni, common_params* params, 
 // - chunk_generated_tokens: 当前 chunk 内已生成的 tokens（用于 repetition penalty，与 Python generate_chunk 对齐）
 // - token_index_in_chunk: 当前 chunk 内的 token 索引（用于判断是否跳过 sampling processors）
 // - force_no_eos: 是否强制阻止 EOS token 被采样（用于 min_new_tokens 逻辑，与 Python generate_chunk 对齐）
-llama_token sample_tts_token(struct common_sampler * smpl, struct omni_context * ctx_omni, common_params* params, int * n_past_tts, const std::vector<llama_token> * all_generated_tokens = nullptr, const std::vector<llama_token> * chunk_generated_tokens = nullptr, int token_index_in_chunk = 0, bool force_no_eos = false);
+llama_token sample_tts_token(struct common_sampler * smpl, struct omni_context * ctx_omni, common_params* params, int * n_past_tts, const std::vector<llama_token> * all_generated_tokens = nullptr, const std::vector<llama_token> * chunk_generated_tokens = nullptr, int token_index_in_chunk = 0, bool force_no_eos = false, bool is_final_text_chunk = false);
 
 // Projector 函数声明（精度验证版本）
 bool projector_init(projector_model & model, const std::string & fname, bool use_cuda);

--- a/tools/omni/test/test-token2wav-frontend.cpp
+++ b/tools/omni/test/test-token2wav-frontend.cpp
@@ -1,0 +1,433 @@
+#include "token2wav-frontend.h"
+
+#undef NDEBUG
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+static std::vector<float> sine_wave(int sample_rate, float seconds, float frequency) {
+    const size_t n = static_cast<size_t>(sample_rate * seconds);
+    std::vector<float> audio(n);
+    for (size_t i = 0; i < n; ++i) {
+        audio[i] = 0.2f * std::sin(2.0f * static_cast<float>(M_PI) * frequency *
+                                   static_cast<float>(i) / static_cast<float>(sample_rate));
+    }
+    return audio;
+}
+
+static void assert_close(float actual, float expected, float tolerance, const char * name) {
+    if (std::fabs(actual - expected) > tolerance) {
+        std::fprintf(stderr, "%s mismatch: actual=%0.9f expected=%0.9f tolerance=%0.9f\n",
+                     name, actual, expected, tolerance);
+        assert(false);
+    }
+}
+
+static void test_resample_matches_stepaudio2_contract() {
+    omni::flow::AudioBuffer input;
+    input.sample_rate = 24000;
+    input.samples.assign(32, 0.0f);
+    input.samples[5] = 1.0f;
+
+    omni::flow::AudioBuffer output;
+    assert(omni::flow::Token2WavFrontend::resample_mono(input, 16000, output));
+    assert(output.sample_rate == 16000);
+    assert(output.samples.size() == 22);
+
+    const float expected[] = {
+        -0.021723339334f,
+        0.050903785974f,
+        -0.118959866464f,
+        0.543885588646f,
+        0.270691812038f,
+        -0.093562029302f,
+        0.042748011649f,
+        -0.017954932526f,
+        0.005282599479f,
+        -0.000366034976f,
+        0.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+    };
+    for (size_t i = 0; i < output.samples.size(); ++i) {
+        assert_close(output.samples[i], expected[i], 2e-6f, "resample");
+    }
+}
+
+static void test_s3_tokenizer_mel_contract() {
+    const auto audio = sine_wave(16000, 1.0f, 440.0f);
+    omni::flow::AudioFeatures features;
+    assert(omni::flow::Token2WavFrontend::compute_s3_log_mel(audio, features));
+    assert(features.channels == 128);
+    assert(features.frames == 100);
+    assert(features.values.size() == static_cast<size_t>(128 * 100));
+    for (const float value : features.values) {
+        assert(std::isfinite(value));
+    }
+    const float expected[] = {
+        0.708549559f,
+        0.196541548f,
+        -0.713614941f,
+        0.214703143f,
+        -0.713614941f,
+        -0.713614941f,
+    };
+    const size_t indices[] = {0, 1, 127, 128 * 50, 128 * 99, 128 * 100 - 1};
+    for (size_t i = 0; i < 6; ++i) {
+        assert_close(features.values[indices[i]], expected[i], 2e-3f, "s3_log_mel");
+    }
+}
+
+static void test_token2wav_prompt_mel_contract() {
+    const auto audio = sine_wave(24000, 1.0f, 440.0f);
+    omni::flow::AudioFeatures features;
+    assert(omni::flow::Token2WavFrontend::compute_token2wav_prompt_mel(audio, features));
+    assert(features.channels == 80);
+    assert(features.frames == 50);
+    assert(features.values.size() == static_cast<size_t>(80 * 50));
+    for (const float value : features.values) {
+        assert(std::isfinite(value));
+    }
+    const float expected[] = {
+        -1.431666017f,
+        -1.409540534f,
+        -6.810078621f,
+        -10.043351173f,
+        -1.436961055f,
+        -6.813612938f,
+    };
+    const size_t indices[] = {
+        0,
+        1 * 50,
+        79 * 50,
+        25,
+        49,
+        79 * 50 + 49,
+    };
+    for (size_t i = 0; i < 6; ++i) {
+        assert_close(features.values[indices[i]], expected[i], 2e-2f, "token2wav_prompt_mel");
+    }
+}
+
+static void test_campplus_fbank_contract() {
+    const auto audio = sine_wave(16000, 1.0f, 440.0f);
+    omni::flow::AudioFeatures features;
+    assert(omni::flow::Token2WavFrontend::compute_campplus_fbank(audio, features));
+    assert(features.channels == 80);
+    assert(features.frames == 98);
+    assert(features.values.size() == static_cast<size_t>(80 * 98));
+    for (const float value : features.values) {
+        assert(std::isfinite(value));
+    }
+    const float expected[] = {
+        -13.403847694f,
+        -12.797039986f,
+        -15.942384720f,
+        -13.475249290f,
+        -12.455262184f,
+        -14.080187798f,
+    };
+    const size_t indices[] = {0, 1, 79, 80 * 49, 80 * 97, 80 * 98 - 1};
+    for (size_t i = 0; i < 6; ++i) {
+        // The C++ float sine fixture and the Python reference use different
+        // arithmetic order, so keep this as a regression check rather than
+        // an exact cross-language parity test.
+        assert_close(features.values[indices[i]], expected[i], 1e-2f, "campplus_fbank");
+    }
+}
+
+static void test_prompt_bundle_assembly_adds_lookahead_and_converts_mel_layout() {
+    const std::vector<int32_t> speech_tokens = { 10, 11, 12, 13 };
+    omni::flow::AudioFeatures prompt_mel;
+    prompt_mel.channels = 80;
+    prompt_mel.frames   = 8;
+    prompt_mel.values.resize(static_cast<size_t>(prompt_mel.channels) * prompt_mel.frames);
+    for (int c = 0; c < prompt_mel.channels; ++c) {
+        for (int t = 0; t < prompt_mel.frames; ++t) {
+            prompt_mel.values[static_cast<size_t>(c) * prompt_mel.frames + t] =
+                static_cast<float>(c * 1000 + t);
+        }
+    }
+    const std::vector<float> speaker_embedding(192, 0.25f);
+
+    omni::flow::FrontendPromptBundle bundle;
+    std::string error;
+    assert(omni::flow::Token2WavFrontend::assemble_prompt_bundle(
+        speech_tokens, prompt_mel, speaker_embedding, bundle, &error));
+    assert(error.empty());
+    assert(bundle.B == 1);
+    assert(bundle.T_prompt_token == 7);
+    assert(bundle.T_prompt_mel == 8);
+    assert(bundle.prompt_tokens_bt == std::vector<int32_t>({ 10, 11, 12, 13, 4218, 4218, 4218 }));
+    assert(bundle.spk_bc == speaker_embedding);
+    for (int t = 0; t < prompt_mel.frames; ++t) {
+        for (int c = 0; c < prompt_mel.channels; ++c) {
+            const size_t index = static_cast<size_t>(t) * prompt_mel.channels + c;
+            assert(bundle.prompt_mel_btc[index] ==
+                   static_cast<float>(c * 1000 + t));
+        }
+    }
+}
+
+static void test_prompt_bundle_assembly_rejects_shape_mismatch() {
+    const std::vector<int32_t> speech_tokens = { 10, 11, 12, 13 };
+    omni::flow::AudioFeatures prompt_mel;
+    prompt_mel.channels = 80;
+    prompt_mel.frames   = 7;
+    prompt_mel.values.assign(static_cast<size_t>(prompt_mel.channels) * prompt_mel.frames, 0.0f);
+    const std::vector<float> speaker_embedding(192, 0.25f);
+
+    omni::flow::FrontendPromptBundle bundle;
+    std::string error;
+    assert(!omni::flow::Token2WavFrontend::assemble_prompt_bundle(
+        speech_tokens, prompt_mel, speaker_embedding, bundle, &error));
+    assert(error.find("prompt Mel frame count") != std::string::npos);
+}
+
+static void test_frontend_output_shape_contracts_require_single_batch() {
+    std::string error;
+    assert(omni::flow::Token2WavFrontend::validate_speech_tokenizer_output_shape({ 17 }, &error));
+    assert(omni::flow::Token2WavFrontend::validate_speech_tokenizer_output_shape({ 1, 17 }, &error));
+    assert(!omni::flow::Token2WavFrontend::validate_speech_tokenizer_output_shape({ 2, 9 }, &error));
+    assert(error.find("B=1") != std::string::npos);
+
+    error.clear();
+    assert(omni::flow::Token2WavFrontend::validate_campplus_output_shape({ 192 }, &error));
+    assert(omni::flow::Token2WavFrontend::validate_campplus_output_shape({ 1, 192 }, &error));
+    assert(!omni::flow::Token2WavFrontend::validate_campplus_output_shape({ 2, 96 }, &error));
+    assert(error.find("B=1") != std::string::npos);
+}
+
+static void test_load_wav_rejects_short_multichannel_frame() {
+    const std::filesystem::path path =
+        std::filesystem::temp_directory_path() / "token2wav-short-block-align.wav";
+    std::vector<uint8_t> wav(45, 0);
+    auto put_u16 = [&](size_t offset, uint16_t value) {
+        wav[offset] = static_cast<uint8_t>(value & 0xffU);
+        wav[offset + 1] = static_cast<uint8_t>(value >> 8);
+    };
+    auto put_u32 = [&](size_t offset, uint32_t value) {
+        wav[offset] = static_cast<uint8_t>(value & 0xffU);
+        wav[offset + 1] = static_cast<uint8_t>((value >> 8) & 0xffU);
+        wav[offset + 2] = static_cast<uint8_t>((value >> 16) & 0xffU);
+        wav[offset + 3] = static_cast<uint8_t>(value >> 24);
+    };
+    std::memcpy(wav.data(), "RIFF", 4);
+    put_u32(4, static_cast<uint32_t>(wav.size() - 8));
+    std::memcpy(wav.data() + 8, "WAVE", 4);
+    std::memcpy(wav.data() + 12, "fmt ", 4);
+    put_u32(16, 16);
+    put_u16(20, 1);
+    put_u16(22, 2);
+    put_u32(24, 16000);
+    put_u32(28, 16000);
+    put_u16(32, 1);
+    put_u16(34, 16);
+    std::memcpy(wav.data() + 36, "data", 4);
+    put_u32(40, 1);
+
+    {
+        std::ofstream file(path, std::ios::binary);
+        assert(file.good());
+        file.write(reinterpret_cast<const char *>(wav.data()),
+                   static_cast<std::streamsize>(wav.size()));
+        assert(file.good());
+    }
+
+    omni::flow::AudioBuffer output;
+    assert(!omni::flow::Token2WavFrontend::load_wav_mono(path.string(), output));
+    std::filesystem::remove(path);
+}
+
+static void test_resample_rejects_unbounded_kernel_request() {
+    omni::flow::AudioBuffer input;
+    input.sample_rate = 1;
+    input.samples.assign(8, 0.0f);
+
+    omni::flow::AudioBuffer output;
+    assert(!omni::flow::Token2WavFrontend::resample_mono(input, 1000000, output));
+}
+
+static void write_pcm16_wav(const std::string & path, int sample_rate, const std::vector<float> & samples) {
+    std::ofstream file(path, std::ios::binary);
+    assert(file.good());
+
+    const uint32_t data_bytes = static_cast<uint32_t>(samples.size() * sizeof(int16_t));
+    const uint32_t riff_bytes = 36U + data_bytes;
+    auto write_u16 = [&](uint16_t value) {
+        file.put(static_cast<char>(value & 0xffU));
+        file.put(static_cast<char>((value >> 8) & 0xffU));
+    };
+    auto write_u32 = [&](uint32_t value) {
+        file.put(static_cast<char>(value & 0xffU));
+        file.put(static_cast<char>((value >> 8) & 0xffU));
+        file.put(static_cast<char>((value >> 16) & 0xffU));
+        file.put(static_cast<char>((value >> 24) & 0xffU));
+    };
+
+    file.write("RIFF", 4);
+    write_u32(riff_bytes);
+    file.write("WAVEfmt ", 8);
+    write_u32(16);
+    write_u16(1);
+    write_u16(1);
+    write_u32(static_cast<uint32_t>(sample_rate));
+    write_u32(static_cast<uint32_t>(sample_rate * sizeof(int16_t)));
+    write_u16(sizeof(int16_t));
+    write_u16(16);
+    file.write("data", 4);
+    write_u32(data_bytes);
+    for (const float sample : samples) {
+        const float clamped = std::max(-1.0f, std::min(1.0f, sample));
+        const int16_t pcm = static_cast<int16_t>(std::lrintf(clamped * 32767.0f));
+        write_u16(static_cast<uint16_t>(pcm));
+    }
+    assert(file.good());
+}
+
+static void test_gguf_frontend_uses_both_model_files() {
+    const char * speech_path = std::getenv("OMNI_T2W_TEST_SPEECH_TOKENIZER_GGUF");
+    const char * campplus_path = std::getenv("OMNI_T2W_TEST_CAMPPLUS_GGUF");
+    if (!speech_path || !campplus_path || *speech_path == '\0' || *campplus_path == '\0') {
+        std::fprintf(stderr,
+                     "SKIP: set OMNI_T2W_TEST_SPEECH_TOKENIZER_GGUF and "
+                     "OMNI_T2W_TEST_CAMPPLUS_GGUF to run the GGUF frontend test\n");
+        return;
+    }
+
+    const std::filesystem::path wav_path =
+        std::filesystem::temp_directory_path() / "token2wav-gguf-frontend.wav";
+    const auto audio = sine_wave(16000, 1.0f, 440.0f);
+    write_pcm16_wav(wav_path.string(), 16000, audio);
+
+    omni::flow::FrontendPromptBundle bundle;
+    std::string error;
+    const bool ok = omni::flow::Token2WavFrontend::prepare_prompt_bundle(
+        wav_path.string(), speech_path, campplus_path, bundle, &error, 1);
+    std::filesystem::remove(wav_path);
+
+    if (!ok) {
+        std::fprintf(stderr, "GGUF frontend failed: %s\n", error.c_str());
+    }
+    assert(ok);
+    assert(error.empty());
+    assert(bundle.B == 1);
+    assert(bundle.T_prompt_token > 3);
+    assert(bundle.T_prompt_mel == (bundle.T_prompt_token - 3) * 2);
+    assert(bundle.prompt_tokens_bt.size() == static_cast<size_t>(bundle.T_prompt_token));
+    assert(bundle.prompt_mel_btc.size() == static_cast<size_t>(bundle.T_prompt_mel * 80));
+    assert(bundle.spk_bc.size() == 192);
+}
+
+static void write_float_file(const std::string & path, const std::vector<float> & values) {
+    std::ofstream file(path, std::ios::binary);
+    assert(file.good());
+    file.write(reinterpret_cast<const char *>(values.data()),
+               static_cast<std::streamsize>(values.size() * sizeof(float)));
+    assert(file.good());
+}
+
+static void dump_native_bundle(const char * output_dir,
+                               const std::string & ref_wav,
+                               const omni::flow::FrontendPromptBundle & bundle) {
+    std::ofstream tokens(std::string(output_dir) + "/prompt_tokens_i32.bin", std::ios::binary);
+    std::ofstream mel(std::string(output_dir) + "/prompt_mel_btc_f32.bin", std::ios::binary);
+    std::ofstream spk(std::string(output_dir) + "/spk_f32.bin", std::ios::binary);
+    assert(tokens.good());
+    assert(mel.good());
+    assert(spk.good());
+    tokens.write(reinterpret_cast<const char *>(bundle.prompt_tokens_bt.data()),
+                 static_cast<std::streamsize>(bundle.prompt_tokens_bt.size() * sizeof(int32_t)));
+    mel.write(reinterpret_cast<const char *>(bundle.prompt_mel_btc.data()),
+              static_cast<std::streamsize>(bundle.prompt_mel_btc.size() * sizeof(float)));
+    spk.write(reinterpret_cast<const char *>(bundle.spk_bc.data()),
+              static_cast<std::streamsize>(bundle.spk_bc.size() * sizeof(float)));
+    assert(tokens.good());
+    assert(mel.good());
+    assert(spk.good());
+
+    omni::flow::AudioBuffer input;
+    omni::flow::AudioBuffer audio_16k;
+    omni::flow::AudioFeatures fbank;
+    assert(omni::flow::Token2WavFrontend::load_wav_mono(ref_wav, input));
+    assert(omni::flow::Token2WavFrontend::resample_mono(input, 16000, audio_16k));
+    assert(omni::flow::Token2WavFrontend::compute_campplus_fbank(audio_16k.samples, fbank));
+    omni::flow::AudioFeatures speech_features;
+    assert(omni::flow::Token2WavFrontend::compute_s3_log_mel(audio_16k.samples, speech_features));
+    write_float_file(std::string(output_dir) + "/audio_16k_f32.bin", audio_16k.samples);
+    write_float_file(std::string(output_dir) + "/speech_log_mel_ct_f32.bin", speech_features.values);
+    write_float_file(std::string(output_dir) + "/campplus_fbank_f32.bin", fbank.values);
+}
+
+static void test_native_frontend_with_real_models(const char * ref_wav,
+                                                   const char * speech_tokenizer_gguf,
+                                                   const char * campplus_gguf,
+                                                   const char * dump_dir = nullptr) {
+    omni::flow::FrontendPromptBundle bundle;
+    std::string error;
+    const bool ok = omni::flow::Token2WavFrontend::prepare_prompt_bundle(
+        ref_wav, speech_tokenizer_gguf, campplus_gguf, bundle, &error, 1);
+    if (!ok) {
+        std::fprintf(stderr, "native frontend failed: %s\n", error.c_str());
+    }
+    assert(ok);
+    assert(error.empty());
+    assert(bundle.B == 1);
+    assert(bundle.T_prompt_token > 3);
+    assert(bundle.T_prompt_mel > 0);
+    assert(bundle.T_prompt_mel == (bundle.T_prompt_token - 3) * 2);
+    assert(bundle.prompt_tokens_bt.size() == static_cast<size_t>(bundle.T_prompt_token));
+    assert(bundle.prompt_mel_btc.size() == static_cast<size_t>(bundle.T_prompt_mel * 80));
+    assert(bundle.spk_bc.size() == 192);
+    for (const float value : bundle.prompt_mel_btc) {
+        assert(std::isfinite(value));
+    }
+    for (const float value : bundle.spk_bc) {
+        assert(std::isfinite(value));
+    }
+    if (dump_dir != nullptr) {
+        dump_native_bundle(dump_dir, ref_wav, bundle);
+    }
+    std::printf("native frontend: tokens=%lld mel_frames=%lld speaker_dim=%zu\n",
+                static_cast<long long>(bundle.T_prompt_token),
+                static_cast<long long>(bundle.T_prompt_mel),
+                bundle.spk_bc.size());
+}
+
+int main(int argc, char ** argv) {
+    if (argc == 5) {
+        test_native_frontend_with_real_models(argv[1], argv[2], argv[3], argv[4]);
+        return 0;
+    }
+    test_resample_matches_stepaudio2_contract();
+    test_s3_tokenizer_mel_contract();
+    test_token2wav_prompt_mel_contract();
+    test_campplus_fbank_contract();
+    test_prompt_bundle_assembly_adds_lookahead_and_converts_mel_layout();
+    test_prompt_bundle_assembly_rejects_shape_mismatch();
+    test_frontend_output_shape_contracts_require_single_batch();
+    test_load_wav_rejects_short_multichannel_frame();
+    test_resample_rejects_unbounded_kernel_request();
+    test_gguf_frontend_uses_both_model_files();
+    if (argc == 4) {
+        test_native_frontend_with_real_models(argv[1], argv[2], argv[3]);
+    } else {
+        assert(argc == 1);
+    }
+    return 0;
+}

--- a/tools/omni/test/test-token2wav-session.cpp
+++ b/tools/omni/test/test-token2wav-session.cpp
@@ -1,0 +1,157 @@
+#include "token2wav-impl.h"
+
+#undef NDEBUG
+#include <cassert>
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+static bool write_wav_mono_i16(const fs::path & path, const std::vector<float> & samples, int sample_rate) {
+    std::vector<int16_t> pcm(samples.size());
+    for (size_t i = 0; i < samples.size(); ++i) {
+        float value = std::isfinite(samples[i]) ? samples[i] : 0.0f;
+        value       = std::max(-1.0f, std::min(1.0f, value));
+        pcm[i]      = static_cast<int16_t>(value * 32767.0f);
+    }
+
+    const uint32_t data_bytes = static_cast<uint32_t>(pcm.size() * sizeof(int16_t));
+    const uint32_t riff_size  = 36u + data_bytes;
+    const uint16_t format     = 1;
+    const uint16_t channels   = 1;
+    const uint16_t bits       = 16;
+    const uint16_t block      = channels * sizeof(int16_t);
+    const uint32_t byte_rate  = static_cast<uint32_t>(sample_rate) * block;
+
+    std::ofstream file(path, std::ios::binary);
+    if (!file) {
+        return false;
+    }
+    file.write("RIFF", 4);
+    file.write(reinterpret_cast<const char *>(&riff_size), sizeof(riff_size));
+    file.write("WAVEfmt ", 8);
+    const uint32_t fmt_size = 16;
+    file.write(reinterpret_cast<const char *>(&fmt_size), sizeof(fmt_size));
+    file.write(reinterpret_cast<const char *>(&format), sizeof(format));
+    file.write(reinterpret_cast<const char *>(&channels), sizeof(channels));
+    file.write(reinterpret_cast<const char *>(&sample_rate), sizeof(sample_rate));
+    file.write(reinterpret_cast<const char *>(&byte_rate), sizeof(byte_rate));
+    file.write(reinterpret_cast<const char *>(&block), sizeof(block));
+    file.write(reinterpret_cast<const char *>(&bits), sizeof(bits));
+    file.write("data", 4);
+    file.write(reinterpret_cast<const char *>(&data_bytes), sizeof(data_bytes));
+    if (data_bytes > 0) {
+        file.write(reinterpret_cast<const char *>(pcm.data()), data_bytes);
+    }
+    return file.good();
+}
+
+static void assert_audio_chunk(const std::vector<float> & samples) {
+    assert(!samples.empty());
+    for (const float sample : samples) {
+        assert(std::isfinite(sample));
+    }
+}
+
+static std::vector<int32_t> smoke_tokens() {
+    return {
+        1493, 4299, 4218, 2049, 528,  2752, 4850, 4569, 4575, 6372, 2127, 4068, 2312, 4993,
+        4769, 2300, 226,  2175, 2160, 2152, 6311, 6065, 4859, 5102, 4615, 6534, 6426, 1763,
+    };
+}
+
+static std::vector<float> generate_one_window(omni::flow::Token2WavSession & session,
+                                               const std::vector<int32_t> & tokens) {
+    std::vector<float> samples;
+    assert(tokens.size() == 28);
+    assert(session.feed_window(tokens, false, samples));
+    assert_audio_chunk(samples);
+    return samples;
+}
+
+int main(int argc, char ** argv) {
+    std::vector<std::string> configured_args;
+    if (argc == 1) {
+        const char * const env_names[] = {
+            "OMNI_T2W_SESSION_MODEL_DIR",
+            "OMNI_T2W_SESSION_SPEECH_TOKENIZER_GGUF",
+            "OMNI_T2W_SESSION_CAMPPLUS_GGUF",
+            "OMNI_T2W_SESSION_VOICE1_WAV",
+            "OMNI_T2W_SESSION_VOICE2_WAV",
+            "OMNI_T2W_SESSION_OUTPUT_DIR",
+        };
+        for (const char * name : env_names) {
+            const char * value = std::getenv(name);
+            if (!value || value[0] == '\0') {
+                std::fprintf(stderr,
+                             "SKIP: set all OMNI_T2W_SESSION_* variables to run the Token2Wav voice-switching E2E\n");
+                return 77;
+            }
+            configured_args.emplace_back(value);
+        }
+    } else if (argc < 7 || argc > 9) {
+        std::fprintf(stderr,
+                     "usage: %s <model_dir> <speech_tokenizer.gguf> <campplus.gguf> "
+                     "<voice1.wav> <voice2.wav> <output_dir> [device] [n_timesteps]\n",
+                     argv[0]);
+        return 2;
+    }
+
+    const fs::path model_dir          = argc == 1 ? configured_args[0] : argv[1];
+    const std::string speech_tokenizer = argc == 1 ? configured_args[1] : argv[2];
+    const std::string campplus         = argc == 1 ? configured_args[2] : argv[3];
+    const fs::path voice1              = argc == 1 ? configured_args[3] : argv[4];
+    const fs::path voice2              = argc == 1 ? configured_args[4] : argv[5];
+    const fs::path output_dir          = argc == 1 ? configured_args[5] : argv[6];
+    const std::string device            = argc >= 8 ? argv[7] : "gpu:0";
+    const int n_timesteps              = argc >= 9 ? std::stoi(argv[8]) : 5;
+
+    fs::create_directories(output_dir);
+    const std::string encoder = (model_dir / "encoder.gguf").string();
+    const std::string flow_matching = (model_dir / "flow_matching.gguf").string();
+    const std::string flow_extra = (model_dir / "flow_extra.gguf").string();
+    const std::string prompt_cache = (model_dir / "prompt_cache.gguf").string();
+    const std::string vocoder = (model_dir / "hifigan2.gguf").string();
+
+    omni::flow::Token2WavSession session;
+    std::fprintf(stderr, "loading Token2Wav models from %s\n", model_dir.c_str());
+    if (!session.init_from_prompt_cache_gguf(
+            encoder, flow_matching, flow_extra, prompt_cache, vocoder, device, device, n_timesteps, 1.0f)) {
+        std::fprintf(stderr, "Token2Wav model/cache initialization failed\n");
+        return 3;
+    }
+    std::fprintf(stderr, "Token2Wav static prompt cache initialized\n");
+
+    const auto tokens = smoke_tokens();
+    if (!session.set_prompt_wav(voice1.string(), speech_tokenizer, campplus, 1, n_timesteps, 1.0f)) {
+        std::fprintf(stderr, "set_prompt_wav failed for voice1: %s\n", voice1.c_str());
+        return 4;
+    }
+    std::fprintf(stderr, "voice1 PromptBundle installed\n");
+    const auto voice1_samples = generate_one_window(session, tokens);
+    assert(write_wav_mono_i16(output_dir / "voice1.wav", voice1_samples, omni::flow::Token2Wav::kSampleRate));
+
+    if (!session.set_prompt_wav(voice2.string(), speech_tokenizer, campplus, 1, n_timesteps, 1.0f)) {
+        std::fprintf(stderr, "set_prompt_wav failed for voice2: %s\n", voice2.c_str());
+        return 5;
+    }
+    std::fprintf(stderr, "voice2 PromptBundle installed\n");
+    const auto voice2_samples = generate_one_window(session, tokens);
+    assert(write_wav_mono_i16(output_dir / "voice2.wav", voice2_samples, omni::flow::Token2Wav::kSampleRate));
+
+    assert(session.reset_to_prompt_cache_gguf(prompt_cache, n_timesteps, 1.0f));
+    const auto default_samples = generate_one_window(session, tokens);
+    assert(write_wav_mono_i16(output_dir / "default.wav", default_samples, omni::flow::Token2Wav::kSampleRate));
+
+    std::printf("token2wav session: voice1_samples=%zu voice2_samples=%zu sample_rate=%d output_dir=%s\n",
+                voice1_samples.size(), voice2_samples.size(), omni::flow::Token2Wav::kSampleRate,
+                output_dir.c_str());
+    return 0;
+}

--- a/tools/omni/test/test-token2wav-session.cpp
+++ b/tools/omni/test/test-token2wav-session.cpp
@@ -1,3 +1,4 @@
+#include "omni.h"
 #include "token2wav-impl.h"
 
 #undef NDEBUG
@@ -76,7 +77,26 @@ static std::vector<float> generate_one_window(omni::flow::Token2WavSession & ses
     return samples;
 }
 
+static void test_first_nonfinal_stream_output_matches_python_contract() {
+    std::vector<float> first = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f };
+    omni::flow::token2wav_utils::trim_stream_wave_b1(
+        first, /*is_first=*/true, /*is_final=*/false, /*cache_len=*/2);
+    assert(first == std::vector<float>({ 0.0f, 0.0f, 1.0f, 2.0f, 3.0f, 4.0f }));
+
+    std::vector<float> next = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f };
+    omni::flow::token2wav_utils::trim_stream_wave_b1(
+        next, /*is_first=*/false, /*is_final=*/false, /*cache_len=*/2);
+    assert(next == std::vector<float>({ 1.0f, 2.0f, 3.0f, 4.0f }));
+
+    std::vector<float> final = { 1.0f, 2.0f, 3.0f };
+    omni::flow::token2wav_utils::trim_stream_wave_b1(
+        final, /*is_first=*/true, /*is_final=*/true, /*cache_len=*/2);
+    assert(final == std::vector<float>({ 1.0f, 2.0f, 3.0f }));
+}
+
 int main(int argc, char ** argv) {
+    test_first_nonfinal_stream_output_matches_python_contract();
+
     std::vector<std::string> configured_args;
     if (argc == 1) {
         const char * const env_names[] = {
@@ -111,7 +131,9 @@ int main(int argc, char ** argv) {
     const fs::path voice2              = argc == 1 ? configured_args[4] : argv[5];
     const fs::path output_dir          = argc == 1 ? configured_args[5] : argv[6];
     const std::string device            = argc >= 8 ? argv[7] : "gpu:0";
-    const int n_timesteps              = argc >= 9 ? std::stoi(argv[8]) : 5;
+    const int n_timesteps              = argc >= 9
+                                             ? std::stoi(argv[8])
+                                             : omni_tts_python_base_config().n_timesteps;
 
     fs::create_directories(output_dir);
     const std::string encoder = (model_dir / "encoder.gguf").string();
@@ -123,7 +145,7 @@ int main(int argc, char ** argv) {
     omni::flow::Token2WavSession session;
     std::fprintf(stderr, "loading Token2Wav models from %s\n", model_dir.c_str());
     if (!session.init_from_prompt_cache_gguf(
-            encoder, flow_matching, flow_extra, prompt_cache, vocoder, device, device, n_timesteps, 1.0f)) {
+            encoder, flow_matching, flow_extra, prompt_cache, vocoder, device, device, -1, 1.0f)) {
         std::fprintf(stderr, "Token2Wav model/cache initialization failed\n");
         return 3;
     }
@@ -146,7 +168,7 @@ int main(int argc, char ** argv) {
     const auto voice2_samples = generate_one_window(session, tokens);
     assert(write_wav_mono_i16(output_dir / "voice2.wav", voice2_samples, omni::flow::Token2Wav::kSampleRate));
 
-    assert(session.reset_to_prompt_cache_gguf(prompt_cache, n_timesteps, 1.0f));
+    assert(session.reset_to_prompt_cache_gguf(prompt_cache, -1, 1.0f));
     const auto default_samples = generate_one_window(session, tokens);
     assert(write_wav_mono_i16(output_dir / "default.wav", default_samples, omni::flow::Token2Wav::kSampleRate));
 

--- a/tools/omni/test/test-tts-quality-contract.cpp
+++ b/tools/omni/test/test-tts-quality-contract.cpp
@@ -1,0 +1,51 @@
+#include "omni.h"
+
+#undef NDEBUG
+#include <cassert>
+#include <cstddef>
+#include <vector>
+
+static void test_head_code_uses_row_major_audio_token_rows() {
+    constexpr int hidden_size = 2;
+    constexpr int audio_tokens = 3;
+    const float source[] = {
+        1.0f, 2.0f,
+        3.0f, 4.0f,
+        5.0f, 6.0f,
+    };
+    std::vector<float> destination(audio_tokens * hidden_size, 0.0f);
+
+    assert(omni_copy_head_code_row_major(
+        source, /*dim0=*/hidden_size, /*dim1=*/audio_tokens,
+        hidden_size, audio_tokens, destination.data()));
+    assert(destination == std::vector<float>({
+        1.0f, 2.0f,
+        3.0f, 4.0f,
+        5.0f, 6.0f,
+    }));
+}
+
+static void test_python_tts_budget_excludes_exhausted_loop_slot() {
+    assert(omni_duplex_tts_output_token_count_for_budget(26) == 25);
+    assert(omni_duplex_tts_output_token_count_for_budget(1) == 0);
+    assert(omni_duplex_tts_output_token_count_for_budget(0) == 0);
+}
+
+static void test_python_text_chunk_plan_reserves_one_lookahead_token() {
+    const OmniTextChunkPlan first = omni_text_chunk_plan(10, false);
+    assert(first.prefix_tokens == 0);
+    assert(first.condition_tokens == 10);
+    assert(first.generated_tokens == 11);
+
+    const OmniTextChunkPlan next = omni_text_chunk_plan(10, true);
+    assert(next.prefix_tokens == 1);
+    assert(next.condition_tokens == 9);
+    assert(next.generated_tokens == 10);
+}
+
+int main() {
+    test_head_code_uses_row_major_audio_token_rows();
+    test_python_tts_budget_excludes_exhausted_loop_slot();
+    test_python_text_chunk_plan_reserves_one_lookahead_token();
+    return 0;
+}

--- a/tools/omni/test/test-tts-quality-contract.cpp
+++ b/tools/omni/test/test-tts-quality-contract.cpp
@@ -43,9 +43,25 @@ static void test_python_text_chunk_plan_reserves_one_lookahead_token() {
     assert(next.generated_tokens == 10);
 }
 
+static void test_python_base_token2wav_configuration() {
+    const OmniTtsPythonBaseConfig config = omni_tts_python_base_config();
+    assert(config.n_timesteps == 10);
+    assert(config.chunk_size == 25);
+    assert(config.prelook_size == 3);
+    assert(config.token2wav_temperature == 1.0f);
+    assert(config.tts_temperature == 0.8f);
+    assert(config.top_p == 0.85f);
+    assert(config.top_k == 25);
+    assert(config.min_tokens_to_keep == 3);
+    assert(config.repetition_penalty == 1.05f);
+    assert(config.repetition_window == 16);
+    assert(config.max_audio_tokens == 500);
+}
+
 int main() {
     test_head_code_uses_row_major_audio_token_rows();
     test_python_tts_budget_excludes_exhausted_loop_slot();
     test_python_text_chunk_plan_reserves_one_lookahead_token();
+    test_python_base_token2wav_configuration();
     return 0;
 }

--- a/tools/omni/test/test-tts-quality-contract.cpp
+++ b/tools/omni/test/test-tts-quality-contract.cpp
@@ -43,6 +43,35 @@ static void test_python_text_chunk_plan_reserves_one_lookahead_token() {
     assert(next.generated_tokens == 10);
 }
 
+static void test_native_t2w_window_waits_for_lookahead() {
+    const OmniTtsWindowPlan incomplete = omni_tts_window_plan(25, false);
+    assert(!incomplete.ready);
+
+    const OmniTtsWindowPlan ready = omni_tts_window_plan(50, false);
+    assert(ready.ready);
+    assert(ready.process_size == 28);
+    assert(ready.slide_amount == 25);
+    assert(!ready.is_last_window);
+
+    const OmniTtsWindowPlan final = omni_tts_window_plan(25, true);
+    assert(final.ready);
+    assert(final.process_size == 25);
+    assert(final.slide_amount == 25);
+    assert(final.is_last_window);
+}
+
+static void test_simplex_lookahead_text_is_deferred() {
+    assert(omni_tts_should_defer_text_piece(
+        /*simplex_mode=*/true, /*need_lookahead=*/true,
+        /*condition_tokens_collected=*/10, /*step_size=*/10));
+    assert(!omni_tts_should_defer_text_piece(
+        /*simplex_mode=*/false, /*need_lookahead=*/true,
+        /*condition_tokens_collected=*/10, /*step_size=*/10));
+    assert(!omni_tts_should_defer_text_piece(
+        /*simplex_mode=*/true, /*need_lookahead=*/false,
+        /*condition_tokens_collected=*/10, /*step_size=*/10));
+}
+
 static void test_python_base_token2wav_configuration() {
     const OmniTtsPythonBaseConfig config = omni_tts_python_base_config();
     assert(config.n_timesteps == 10);
@@ -62,6 +91,8 @@ int main() {
     test_head_code_uses_row_major_audio_token_rows();
     test_python_tts_budget_excludes_exhausted_loop_slot();
     test_python_text_chunk_plan_reserves_one_lookahead_token();
+    test_native_t2w_window_waits_for_lookahead();
+    test_simplex_lookahead_text_is_deferred();
     test_python_base_token2wav_configuration();
     return 0;
 }

--- a/tools/omni/token2wav/token2wav-frontend-gguf.cpp
+++ b/tools/omni/token2wav/token2wav-frontend-gguf.cpp
@@ -1,0 +1,931 @@
+#include "token2wav-frontend-gguf.h"
+
+#include "ggml-cpp.h"
+#include "ggml-cpu.h"
+#include "ggml-alloc.h"
+#include "ggml-backend.h"
+#include "gguf.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace omni {
+namespace flow {
+namespace {
+
+class GGUFWeightStore {
+  public:
+    bool load(const std::string & path, ggml_backend_t backend, std::string * error) {
+        reset();
+        if (!backend) {
+            return fail(error, "GGUF frontend: backend is null");
+        }
+
+        ggml_context * meta = nullptr;
+        gguf_init_params params = {
+            /*.no_alloc =*/ true,
+            /*.ctx      =*/ &meta,
+        };
+        ctx_gguf_.reset(gguf_init_from_file(path.c_str(), params));
+        if (!ctx_gguf_ || !meta) {
+            if (meta) {
+                ggml_free(meta);
+            }
+            return fail(error, "GGUF frontend: failed to load " + path);
+        }
+        ctx_meta_.reset(meta);
+
+        if (gguf_get_version(ctx_gguf_.get()) != GGUF_VERSION) {
+            return fail(error, "GGUF frontend: unsupported GGUF version in " + path);
+        }
+        const int64_t n_tensors = gguf_get_n_tensors(ctx_gguf_.get());
+        if (n_tensors <= 0) {
+            return fail(error, "GGUF frontend: no tensors in " + path);
+        }
+
+        ggml_init_params data_params = {
+            /*.mem_size   =*/ static_cast<size_t>(n_tensors + 1) * ggml_tensor_overhead(),
+            /*.mem_buffer =*/ nullptr,
+            /*.no_alloc   =*/ true,
+        };
+        ctx_data_.reset(ggml_init(data_params));
+        if (!ctx_data_) {
+            return fail(error, "GGUF frontend: failed to allocate tensor metadata for " + path);
+        }
+
+        std::ifstream file(path, std::ios::binary);
+        if (!file.good()) {
+            return fail(error, "GGUF frontend: failed to open " + path);
+        }
+
+        for (int64_t i = 0; i < n_tensors; ++i) {
+            const char * name = gguf_get_tensor_name(ctx_gguf_.get(), i);
+            if (!name || !*name) {
+                return fail(error, "GGUF frontend: tensor has no name in " + path);
+            }
+            ggml_tensor * meta_tensor = ggml_get_tensor(ctx_meta_.get(), name);
+            if (!meta_tensor) {
+                return fail(error, "GGUF frontend: missing tensor metadata for " + std::string(name));
+            }
+            if (meta_tensor->type != GGML_TYPE_F32) {
+                return fail(error, "GGUF frontend: expected F32 tensor " + std::string(name));
+            }
+            ggml_tensor * data_tensor = ggml_dup_tensor(ctx_data_.get(), meta_tensor);
+            if (!data_tensor) {
+                return fail(error, "GGUF frontend: failed to allocate tensor " + std::string(name));
+            }
+            ggml_set_name(data_tensor, name);
+            tensors_.emplace(name, data_tensor);
+            offsets_.emplace(name, gguf_get_data_offset(ctx_gguf_.get()) +
+                                      gguf_get_tensor_offset(ctx_gguf_.get(), i));
+        }
+
+        const ggml_backend_buffer_type_t buft = ggml_backend_get_default_buffer_type(backend);
+        buffer_.reset(ggml_backend_alloc_ctx_tensors_from_buft(ctx_data_.get(), buft));
+        if (!buffer_) {
+            return fail(error, "GGUF frontend: failed to allocate tensor buffer for " + path);
+        }
+        ggml_backend_buffer_set_usage(buffer_.get(), GGML_BACKEND_BUFFER_USAGE_WEIGHTS);
+
+        std::vector<uint8_t> read_buffer;
+        for (const auto & entry : tensors_) {
+            ggml_tensor * tensor = entry.second;
+            const size_t nbytes = ggml_nbytes(tensor);
+            const auto offset_it = offsets_.find(entry.first);
+            if (offset_it == offsets_.end()) {
+                return fail(error, "GGUF frontend: missing offset for tensor " + entry.first);
+            }
+            file.seekg(static_cast<std::streamoff>(offset_it->second), std::ios::beg);
+            if (!file.good()) {
+                return fail(error, "GGUF frontend: failed to seek tensor " + entry.first);
+            }
+            read_buffer.resize(nbytes);
+            if (nbytes > 0 &&
+                (!file.read(reinterpret_cast<char *>(read_buffer.data()),
+                            static_cast<std::streamsize>(nbytes)) ||
+                 file.gcount() != static_cast<std::streamsize>(nbytes))) {
+                return fail(error, "GGUF frontend: failed to read tensor " + entry.first);
+            }
+            ggml_backend_tensor_set(tensor, read_buffer.data(), 0, nbytes);
+        }
+        return true;
+    }
+
+    void reset() {
+        buffer_.reset();
+        ctx_data_.reset();
+        ctx_meta_.reset();
+        ctx_gguf_.reset();
+        tensors_.clear();
+        offsets_.clear();
+    }
+
+    ggml_tensor * get(const std::string & name) const {
+        const auto it = tensors_.find(name);
+        if (it == tensors_.end()) {
+            std::fprintf(stderr, "GGUF frontend: missing tensor %s\n", name.c_str());
+            return nullptr;
+        }
+        return it->second;
+    }
+
+  private:
+    static bool fail(std::string * error, const std::string & message) {
+        if (error) {
+            *error = message;
+        }
+        return false;
+    }
+
+    gguf_context_ptr ctx_gguf_;
+    ggml_context_ptr ctx_meta_;
+    ggml_context_ptr ctx_data_;
+    ggml_backend_buffer_ptr buffer_;
+    std::unordered_map<std::string, ggml_tensor *> tensors_;
+    std::unordered_map<std::string, size_t> offsets_;
+};
+
+static ggml_tensor * scalar_tensor(ggml_context * ctx, float value) {
+    return ggml_arange(ctx, value, value + 1.0f, 1.0f);
+}
+
+static ggml_tensor * linear(ggml_context * ctx,
+                            ggml_tensor * x,
+                            ggml_tensor * weight_onnx,
+                            ggml_tensor * bias) {
+    if (!ctx || !x || !weight_onnx) {
+        return nullptr;
+    }
+    // ONNX MatMul stores [in, out], while ggml_mul_mat consumes [in, out]
+    // as [K, M]. GGUF exposes the reversed logical dimensions, so transpose
+    // the 2-D view before multiplication.
+    ggml_tensor * weight = ggml_cont(ctx, ggml_transpose(ctx, weight_onnx));
+    ggml_tensor * result = ggml_mul_mat(ctx, weight, x);
+    if (bias) {
+        result = ggml_add(ctx, result, bias);
+    }
+    return result;
+}
+
+static ggml_tensor * conv1d(ggml_context * ctx,
+                            ggml_tensor * x,
+                            ggml_tensor * weight,
+                            ggml_tensor * bias,
+                            int stride,
+                            int padding,
+                            int dilation) {
+    if (!ctx || !x || !weight) {
+        return nullptr;
+    }
+    // ggml_conv_1d consumes [time, channels, batch] and returns
+    // [time, output_channels, batch]. The frontend graph uses
+    // [channels, time, batch] everywhere else.
+    ggml_tensor * x_tcb = ggml_cast(ctx, ggml_permute(ctx, x, 1, 0, 2, 3), GGML_TYPE_F16);
+    ggml_tensor * conv_weight = weight->type == GGML_TYPE_F16 ? weight : ggml_cast(ctx, weight, GGML_TYPE_F16);
+    ggml_tensor * result = ggml_conv_1d(ctx, conv_weight, x_tcb, stride, padding, dilation);
+    result = ggml_cont(ctx, ggml_permute(ctx, result, 1, 0, 2, 3));
+    if (bias) {
+        result = ggml_add(ctx, result, bias);
+    }
+    return result;
+}
+
+static ggml_tensor * conv1d_depthwise(ggml_context * ctx,
+                                      ggml_tensor * x,
+                                      ggml_tensor * weight,
+                                      int stride,
+                                      int padding,
+                                      int dilation) {
+    if (!ctx || !x || !weight) {
+        return nullptr;
+    }
+    ggml_tensor * x_tcb = ggml_cont(ctx, ggml_permute(ctx, x, 1, 0, 2, 3));
+    ggml_tensor * conv_weight = weight->type == GGML_TYPE_F16 ? weight : ggml_cast(ctx, weight, GGML_TYPE_F16);
+    ggml_tensor * result = ggml_conv_1d_dw(ctx, conv_weight, x_tcb, stride, padding, dilation);
+    return ggml_cont(ctx, ggml_permute(ctx, result, 1, 0, 2, 3));
+}
+
+static ggml_tensor * conv2d(ggml_context * ctx,
+                            ggml_tensor * x,
+                            ggml_tensor * weight,
+                            ggml_tensor * bias,
+                            int stride_w,
+                            int stride_h,
+                            int padding_w,
+                            int padding_h) {
+    if (!ctx || !x || !weight) {
+        return nullptr;
+    }
+    ggml_tensor * conv_weight = weight->type == GGML_TYPE_F16 ? weight : ggml_cast(ctx, weight, GGML_TYPE_F16);
+    ggml_tensor * raw = ggml_conv_2d(ctx, conv_weight, x, stride_w, stride_h,
+                                     padding_w, padding_h, 1, 1);
+    if (!bias) {
+        return raw;
+    }
+    std::fprintf(stderr, "conv2d before bias reshape\n");
+    ggml_tensor * bias_4d = ggml_reshape_4d(ctx, bias, 1, 1, bias->ne[0], 1);
+    std::fprintf(stderr, "conv2d before bias add\n");
+    return ggml_add(ctx, raw, bias_4d);
+}
+
+static ggml_tensor * layer_norm(ggml_context * ctx,
+                                ggml_tensor * x,
+                                ggml_tensor * weight,
+                                ggml_tensor * bias,
+                                float epsilon = 1e-5f) {
+    ggml_tensor * result = ggml_norm(ctx, x, epsilon);
+    result = ggml_mul(ctx, result, weight);
+    return bias ? ggml_add(ctx, result, bias) : result;
+}
+
+static ggml_tensor * relu(ggml_context * ctx, ggml_tensor * x) {
+    return x ? ggml_relu(ctx, x) : nullptr;
+}
+
+static ggml_tensor * gelu(ggml_context * ctx, ggml_tensor * x) {
+    return x ? ggml_gelu_erf(ctx, x) : nullptr;
+}
+
+static ggml_tensor * make_rotary_factor(ggml_context * ctx, int64_t dimension, int64_t time) {
+    ggml_tensor * factor = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, dimension, time);
+    ggml_set_input(factor);
+    return factor;
+}
+
+static ggml_tensor * rotate_half(ggml_context * ctx, ggml_tensor * x) {
+    const int64_t dimension = x->ne[0];
+    const int64_t half = dimension / 2;
+    ggml_tensor * left = ggml_view_3d(ctx, x, half, x->ne[1], x->ne[2],
+                                      x->nb[1], x->nb[2], 0);
+    ggml_tensor * right = ggml_view_3d(ctx, x, half, x->ne[1], x->ne[2],
+                                       x->nb[1], x->nb[2], half * x->nb[0]);
+    return ggml_concat(ctx, ggml_neg(ctx, right), left, 0);
+}
+
+static ggml_tensor * rotary_apply(ggml_context * ctx,
+                                  ggml_tensor * x,
+                                  ggml_tensor * cos_factor,
+                                  ggml_tensor * sin_factor) {
+    cos_factor = ggml_repeat(ctx, ggml_reshape_3d(ctx, cos_factor, cos_factor->ne[0], 1, cos_factor->ne[1]), x);
+    sin_factor = ggml_repeat(ctx, ggml_reshape_3d(ctx, sin_factor, sin_factor->ne[0], 1, sin_factor->ne[1]), x);
+    return ggml_add(ctx,
+                    ggml_mul(ctx, x, cos_factor),
+                    ggml_mul(ctx, rotate_half(ctx, x), sin_factor));
+}
+
+struct S3BlockNames {
+    const char * fsmn;
+    const char * attn_ln_w;
+    const char * attn_ln_b;
+    const char * q_w;
+    const char * q_b;
+    const char * k_w;
+    const char * v_w;
+    const char * v_b;
+    const char * out_w;
+    const char * out_b;
+    const char * mlp_ln_w;
+    const char * mlp_ln_b;
+    const char * mlp1_w;
+    const char * mlp1_b;
+    const char * mlp2_w;
+    const char * mlp2_b;
+};
+
+static const std::array<S3BlockNames, 6> & s3_block_names() {
+    static const std::array<S3BlockNames, 6> names = {{
+        {"blocks.0.attn.fsmn_block.weight", "onnx::LayerNormalization_2224", "onnx::LayerNormalization_2225",
+         "onnx::MatMul_2228", "onnx::Add_2227", "onnx::MatMul_2230", "onnx::MatMul_2233", "onnx::Add_2232",
+         "onnx::MatMul_2267", "onnx::Add_2266", "onnx::LayerNormalization_2268", "onnx::LayerNormalization_2269",
+         "onnx::MatMul_2272", "onnx::Add_2271", "onnx::MatMul_2275", "onnx::Add_2274"},
+        {"blocks.1.attn.fsmn_block.weight", "onnx::LayerNormalization_2276", "onnx::LayerNormalization_2277",
+         "onnx::MatMul_2280", "onnx::Add_2279", "onnx::MatMul_2282", "onnx::MatMul_2285", "onnx::Add_2284",
+         "onnx::MatMul_2319", "onnx::Add_2318", "onnx::LayerNormalization_2320", "onnx::LayerNormalization_2321",
+         "onnx::MatMul_2324", "onnx::Add_2323", "onnx::MatMul_2327", "onnx::Add_2326"},
+        {"blocks.2.attn.fsmn_block.weight", "onnx::LayerNormalization_2328", "onnx::LayerNormalization_2329",
+         "onnx::MatMul_2332", "onnx::Add_2331", "onnx::MatMul_2334", "onnx::MatMul_2337", "onnx::Add_2336",
+         "onnx::MatMul_2371", "onnx::Add_2370", "onnx::LayerNormalization_2372", "onnx::LayerNormalization_2373",
+         "onnx::MatMul_2376", "onnx::Add_2375", "onnx::MatMul_2379", "onnx::Add_2378"},
+        {"blocks.3.attn.fsmn_block.weight", "onnx::LayerNormalization_2380", "onnx::LayerNormalization_2381",
+         "onnx::MatMul_2384", "onnx::Add_2383", "onnx::MatMul_2386", "onnx::MatMul_2389", "onnx::Add_2388",
+         "onnx::MatMul_2423", "onnx::Add_2422", "onnx::LayerNormalization_2424", "onnx::LayerNormalization_2425",
+         "onnx::MatMul_2428", "onnx::Add_2427", "onnx::MatMul_2431", "onnx::Add_2430"},
+        {"blocks.4.attn.fsmn_block.weight", "onnx::LayerNormalization_2432", "onnx::LayerNormalization_2433",
+         "onnx::MatMul_2436", "onnx::Add_2435", "onnx::MatMul_2438", "onnx::MatMul_2441", "onnx::Add_2440",
+         "onnx::MatMul_2475", "onnx::Add_2474", "onnx::LayerNormalization_2476", "onnx::LayerNormalization_2477",
+         "onnx::MatMul_2480", "onnx::Add_2479", "onnx::MatMul_2483", "onnx::Add_2482"},
+        {"blocks.5.attn.fsmn_block.weight", "onnx::LayerNormalization_2484", "onnx::LayerNormalization_2485",
+         "onnx::MatMul_2488", "onnx::Add_2487", "onnx::MatMul_2490", "onnx::MatMul_2493", "onnx::Add_2492",
+         "onnx::MatMul_2527", "onnx::Add_2526", "onnx::LayerNormalization_2528", "onnx::LayerNormalization_2529",
+         "onnx::MatMul_2532", "onnx::Add_2531", "onnx::MatMul_2535", "onnx::Add_2534"},
+    }};
+    return names;
+}
+
+static ggml_tensor * flatten_attention_qk(ggml_context * ctx,
+                                          ggml_tensor *  heads,
+                                          int            head_dim,
+                                          int64_t        time,
+                                          int64_t        batch,
+                                          int            head_count) {
+    ggml_tensor * permuted = ggml_permute(ctx, heads, 0, 2, 1, 3);
+    ggml_tensor * contiguous = ggml_cont(ctx, permuted);
+    return ggml_reshape_3d(ctx, contiguous, head_dim, time, static_cast<int64_t>(head_count) * batch);
+}
+
+static ggml_tensor * flatten_attention_v(ggml_context * ctx,
+                                         ggml_tensor *  heads,
+                                         int            head_dim,
+                                         int64_t        time,
+                                         int64_t        batch,
+                                         int            head_count) {
+    ggml_tensor * flat_qk = flatten_attention_qk(ctx, heads, head_dim, time, batch, head_count);
+    ggml_tensor * permuted = ggml_permute(ctx, flat_qk, 1, 0, 2, 3);
+    ggml_tensor * contiguous = ggml_cont(ctx, permuted);
+    return ggml_reshape_3d(ctx, contiguous, time, head_dim, static_cast<int64_t>(head_count) * batch);
+}
+
+static ggml_tensor * merge_attention_heads(ggml_context * ctx,
+                                            ggml_tensor *  heads_flat,
+                                            int            head_dim,
+                                            int            head_count,
+                                            int64_t        time,
+                                            int64_t        batch) {
+    ggml_tensor * view4d = ggml_reshape_4d(ctx, heads_flat, head_dim, time, head_count, batch);
+    ggml_tensor * permuted = ggml_permute(ctx, view4d, 0, 2, 1, 3);
+    ggml_tensor * contiguous = ggml_cont(ctx, permuted);
+    return ggml_reshape_3d(ctx, contiguous, static_cast<int64_t>(head_dim) * head_count, time, batch);
+}
+
+static ggml_tensor * add_bias_time_channels(ggml_context * ctx,
+                                            ggml_tensor * x,
+                                            ggml_tensor * bias) {
+    if (!bias) {
+        return x;
+    }
+    ggml_tensor * bias_tc = ggml_reshape_2d(ctx, bias, bias->ne[0], 1);
+    return ggml_add(ctx, x, ggml_repeat(ctx, bias_tc, x));
+}
+
+static ggml_tensor * conv1d_time_major(ggml_context * ctx,
+                                       ggml_tensor * x,
+                                       ggml_tensor * weight,
+                                       ggml_tensor * bias,
+                                       int stride,
+                                       int padding,
+                                       int dilation) {
+    if (!ctx || !x || !weight) {
+        return nullptr;
+    }
+    ggml_tensor * conv_weight = weight->type == GGML_TYPE_F16 ? weight : ggml_cast(ctx, weight, GGML_TYPE_F16);
+    ggml_tensor * result = ggml_conv_1d(ctx, conv_weight, x, stride, padding, dilation);
+    if (bias) {
+        result = ggml_add(ctx, result, ggml_reshape_2d(ctx, bias, 1, bias->ne[0]));
+    }
+    return result;
+}
+
+static ggml_tensor * batch_norm_time_major(ggml_context * ctx,
+                                           ggml_tensor * x,
+                                           ggml_tensor * weight,
+                                           ggml_tensor * bias,
+                                           ggml_tensor * running_mean,
+                                           ggml_tensor * running_var,
+                                           float epsilon = 1e-5f) {
+    if (!ctx || !x || !weight || !bias || !running_mean || !running_var) {
+        return nullptr;
+    }
+    const int64_t channels = weight->ne[0];
+    auto broadcast = [&](ggml_tensor * value) {
+        return ggml_reshape_2d(ctx, value, 1, channels);
+    };
+    ggml_tensor * normalized = ggml_div(
+        ctx,
+        ggml_sub(ctx, x, broadcast(running_mean)),
+        ggml_sqrt(ctx, ggml_add(ctx, broadcast(running_var), scalar_tensor(ctx, epsilon))));
+    return ggml_add(ctx, ggml_mul(ctx, normalized, broadcast(weight)), broadcast(bias));
+}
+
+static ggml_tensor * batch_norm_time_major_no_affine(ggml_context * ctx,
+                                                      ggml_tensor * x,
+                                                      ggml_tensor * running_mean,
+                                                      ggml_tensor * running_var,
+                                                      float epsilon = 1e-5f) {
+    if (!ctx || !x || !running_mean || !running_var) {
+        return nullptr;
+    }
+    const int64_t channels = running_mean->ne[0];
+    auto broadcast = [&](ggml_tensor * value) {
+        return ggml_reshape_2d(ctx, value, 1, channels);
+    };
+    return ggml_div(
+        ctx,
+        ggml_sub(ctx, x, broadcast(running_mean)),
+        ggml_sqrt(ctx, ggml_add(ctx, broadcast(running_var), scalar_tensor(ctx, epsilon))));
+}
+
+static ggml_tensor * segment_average_time_major(ggml_context * ctx,
+                                                ggml_tensor * x,
+                                                int64_t segment_length) {
+    std::vector<ggml_tensor *> segments;
+    for (int64_t start = 0; start < x->ne[0]; start += segment_length) {
+        const int64_t length = std::min(segment_length, x->ne[0] - start);
+        ggml_tensor * segment = ggml_view_2d(ctx, x, length, x->ne[1], x->nb[1],
+                                             static_cast<size_t>(start) * x->nb[0]);
+        ggml_tensor * mean = ggml_scale(
+            ctx, ggml_sum_rows(ctx, segment), 1.0f / static_cast<float>(segment_length));
+        segments.push_back(ggml_repeat(ctx, mean, segment));
+    }
+    while (segments.size() > 1) {
+        std::vector<ggml_tensor *> next;
+        next.reserve((segments.size() + 1) / 2);
+        for (size_t i = 0; i < segments.size(); i += 2) {
+            next.push_back(i + 1 < segments.size() ? ggml_concat(ctx, segments[i], segments[i + 1], 0)
+                                                    : segments[i]);
+        }
+        segments.swap(next);
+    }
+    return segments.empty() ? nullptr : segments.front();
+}
+
+static ggml_tensor * campplus_dense_layer(ggml_context * ctx,
+                                          ggml_tensor * x,
+                                          GGUFWeightStore & weights,
+                                          int block,
+                                          int layer,
+                                          const char * linear_weight_name,
+                                          const char * linear_bias_name,
+                                          int dilation) {
+    const std::string prefix = "xvector.block" + std::to_string(block) + ".tdnnd" + std::to_string(layer);
+    ggml_tensor * hidden = batch_norm_time_major(
+        ctx, x,
+        weights.get(prefix + ".nonlinear1.batchnorm.weight"),
+        weights.get(prefix + ".nonlinear1.batchnorm.bias"),
+        weights.get(prefix + ".nonlinear1.batchnorm.running_mean"),
+        weights.get(prefix + ".nonlinear1.batchnorm.running_var"));
+    hidden = relu(ctx, hidden);
+    hidden = conv1d_time_major(ctx, hidden, weights.get(linear_weight_name),
+                                  weights.get(linear_bias_name), 1, 0, 1);
+    hidden = relu(ctx, hidden);
+
+    const std::string local_name = prefix + ".cam_layer.linear_local.weight";
+    ggml_tensor * local = conv1d_time_major(ctx, hidden, weights.get(local_name), nullptr, 1, dilation, dilation);
+
+    // CAM combines the global mean with a 100-frame segment mean, then
+    // predicts a channel gate for the local convolution output.
+    ggml_tensor * segment_mean = segment_average_time_major(ctx, hidden, 100);
+    ggml_tensor * global_mean = ggml_mean(ctx, hidden);
+    ggml_tensor * context = ggml_add(ctx, segment_mean, global_mean);
+    context = relu(ctx, conv1d_time_major(
+        ctx, context,
+        weights.get(prefix + ".cam_layer.linear1.weight"),
+        weights.get(prefix + ".cam_layer.linear1.bias"), 1, 0, 1));
+    context = ggml_sigmoid(ctx, conv1d_time_major(
+        ctx, context,
+        weights.get(prefix + ".cam_layer.linear2.weight"),
+        weights.get(prefix + ".cam_layer.linear2.bias"), 1, 0, 1));
+    return ggml_mul(ctx, local, context);
+}
+
+static ggml_tensor * campplus_residual_block(ggml_context * ctx,
+                                             ggml_tensor * x,
+                                             GGUFWeightStore & weights,
+                                             const char * conv1_weight,
+                                             const char * conv1_bias,
+                                             const char * conv2_weight,
+                                             const char * conv2_bias,
+                                             const char * shortcut_weight,
+                                             const char * shortcut_bias,
+                                             int stride) {
+    const int64_t input_channels = x->ne[2];
+    const int64_t output_channels = weights.get(conv1_bias)->ne[0];
+    ggml_tensor * y = conv2d(ctx, x, weights.get(conv1_weight), weights.get(conv1_bias),
+                             1, stride, 1, 1);
+    y = relu(ctx, y);
+    y = conv2d(ctx, y, weights.get(conv2_weight), weights.get(conv2_bias),
+               1, 1, 1, 1);
+    ggml_tensor * shortcut = x;
+    if (stride != 1 || input_channels != output_channels) {
+        shortcut = conv2d(ctx, x, weights.get(shortcut_weight), weights.get(shortcut_bias),
+                           1, stride, 0, 0);
+    }
+    return relu(ctx, ggml_add(ctx, y, shortcut));
+}
+
+static ggml_tensor * build_campplus_fcm(ggml_context * ctx,
+                                        ggml_tensor * input,
+                                        GGUFWeightStore & weights) {
+    ggml_tensor * x = conv2d(ctx, input,
+                                      weights.get("onnx::Conv_4423"),
+                                      weights.get("onnx::Conv_4424"), 1, 1, 1, 1);
+    x = relu(ctx, x);
+    x = campplus_residual_block(ctx, x, weights,
+                                "onnx::Conv_4426", "onnx::Conv_4427",
+                                "onnx::Conv_4429", "onnx::Conv_4430",
+                                "onnx::Conv_4432", "onnx::Conv_4433", 2);
+    x = campplus_residual_block(ctx, x, weights,
+                                "onnx::Conv_4435", "onnx::Conv_4436",
+                                "onnx::Conv_4438", "onnx::Conv_4439",
+                                nullptr, nullptr, 1);
+    x = campplus_residual_block(ctx, x, weights,
+                                "onnx::Conv_4441", "onnx::Conv_4442",
+                                "onnx::Conv_4444", "onnx::Conv_4445",
+                                "onnx::Conv_4447", "onnx::Conv_4448", 2);
+    x = campplus_residual_block(ctx, x, weights,
+                                "onnx::Conv_4450", "onnx::Conv_4451",
+                                "onnx::Conv_4453", "onnx::Conv_4454",
+                                nullptr, nullptr, 1);
+    x = relu(ctx, conv2d(ctx, x,
+                         weights.get("onnx::Conv_4456"),
+                         weights.get("onnx::Conv_4457"), 1, 2, 1, 1));
+    // Reinterpret the convolution buffer as time-major [time, channels].
+    // Its physical order is already [channel, frequency, time], which is
+    // exactly the contiguous layout required by a ggml [time, channels]
+    // tensor.
+    ggml_tensor * output = ggml_reshape_2d(ctx, x, x->ne[0], x->ne[1] * x->ne[2]);
+    return output;
+}
+
+static ggml_tensor * build_campplus_graph(ggml_context * ctx,
+                                          ggml_tensor * input,
+                                          GGUFWeightStore & weights) {
+    ggml_tensor * x = build_campplus_fcm(ctx, input, weights);
+    x = relu(ctx, conv1d_time_major(ctx, x,
+                                       weights.get("onnx::Conv_4459"),
+                                       weights.get("onnx::Conv_4460"), 2, 2, 1));
+    constexpr std::array<int, 3> layer_counts = { 12, 24, 16 };
+    constexpr std::array<int, 3> linear_bases = { 4462, 4498, 4570 };
+    constexpr std::array<int, 3> dilations = { 1, 2, 2 };
+    constexpr std::array<int, 3> block_ids = { 1, 2, 3 };
+
+    for (size_t block_index = 0; block_index < layer_counts.size(); ++block_index) {
+        const int block = block_ids[block_index];
+        for (int layer = 1; layer <= layer_counts[block_index]; ++layer) {
+            const int weight_id = linear_bases[block_index] + 3 * (layer - 1);
+            const std::string linear_weight = "onnx::Conv_" + std::to_string(weight_id);
+            const std::string linear_bias = "onnx::Conv_" + std::to_string(weight_id + 1);
+            ggml_tensor * dense = campplus_dense_layer(
+                ctx, x, weights, block, layer, linear_weight.c_str(),
+                linear_bias.c_str(), dilations[block_index]);
+            x = ggml_concat(ctx, x, dense, 1);
+        }
+
+        const std::string transit = "xvector.transit" + std::to_string(block);
+        x = batch_norm_time_major(
+            ctx, x,
+            weights.get(transit + ".nonlinear.batchnorm.weight"),
+            weights.get(transit + ".nonlinear.batchnorm.bias"),
+            weights.get(transit + ".nonlinear.batchnorm.running_mean"),
+            weights.get(transit + ".nonlinear.batchnorm.running_var"));
+        x = relu(ctx, x);
+        const std::string transit_weight =
+            block == 3 ? "onnx::Conv_4618"
+                       : ("xvector.transit" + std::to_string(block) + ".linear.weight");
+        const char * transit_bias_name = block == 3 ? "onnx::Conv_4619" : nullptr;
+        x = conv1d_time_major(ctx, x, weights.get(transit_weight),
+                                 transit_bias_name ? weights.get(transit_bias_name) : nullptr,
+                                 1, 0, 1);
+    }
+
+    x = relu(ctx, x);
+
+    const int64_t time = x->ne[0];
+    ggml_tensor * mean = ggml_mean(ctx, x);
+    ggml_tensor * centered = ggml_sub(ctx, x, mean);
+    ggml_tensor * variance = ggml_mean(ctx, ggml_sqr(ctx, centered));
+    variance = ggml_scale(ctx, variance, static_cast<float>(time) /
+                                         static_cast<float>(std::max<int64_t>(1, time - 1)));
+    ggml_tensor * stdev = ggml_sqrt(ctx, variance);
+    ggml_tensor * statistics = ggml_concat(ctx, mean, stdev, 1);
+
+    ggml_tensor * dense = conv1d_time_major(
+        ctx, statistics, weights.get("xvector.dense.linear.weight"), nullptr, 1, 0, 1);
+    return batch_norm_time_major_no_affine(
+        ctx, dense,
+        weights.get("xvector.dense.nonlinear.batchnorm.running_mean"),
+        weights.get("xvector.dense.nonlinear.batchnorm.running_var"));
+}
+
+class FrontendGGUFModels {
+  public:
+    bool load(const std::string & speech_path, const std::string & campplus_path, std::string * error) {
+        backend_.reset(ggml_backend_cpu_init());
+        if (!backend_) {
+            return fail(error, "GGUF frontend: failed to initialize CPU backend");
+        }
+        if (!speech_.load(speech_path, backend_.get(), error)) {
+            return false;
+        }
+        if (!campplus_.load(campplus_path, backend_.get(), error)) {
+            return false;
+        }
+        return true;
+    }
+
+    bool run_speech(const AudioFeatures & features,
+                    int num_threads,
+                    std::vector<int32_t> & tokens,
+                    std::string * error);
+
+    bool run_campplus(const AudioFeatures & features,
+                      int num_threads,
+                      std::vector<float> & embedding,
+                      std::string * error);
+
+  private:
+    static bool fail(std::string * error, const std::string & message) {
+        if (error) {
+            *error = message;
+        }
+        return false;
+    }
+
+    ggml_backend_ptr backend_;
+    GGUFWeightStore speech_;
+    GGUFWeightStore campplus_;
+    std::mutex run_mutex_;
+};
+
+static std::shared_ptr<FrontendGGUFModels> get_frontend_models(
+        const std::string & speech_path, const std::string & campplus_path, std::string * error) {
+    static std::mutex cache_mutex;
+    static std::shared_ptr<FrontendGGUFModels> cached;
+    static std::string cached_speech_path;
+    static std::string cached_campplus_path;
+
+    std::lock_guard<std::mutex> lock(cache_mutex);
+    if (cached && cached_speech_path == speech_path && cached_campplus_path == campplus_path) {
+        return cached;
+    }
+    auto candidate = std::make_shared<FrontendGGUFModels>();
+    if (!candidate->load(speech_path, campplus_path, error)) {
+        return nullptr;
+    }
+    cached = std::move(candidate);
+    cached_speech_path = speech_path;
+    cached_campplus_path = campplus_path;
+    return cached;
+}
+
+static ggml_tensor * s3_attention(ggml_context * ctx,
+                                  ggml_tensor * x,
+                                  const S3BlockNames & names,
+                                  GGUFWeightStore & weights,
+                                  ggml_tensor * cos_factor,
+                                  ggml_tensor * sin_factor) {
+    constexpr int64_t n_head = 20;
+    constexpr int64_t head_dim = 64;
+    const int64_t time = x->ne[1];
+    ggml_tensor * normalized = layer_norm(ctx, x, weights.get(names.attn_ln_w), weights.get(names.attn_ln_b));
+    ggml_tensor * q = linear(ctx, normalized, weights.get(names.q_w), weights.get(names.q_b));
+    ggml_tensor * k = linear(ctx, normalized, weights.get(names.k_w), nullptr);
+    ggml_tensor * v = linear(ctx, normalized, weights.get(names.v_w), weights.get(names.v_b));
+    q = ggml_reshape_3d(ctx, q, head_dim, n_head, time);
+    k = ggml_reshape_3d(ctx, k, head_dim, n_head, time);
+    v = ggml_reshape_3d(ctx, v, head_dim, n_head, time);
+    q = rotary_apply(ctx, q, cos_factor, sin_factor);
+    k = rotary_apply(ctx, k, cos_factor, sin_factor);
+
+    ggml_tensor * q_flat = flatten_attention_qk(ctx, q, head_dim, time, 1, n_head);
+    ggml_tensor * k_flat = flatten_attention_qk(ctx, k, head_dim, time, 1, n_head);
+    ggml_tensor * scores = ggml_mul_mat(ctx, k_flat, q_flat);  // [T, T, H]
+    ggml_mul_mat_set_prec(scores, GGML_PREC_F32);
+    scores = ggml_scale(ctx, scores, std::pow(static_cast<float>(head_dim), -0.5f));
+    ggml_tensor * probabilities = ggml_soft_max(ctx, scores);
+
+    ggml_tensor * v_flat = flatten_attention_v(ctx, v, head_dim, time, 1, n_head);
+    ggml_tensor * context = ggml_mul_mat(ctx, v_flat, probabilities); // [D, T, H]
+    context = merge_attention_heads(ctx, context, head_dim, n_head, time, 1);
+    ggml_tensor * projected = linear(ctx, context, weights.get(names.out_w), weights.get(names.out_b));
+
+    ggml_tensor * v_for_fsmn = linear(ctx, normalized, weights.get(names.v_w), weights.get(names.v_b));
+    ggml_tensor * fsmn_input = v_for_fsmn;
+    v_for_fsmn = ggml_pad_ext(ctx, v_for_fsmn, 0, 0, 15, 15, 0, 0, 0, 0);
+    ggml_tensor * fsmn = conv1d_depthwise(ctx, v_for_fsmn, weights.get(names.fsmn), 1, 0, 1);
+    fsmn = ggml_add(ctx, fsmn, fsmn_input);
+    return ggml_add(ctx, projected, fsmn);
+}
+
+static ggml_tensor * build_s3_graph(ggml_context * ctx,
+                                     ggml_tensor * input,
+                                     GGUFWeightStore & weights,
+                                     ggml_tensor * cos_factor,
+                                     ggml_tensor * sin_factor) {
+    ggml_tensor * x = conv1d(ctx, input, weights.get("onnx::Conv_2216"),
+                             weights.get("onnx::Conv_2217"), 2, 1, 1);
+    x = gelu(ctx, x);
+    x = conv1d(ctx, x, weights.get("onnx::Conv_2218"),
+               weights.get("onnx::Conv_2219"), 2, 1, 1);
+    x = gelu(ctx, x);
+    x = ggml_cont_2d(ctx, x, x->ne[0], x->ne[1]);
+
+    for (const auto & block : s3_block_names()) {
+        ggml_tensor * residual = x;
+        ggml_tensor * attention = s3_attention(ctx, x, block, weights, cos_factor, sin_factor);
+        x = ggml_add(ctx, residual, attention);
+        residual = x;
+        ggml_tensor * mlp_input = layer_norm(ctx, x, weights.get(block.mlp_ln_w), weights.get(block.mlp_ln_b));
+        mlp_input = linear(ctx, mlp_input, weights.get(block.mlp1_w), weights.get(block.mlp1_b));
+        mlp_input = gelu(ctx, mlp_input);
+        mlp_input = linear(ctx, mlp_input, weights.get(block.mlp2_w), weights.get(block.mlp2_b));
+        x = ggml_add(ctx, residual, mlp_input);
+    }
+    ggml_tensor * output = linear(ctx, x, weights.get("onnx::MatMul_2536"),
+                                  weights.get("quantizer.project_in.bias"));
+    return output;
+}
+
+}  // namespace
+
+bool FrontendGGUFModels::run_speech(const AudioFeatures & features,
+                                    int num_threads,
+                                    std::vector<int32_t> & tokens,
+                                    std::string * error) {
+    std::lock_guard<std::mutex> lock(run_mutex_);
+    tokens.clear();
+    if (features.channels != 128 || features.frames <= 0 ||
+        features.values.size() != static_cast<size_t>(features.channels) * features.frames) {
+        return fail(error, "GGUF speech tokenizer input must have shape [128, T]");
+    }
+
+    ggml_backend_cpu_set_n_threads(backend_.get(), std::max(1, num_threads));
+    ggml_init_params params = {
+        /*.mem_size   =*/ 1024ull * 1024ull * 1024ull,
+        /*.mem_buffer =*/ nullptr,
+        /*.no_alloc   =*/ true,
+    };
+    ggml_context_ptr ctx(ggml_init(params));
+    if (!ctx) {
+        return fail(error, "GGUF speech tokenizer: failed to create compute context");
+    }
+    const int64_t time = features.frames;
+    ggml_tensor * input = ggml_new_tensor_2d(ctx.get(), GGML_TYPE_F32, features.channels, time);
+    ggml_set_input(input);
+    const int64_t token_time = ((time + 1) / 2 + 1) / 2;
+    ggml_tensor * cos_factor = make_rotary_factor(ctx.get(), 64, token_time);
+    ggml_tensor * sin_factor = make_rotary_factor(ctx.get(), 64, token_time);
+    ggml_tensor * output = build_s3_graph(ctx.get(), input, speech_, cos_factor, sin_factor);
+    if (!output) {
+        return fail(error, "GGUF speech tokenizer: failed to build graph");
+    }
+    const int64_t output_time = output->ne[1];
+    // The graph output is [8, T]. Quantization uses tanh -> round + 1 and
+    // base-3 positional encoding over the eight scalar code dimensions.
+    ggml_tensor * quantized = ggml_tanh(ctx.get(), output);
+    quantized = ggml_scale(ctx.get(), quantized, 0.9990000128746033f);
+    quantized = ggml_add(ctx.get(), quantized, scalar_tensor(ctx.get(), 1.0f));
+    quantized = ggml_round(ctx.get(), quantized);
+    ggml_tensor * powers = ggml_new_tensor_1d(ctx.get(), GGML_TYPE_F32, 8);
+    ggml_set_input(powers);
+    std::array<float, 8> power_values{};
+    power_values[0] = 1.0f;
+    for (size_t i = 1; i < power_values.size(); ++i) {
+        power_values[i] = power_values[i - 1] * 3.0f;
+    }
+    ggml_tensor * code_values = ggml_sum_rows(ctx.get(), ggml_mul(ctx.get(), quantized, powers));
+    ggml_cgraph * graph = ggml_new_graph_custom(ctx.get(), GGML_DEFAULT_GRAPH_SIZE * 16, false);
+    ggml_build_forward_expand(graph, code_values);
+    ggml_set_output(code_values);
+
+    ggml_backend_buffer_ptr buffer(
+        ggml_backend_alloc_ctx_tensors_from_buft(ctx.get(), ggml_backend_get_default_buffer_type(backend_.get())));
+    if (!buffer) {
+        return fail(error, "GGUF speech tokenizer: failed to allocate compute buffer");
+    }
+    std::vector<float> input_values(features.values.size());
+    for (int64_t frame = 0; frame < time; ++frame) {
+        for (int64_t channel = 0; channel < features.channels; ++channel) {
+            input_values[static_cast<size_t>(frame) * features.channels + channel] =
+                features.values[static_cast<size_t>(channel) * time + frame];
+        }
+    }
+    ggml_backend_tensor_set(input, input_values.data(), 0, input_values.size() * sizeof(float));
+    std::array<float, 8> powers_host = power_values;
+    ggml_backend_tensor_set(powers, powers_host.data(), 0, powers_host.size() * sizeof(float));
+    // make_rotary_factor wrote host values before allocation; copy them again
+    // through the backend API because no_alloc contexts do not retain data.
+    std::vector<float> cos_values(static_cast<size_t>(64 * cos_factor->ne[1]));
+    std::vector<float> sin_values(static_cast<size_t>(64 * sin_factor->ne[1]));
+    for (int64_t t = 0; t < cos_factor->ne[1]; ++t) {
+        for (int64_t d = 0; d < 64; ++d) {
+            const int64_t half = d % 32;
+            const float frequency = std::pow(10000.0f, -2.0f * static_cast<float>(half) / 64.0f);
+            cos_values[static_cast<size_t>(d + 64 * t)] = std::cos(static_cast<float>(t) * frequency);
+            sin_values[static_cast<size_t>(d + 64 * t)] = std::sin(static_cast<float>(t) * frequency);
+        }
+    }
+    ggml_backend_tensor_set(cos_factor, cos_values.data(), 0, cos_values.size() * sizeof(float));
+    ggml_backend_tensor_set(sin_factor, sin_values.data(), 0, sin_values.size() * sizeof(float));
+    if (ggml_backend_graph_compute(backend_.get(), graph) != GGML_STATUS_SUCCESS) {
+        return fail(error, "GGUF speech tokenizer: graph compute failed");
+    }
+
+    std::vector<float> code_host(static_cast<size_t>(code_values->ne[0] * code_values->ne[1]));
+    ggml_backend_tensor_get(code_values, code_host.data(), 0, code_host.size() * sizeof(float));
+    tokens.resize(static_cast<size_t>(output_time));
+    for (int64_t t = 0; t < output_time; ++t) {
+        const float value = code_host[static_cast<size_t>(t)];
+        if (!std::isfinite(value) || value < 0.0f || value > 6560.0f) {
+            return fail(error, "GGUF speech tokenizer: invalid quantized token");
+        }
+        tokens[static_cast<size_t>(t)] = static_cast<int32_t>(value);
+    }
+    return true;
+}
+
+bool FrontendGGUFModels::run_campplus(const AudioFeatures & features,
+                                      int num_threads,
+                                      std::vector<float> & embedding,
+                                      std::string * error) {
+    embedding.clear();
+    if (features.channels != 80 || features.frames <= 0 ||
+        features.values.size() != static_cast<size_t>(features.channels) * features.frames) {
+        return fail(error, "GGUF CampPlus input must have shape [T, 80]");
+    }
+
+    ggml_backend_cpu_set_n_threads(backend_.get(), std::max(1, num_threads));
+    ggml_init_params params = {
+        /*.mem_size   =*/ 1024ull * 1024ull * 1024ull,
+        /*.mem_buffer =*/ nullptr,
+        /*.no_alloc   =*/ true,
+    };
+    ggml_context_ptr ctx(ggml_init(params));
+    if (!ctx) {
+        return fail(error, "GGUF CampPlus: failed to create compute context");
+    }
+
+    const int64_t time = features.frames;
+    // GGML conv2d uses [time, frequency, channels, batch], while the public
+    // AudioFeatures buffer is stored as [frame, frequency].
+    ggml_tensor * input = ggml_new_tensor_4d(ctx.get(), GGML_TYPE_F32, time, 80, 1, 1);
+    ggml_set_input(input);
+    ggml_tensor * output = build_campplus_graph(ctx.get(), input, campplus_);
+    if (!output || output->ne[0] != 1 || output->ne[1] != 192) {
+        return fail(error, "GGUF CampPlus: graph produced an invalid output shape");
+    }
+    ggml_set_output(output);
+    ggml_cgraph * graph = ggml_new_graph_custom(ctx.get(), GGML_DEFAULT_GRAPH_SIZE * 512, false);
+    ggml_build_forward_expand(graph, output);
+
+    ggml_backend_buffer_ptr buffer(
+        ggml_backend_alloc_ctx_tensors_from_buft(ctx.get(), ggml_backend_get_default_buffer_type(backend_.get())));
+    if (!buffer) {
+        return fail(error, "GGUF CampPlus: failed to allocate compute buffer");
+    }
+
+    std::vector<float> input_values(static_cast<size_t>(time) * 80);
+    for (int64_t feature = 0; feature < 80; ++feature) {
+        for (int64_t frame = 0; frame < time; ++frame) {
+            input_values[static_cast<size_t>(frame) + static_cast<size_t>(time) * feature] =
+                features.values[static_cast<size_t>(frame) * 80 + static_cast<size_t>(feature)];
+        }
+    }
+    ggml_backend_tensor_set(input, input_values.data(), 0, input_values.size() * sizeof(float));
+    if (ggml_backend_graph_compute(backend_.get(), graph) != GGML_STATUS_SUCCESS) {
+        return fail(error, "GGUF CampPlus: graph compute failed");
+    }
+
+    embedding.resize(192);
+    ggml_backend_tensor_get(output, embedding.data(), 0, embedding.size() * sizeof(float));
+    for (const float value : embedding) {
+        if (!std::isfinite(value)) {
+            embedding.clear();
+            return fail(error, "GGUF CampPlus: output contains a non-finite value");
+        }
+    }
+    return true;
+}
+
+bool prepare_prompt_bundle_gguf(const AudioFeatures & speech_features,
+                                const AudioFeatures & campplus_features,
+                                const std::string &  speech_model_path,
+                                const std::string &  campplus_model_path,
+                                int                    num_threads,
+                                std::vector<int32_t> & speech_tokens,
+                                std::vector<float> &   speaker_embedding,
+                                std::string *           error) {
+    auto models = get_frontend_models(speech_model_path, campplus_model_path, error);
+    if (!models) {
+        return false;
+    }
+    if (!models->run_speech(speech_features, num_threads, speech_tokens, error)) {
+        return false;
+    }
+    return models->run_campplus(campplus_features, num_threads, speaker_embedding, error);
+}
+
+}  // namespace flow
+}  // namespace omni

--- a/tools/omni/token2wav/token2wav-frontend-gguf.h
+++ b/tools/omni/token2wav/token2wav-frontend-gguf.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "token2wav-frontend.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace omni {
+namespace flow {
+
+// Run both StepAudio2 frontend models from GGUF weights using ggml.
+bool prepare_prompt_bundle_gguf(const AudioFeatures & speech_features,
+                                const AudioFeatures & campplus_features,
+                                const std::string &  speech_model_path,
+                                const std::string &  campplus_model_path,
+                                int                    num_threads,
+                                std::vector<int32_t> & speech_tokens,
+                                std::vector<float> &   speaker_embedding,
+                                std::string *           error = nullptr);
+
+}  // namespace flow
+}  // namespace omni

--- a/tools/omni/token2wav/token2wav-frontend.cpp
+++ b/tools/omni/token2wav/token2wav-frontend.cpp
@@ -1,0 +1,778 @@
+#include "token2wav-frontend.h"
+#include "token2wav-frontend-gguf.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <limits>
+#include <numeric>
+#include <sstream>
+#include <string>
+#include <utility>
+
+namespace omni {
+namespace flow {
+namespace {
+
+constexpr float  kPi = 3.14159265358979323846f;
+constexpr size_t kMaxResampleKernelElements = 4ULL * 1024ULL * 1024ULL;
+
+static float hz_to_mel_slaney(float hz) {
+    constexpr float min_log_hz = 1000.0f;
+    constexpr float min_log_mel = 15.0f;
+    constexpr float logstep = 0.06875177742094912f;  // log(6.4) / 27
+    if (hz < min_log_hz) {
+        return hz * (3.0f / 200.0f);
+    }
+    return min_log_mel + std::log(hz / min_log_hz) / logstep;
+}
+
+static float mel_to_hz_slaney(float mel) {
+    constexpr float min_log_hz = 1000.0f;
+    constexpr float min_log_mel = 15.0f;
+    constexpr float logstep = 0.06875177742094912f;
+    if (mel < min_log_mel) {
+        return mel * (200.0f / 3.0f);
+    }
+    return min_log_hz * std::exp(logstep * (mel - min_log_mel));
+}
+
+static std::vector<float> make_librosa_mel_filterbank(int sample_rate,
+                                                       int n_fft,
+                                                       int n_mels,
+                                                       float fmin,
+                                                       float fmax) {
+    const int n_freqs = n_fft / 2 + 1;
+    std::vector<float> filters(static_cast<size_t>(n_mels) * static_cast<size_t>(n_freqs), 0.0f);
+
+    const float mel_min = hz_to_mel_slaney(fmin);
+    const float mel_max = hz_to_mel_slaney(fmax);
+    std::vector<float> points(static_cast<size_t>(n_mels + 2));
+    for (int i = 0; i < n_mels + 2; ++i) {
+        const float mel = mel_min + (mel_max - mel_min) * static_cast<float>(i) /
+                                           static_cast<float>(n_mels + 1);
+        points[static_cast<size_t>(i)] = mel_to_hz_slaney(mel);
+    }
+
+    for (int m = 0; m < n_mels; ++m) {
+        const float left   = points[static_cast<size_t>(m)];
+        const float center = points[static_cast<size_t>(m + 1)];
+        const float right  = points[static_cast<size_t>(m + 2)];
+        const int left_i   = std::max(0, static_cast<int>(std::floor(
+                                      left * static_cast<float>(n_fft) / static_cast<float>(sample_rate))));
+        const int right_i  = std::min(n_freqs - 1, static_cast<int>(std::ceil(
+                                       right * static_cast<float>(n_fft) / static_cast<float>(sample_rate))));
+
+        for (int k = left_i; k <= right_i; ++k) {
+            const float frequency = static_cast<float>(k) * static_cast<float>(sample_rate) /
+                                    static_cast<float>(n_fft);
+            const float up = (frequency - left) / (center - left);
+            const float down = (right - frequency) / (right - center);
+            filters[static_cast<size_t>(m) * n_freqs + k] = std::max(0.0f, std::min(up, down));
+        }
+
+        // librosa's default Slaney normalization makes the area of every
+        // triangular filter equal to one in the frequency domain.
+        const float enorm = 2.0f / std::max(1e-12f, right - left);
+        for (int k = left_i; k <= right_i; ++k) {
+            filters[static_cast<size_t>(m) * n_freqs + k] *= enorm;
+        }
+    }
+    return filters;
+}
+
+struct DftPlan {
+    int                n_fft = 0;
+    std::vector<float> cos_table;
+    std::vector<float> sin_table;
+};
+
+static DftPlan make_dft_plan(int n_fft) {
+    DftPlan plan;
+    plan.n_fft = n_fft;
+    plan.cos_table.resize(static_cast<size_t>(n_fft / 2 + 1) * static_cast<size_t>(n_fft));
+    plan.sin_table.resize(static_cast<size_t>(n_fft / 2 + 1) * static_cast<size_t>(n_fft));
+    for (int k = 0; k <= n_fft / 2; ++k) {
+        for (int n = 0; n < n_fft; ++n) {
+            const float angle = 2.0f * kPi * static_cast<float>(k * n) / static_cast<float>(n_fft);
+            plan.cos_table[static_cast<size_t>(k) * n_fft + n] = std::cos(angle);
+            plan.sin_table[static_cast<size_t>(k) * n_fft + n] = std::sin(angle);
+        }
+    }
+    return plan;
+}
+
+static std::vector<float> dft_power(const std::vector<float> & frame, const DftPlan & plan) {
+    const int n_fft   = plan.n_fft;
+    const int n_freqs = n_fft / 2 + 1;
+    std::vector<float> power(static_cast<size_t>(n_freqs), 0.0f);
+    for (int k = 0; k < n_freqs; ++k) {
+        float real = 0.0f;
+        float imag = 0.0f;
+        const size_t base = static_cast<size_t>(k) * n_fft;
+        for (int n = 0; n < n_fft; ++n) {
+            real += frame[static_cast<size_t>(n)] * plan.cos_table[base + n];
+            imag -= frame[static_cast<size_t>(n)] * plan.sin_table[base + n];
+        }
+        power[static_cast<size_t>(k)] = real * real + imag * imag;
+    }
+    return power;
+}
+
+static std::vector<float> dft_magnitude(const std::vector<float> & frame, const DftPlan & plan) {
+    const int n_fft   = plan.n_fft;
+    const int n_freqs = n_fft / 2 + 1;
+    std::vector<float> magnitude(static_cast<size_t>(n_freqs), 0.0f);
+    for (int k = 0; k < n_freqs; ++k) {
+        float real = 0.0f;
+        float imag = 0.0f;
+        const size_t base = static_cast<size_t>(k) * n_fft;
+        for (int n = 0; n < n_fft; ++n) {
+            real += frame[static_cast<size_t>(n)] * plan.cos_table[base + n];
+            imag -= frame[static_cast<size_t>(n)] * plan.sin_table[base + n];
+        }
+        magnitude[static_cast<size_t>(k)] = std::sqrt(real * real + imag * imag + 1e-9f);
+    }
+    return magnitude;
+}
+
+static float reflect_sample(const std::vector<float> & input, int index) {
+    const int n = static_cast<int>(input.size());
+    if (n <= 1) {
+        return input.empty() ? 0.0f : input[0];
+    }
+    while (index < 0 || index >= n) {
+        if (index < 0) {
+            index = -index;
+        } else {
+            index = 2 * n - 2 - index;
+        }
+    }
+    return input[static_cast<size_t>(index)];
+}
+
+static std::vector<float> hann_window(int size) {
+    std::vector<float> window(static_cast<size_t>(size));
+    for (int i = 0; i < size; ++i) {
+        window[static_cast<size_t>(i)] =
+            0.5f - 0.5f * std::cos(2.0f * kPi * static_cast<float>(i) / static_cast<float>(size));
+    }
+    return window;
+}
+
+static std::vector<float> povey_window(int size) {
+    std::vector<float> window(static_cast<size_t>(size));
+    for (int i = 0; i < size; ++i) {
+        const float phase = 2.0f * kPi * static_cast<float>(i) / static_cast<float>(size - 1);
+        window[static_cast<size_t>(i)] = std::pow(0.5f - 0.5f * std::cos(phase), 0.85f);
+    }
+    return window;
+}
+
+static void set_features(AudioFeatures & out, int channels, int frames, std::vector<float> values) {
+    out.channels = channels;
+    out.frames   = frames;
+    out.values   = std::move(values);
+}
+
+static uint16_t read_u16_le(const uint8_t * data) {
+    return static_cast<uint16_t>(data[0]) | (static_cast<uint16_t>(data[1]) << 8);
+}
+
+static uint32_t read_u32_le(const uint8_t * data) {
+    return static_cast<uint32_t>(data[0]) |
+           (static_cast<uint32_t>(data[1]) << 8) |
+           (static_cast<uint32_t>(data[2]) << 16) |
+           (static_cast<uint32_t>(data[3]) << 24);
+}
+
+static int32_t sign_extend_24(uint32_t value) {
+    if (value & 0x00800000U) {
+        value |= 0xff000000U;
+    }
+    return static_cast<int32_t>(value);
+}
+
+static bool valid_audio(const std::vector<float> & audio) {
+    if (audio.empty()) {
+        return false;
+    }
+    for (const float value : audio) {
+        if (!std::isfinite(value)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static bool set_error(std::string * error, const std::string & message) {
+    if (error) {
+        *error = message;
+    }
+    return false;
+}
+
+static bool replicate_pad_features(AudioFeatures & features, int target_frames, std::string * error) {
+    if (features.channels <= 0 || features.frames <= 0 ||
+        features.values.size() != static_cast<size_t>(features.channels) * features.frames) {
+        return set_error(error, "cannot pad invalid audio features");
+    }
+    if (target_frames < features.frames) {
+        return set_error(error,
+                         "prompt Mel has more frames than speech token target: target " +
+                             std::to_string(target_frames) + ", got " + std::to_string(features.frames));
+    }
+    if (target_frames == features.frames) {
+        return true;
+    }
+
+    std::vector<float> padded(static_cast<size_t>(features.channels) * target_frames);
+    for (int c = 0; c < features.channels; ++c) {
+        const size_t source_base = static_cast<size_t>(c) * features.frames;
+        const size_t target_base = static_cast<size_t>(c) * target_frames;
+        std::copy(features.values.begin() + source_base,
+                  features.values.begin() + source_base + features.frames,
+                  padded.begin() + target_base);
+        const float last = features.values[source_base + features.frames - 1];
+        std::fill(padded.begin() + target_base + features.frames,
+                  padded.begin() + target_base + target_frames,
+                  last);
+    }
+    features.frames = target_frames;
+    features.values = std::move(padded);
+    return true;
+}
+
+static bool subtract_feature_column_mean(AudioFeatures & features, std::string * error) {
+    if (features.channels <= 0 || features.frames <= 0 ||
+        features.values.size() != static_cast<size_t>(features.channels) * features.frames) {
+        return set_error(error, "cannot normalize invalid audio features");
+    }
+    for (int c = 0; c < features.channels; ++c) {
+        float mean = 0.0f;
+        for (int t = 0; t < features.frames; ++t) {
+            mean += features.values[static_cast<size_t>(t) * features.channels + c];
+        }
+        mean /= static_cast<float>(features.frames);
+        for (int t = 0; t < features.frames; ++t) {
+            features.values[static_cast<size_t>(t) * features.channels + c] -= mean;
+        }
+    }
+    return true;
+}
+
+}  // namespace
+
+bool Token2WavFrontend::validate_speech_tokenizer_output_shape(const std::vector<int64_t> & shape,
+                                                               std::string *                  error) {
+    const bool valid = (shape.size() == 1 && shape[0] > 0) ||
+                       (shape.size() == 2 && shape[0] == 1 && shape[1] > 0);
+    if (!valid) {
+        return set_error(error, "speech tokenizer output must have shape [T] or [1, T] with B=1");
+    }
+    return true;
+}
+
+bool Token2WavFrontend::validate_campplus_output_shape(const std::vector<int64_t> & shape,
+                                                       std::string *                  error) {
+    const bool valid = (shape.size() == 1 && shape[0] == 192) ||
+                       (shape.size() == 2 && shape[0] == 1 && shape[1] == 192);
+    if (!valid) {
+        return set_error(error, "CampPlus output must have shape [192] or [1, 192] with B=1");
+    }
+    return true;
+}
+
+bool Token2WavFrontend::load_wav_mono(const std::string & path, AudioBuffer & out) {
+    out = AudioBuffer();
+
+    std::error_code file_error;
+    const std::filesystem::file_status status = std::filesystem::status(path, file_error);
+    if (file_error || !std::filesystem::is_regular_file(status)) {
+        return false;
+    }
+    const uintmax_t file_size = std::filesystem::file_size(path, file_error);
+    if (file_error || file_size < 12 || file_size > kMaxReferenceWavBytes ||
+        file_size > static_cast<uintmax_t>(std::numeric_limits<size_t>::max())) {
+        return false;
+    }
+
+    std::ifstream file(path, std::ios::binary);
+    if (!file.good()) {
+        return false;
+    }
+
+    std::vector<uint8_t> bytes(static_cast<size_t>(file_size));
+    if (!bytes.empty() &&
+        (!file.read(reinterpret_cast<char *>(bytes.data()),
+                    static_cast<std::streamsize>(bytes.size())) ||
+         file.gcount() != static_cast<std::streamsize>(bytes.size()))) {
+        return false;
+    }
+    if (bytes.size() < 12 || std::memcmp(bytes.data(), "RIFF", 4) != 0 ||
+        std::memcmp(bytes.data() + 8, "WAVE", 4) != 0) {
+        return false;
+    }
+
+    uint16_t format_tag = 0;
+    uint16_t channels = 0;
+    uint16_t bits_per_sample = 0;
+    uint32_t sample_rate = 0;
+    uint16_t block_align = 0;
+    size_t data_offset = 0;
+    size_t data_size = 0;
+    size_t offset = 12;
+    while (offset + 8 <= bytes.size()) {
+        const uint8_t * chunk = bytes.data() + offset;
+        const uint32_t chunk_size = read_u32_le(chunk + 4);
+        const size_t payload = offset + 8;
+        if (payload > bytes.size() || chunk_size > bytes.size() - payload) {
+            return false;
+        }
+        if (std::memcmp(chunk, "fmt ", 4) == 0 && chunk_size >= 16) {
+            format_tag       = read_u16_le(bytes.data() + payload);
+            channels         = read_u16_le(bytes.data() + payload + 2);
+            sample_rate      = read_u32_le(bytes.data() + payload + 4);
+            block_align      = read_u16_le(bytes.data() + payload + 12);
+            bits_per_sample  = read_u16_le(bytes.data() + payload + 14);
+            if (format_tag == 0xfffe && chunk_size >= 40) {
+                // WAVE_FORMAT_EXTENSIBLE stores the PCM/IEEE subtype at
+                // the beginning of the 16-byte subformat GUID.
+                const uint16_t subtype = read_u16_le(bytes.data() + payload + 24);
+                if (subtype == 1 || subtype == 3) {
+                    format_tag = subtype;
+                }
+            }
+        } else if (std::memcmp(chunk, "data", 4) == 0) {
+            data_offset = payload;
+            data_size   = chunk_size;
+        }
+        offset = payload + chunk_size + (chunk_size & 1U);
+    }
+
+    const size_t bytes_per_sample = bits_per_sample / 8;
+    const size_t frame_bytes = static_cast<size_t>(channels) * bytes_per_sample;
+    if ((format_tag != 1 && format_tag != 3) || channels == 0 || sample_rate == 0 ||
+        bytes_per_sample == 0 || block_align == 0 || frame_bytes > block_align ||
+        data_size == 0 || data_offset > bytes.size() ||
+        data_size > bytes.size() - data_offset || data_size % block_align != 0) {
+        return false;
+    }
+    if (format_tag == 3 && bits_per_sample != 32) {
+        return false;
+    }
+    if (format_tag == 1 && bits_per_sample != 8 && bits_per_sample != 16 &&
+        bits_per_sample != 24 && bits_per_sample != 32) {
+        return false;
+    }
+
+    const size_t frame_count = data_size / block_align;
+    const uint64_t max_frame_count =
+        static_cast<uint64_t>(sample_rate) * kMaxReferenceAudioDurationSeconds;
+    if (frame_count > max_frame_count) {
+        return false;
+    }
+
+    out.sample_rate = static_cast<int32_t>(sample_rate);
+    out.samples.resize(frame_count);
+    for (size_t frame = 0; frame < frame_count; ++frame) {
+        const size_t frame_offset = data_offset + frame * block_align;
+        float mono = 0.0f;
+        for (uint16_t channel = 0; channel < channels; ++channel) {
+            const size_t channel_offset = static_cast<size_t>(channel) * bytes_per_sample;
+            if (channel_offset > block_align ||
+                bytes_per_sample > block_align - channel_offset ||
+                frame_offset > bytes.size() ||
+                channel_offset > bytes.size() - frame_offset ||
+                bytes_per_sample > bytes.size() - frame_offset - channel_offset) {
+                return false;
+            }
+            const size_t sample_offset = frame_offset + channel_offset;
+            const uint8_t * sample = bytes.data() + sample_offset;
+            float value = 0.0f;
+            if (format_tag == 3) {
+                std::memcpy(&value, sample, sizeof(float));
+            } else if (bits_per_sample == 8) {
+                value = (static_cast<int>(sample[0]) - 128) / 128.0f;
+            } else if (bits_per_sample == 16) {
+                const int16_t integer = static_cast<int16_t>(read_u16_le(sample));
+                value = static_cast<float>(integer) / 32768.0f;
+            } else if (bits_per_sample == 24) {
+                const uint32_t packed = static_cast<uint32_t>(sample[0]) |
+                                         (static_cast<uint32_t>(sample[1]) << 8) |
+                                         (static_cast<uint32_t>(sample[2]) << 16);
+                value = static_cast<float>(sign_extend_24(packed)) / 8388608.0f;
+            } else {
+                const int32_t integer = static_cast<int32_t>(read_u32_le(sample));
+                value = static_cast<float>(static_cast<double>(integer) / 2147483648.0);
+            }
+            mono += value;
+        }
+        out.samples[frame] = mono / static_cast<float>(channels);
+    }
+    return valid_audio(out.samples);
+}
+
+bool Token2WavFrontend::resample_mono(const AudioBuffer & input, int32_t target_sample_rate, AudioBuffer & out) {
+    out = AudioBuffer();
+    if (input.sample_rate <= 0 || target_sample_rate <= 0 || !valid_audio(input.samples)) {
+        return false;
+    }
+    if (input.sample_rate == target_sample_rate) {
+        out = input;
+        return true;
+    }
+
+    const int rate_gcd = std::gcd(input.sample_rate, target_sample_rate);
+    const int64_t orig_freq_64 = input.sample_rate / rate_gcd;
+    const int64_t new_freq_64 = target_sample_rate / rate_gcd;
+    constexpr int lowpass_filter_width = 6;
+    constexpr double rolloff = 0.99;
+    const double base_freq = static_cast<double>(std::min(orig_freq_64, new_freq_64)) * rolloff;
+    const int64_t width_64 = static_cast<int64_t>(std::ceil(
+        static_cast<double>(lowpass_filter_width) * static_cast<double>(orig_freq_64) / base_freq));
+    const int64_t kernel_width_64 = 2 * width_64 + orig_freq_64;
+    if (orig_freq_64 > std::numeric_limits<int>::max() ||
+        new_freq_64 > std::numeric_limits<int>::max() ||
+        width_64 > std::numeric_limits<int>::max() ||
+        kernel_width_64 > std::numeric_limits<int>::max() ||
+        static_cast<uint64_t>(new_freq_64) >
+            kMaxResampleKernelElements / static_cast<uint64_t>(kernel_width_64)) {
+        return false;
+    }
+    const int orig_freq = static_cast<int>(orig_freq_64);
+    const int new_freq = static_cast<int>(new_freq_64);
+    const int width = static_cast<int>(width_64);
+    const int kernel_width = static_cast<int>(kernel_width_64);
+    const int group_count = static_cast<int>(
+        (input.samples.size() + static_cast<size_t>(orig_freq) - 1) / static_cast<size_t>(orig_freq));
+    const size_t output_size = static_cast<size_t>(
+        std::max<int64_t>(
+            1,
+            (static_cast<int64_t>(input.samples.size()) * new_freq + orig_freq - 1) / orig_freq));
+
+    out.sample_rate = target_sample_rate;
+    out.samples.resize(output_size);
+
+    // Match torchaudio.functional._get_sinc_resample_kernel and
+    // _apply_sinc_resample_kernel. The kernel is stored as float32 because
+    // torchaudio.transforms.Resample caches a float32 kernel by default.
+    std::vector<float> kernels(static_cast<size_t>(new_freq) * kernel_width, 0.0f);
+    for (int phase = 0; phase < new_freq; ++phase) {
+        for (int k = 0; k < kernel_width; ++k) {
+            const double idx = static_cast<double>(k - width) / static_cast<double>(orig_freq);
+            double t = (idx - static_cast<double>(phase) / static_cast<double>(new_freq)) * base_freq;
+            t = std::max(-static_cast<double>(lowpass_filter_width),
+                         std::min(static_cast<double>(lowpass_filter_width), t));
+            const double window =
+                std::cos(t * kPi / static_cast<double>(lowpass_filter_width) / 2.0);
+            const double t_pi = t * kPi;
+            const double sinc = std::fabs(t_pi) < 1e-15 ? 1.0 : std::sin(t_pi) / t_pi;
+            kernels[static_cast<size_t>(phase) * kernel_width + k] =
+                static_cast<float>(sinc * window * window * base_freq / static_cast<double>(orig_freq));
+        }
+    }
+
+    size_t output_index = 0;
+    for (int group = 0; group < group_count && output_index < output_size; ++group) {
+        for (int phase = 0; phase < new_freq && output_index < output_size; ++phase) {
+            float value = 0.0f;
+            const size_t kernel_base = static_cast<size_t>(phase) * kernel_width;
+            for (int k = 0; k < kernel_width; ++k) {
+                const int64_t source_index =
+                    static_cast<int64_t>(group) * orig_freq + k - width;
+                if (source_index >= 0 && source_index < static_cast<int64_t>(input.samples.size())) {
+                    value += input.samples[static_cast<size_t>(source_index)] *
+                             kernels[kernel_base + k];
+                }
+            }
+            out.samples[output_index++] = value;
+        }
+    }
+    if (output_index != output_size) {
+        return false;
+    }
+    return valid_audio(out.samples);
+}
+
+bool Token2WavFrontend::assemble_prompt_bundle(const std::vector<int32_t> & speech_tokens,
+                                               const AudioFeatures &          prompt_mel_ct,
+                                               const std::vector<float> &     speaker_embedding,
+                                               FrontendPromptBundle &         out,
+                                               std::string *                  error) {
+    out = FrontendPromptBundle();
+    if (speech_tokens.empty()) {
+        return set_error(error, "speech tokenizer returned no tokens");
+    }
+    if (prompt_mel_ct.channels != 80 || prompt_mel_ct.frames <= 0 ||
+        prompt_mel_ct.values.size() != static_cast<size_t>(prompt_mel_ct.channels) * prompt_mel_ct.frames) {
+        return set_error(error, "prompt Mel must have shape [80, T]");
+    }
+    if (speaker_embedding.size() != 192) {
+        return set_error(error, "speaker embedding must have 192 dimensions");
+    }
+
+    const int64_t expected_frames = static_cast<int64_t>(speech_tokens.size()) * 2;
+    if (prompt_mel_ct.frames != expected_frames) {
+        return set_error(error,
+                         "prompt Mel frame count does not match speech token count: expected " +
+                             std::to_string(expected_frames) + ", got " +
+                             std::to_string(prompt_mel_ct.frames));
+    }
+    for (const float value : prompt_mel_ct.values) {
+        if (!std::isfinite(value)) {
+            return set_error(error, "prompt Mel contains a non-finite value");
+        }
+    }
+    for (const float value : speaker_embedding) {
+        if (!std::isfinite(value)) {
+            return set_error(error, "speaker embedding contains a non-finite value");
+        }
+    }
+
+    out.B = 1;
+    out.prompt_tokens_bt = speech_tokens;
+    out.prompt_tokens_bt.insert(out.prompt_tokens_bt.end(), 3, 4218);
+    out.T_prompt_token = static_cast<int64_t>(out.prompt_tokens_bt.size());
+    out.T_prompt_mel   = prompt_mel_ct.frames;
+    out.prompt_mel_btc.resize(prompt_mel_ct.values.size());
+    for (int64_t t = 0; t < prompt_mel_ct.frames; ++t) {
+        for (int64_t c = 0; c < prompt_mel_ct.channels; ++c) {
+            out.prompt_mel_btc[static_cast<size_t>(t) * prompt_mel_ct.channels + c] =
+                prompt_mel_ct.values[static_cast<size_t>(c) * prompt_mel_ct.frames + t];
+        }
+    }
+    out.spk_bc = speaker_embedding;
+    return true;
+}
+
+bool Token2WavFrontend::prepare_prompt_bundle(const std::string & ref_wav_path,
+                                              const std::string & speech_tokenizer_gguf,
+                                              const std::string & campplus_gguf,
+                                              FrontendPromptBundle & out,
+                                              std::string *            error,
+                                              int                      num_threads) {
+    out = FrontendPromptBundle();
+    AudioBuffer input;
+    if (!load_wav_mono(ref_wav_path, input)) {
+        return set_error(error, "failed to decode reference WAV: " + ref_wav_path);
+    }
+
+    AudioBuffer audio_16k;
+    AudioBuffer audio_24k;
+    if (!resample_mono(input, 16000, audio_16k)) {
+        return set_error(error, "failed to resample reference WAV to 16 kHz");
+    }
+    if (!resample_mono(input, 24000, audio_24k)) {
+        return set_error(error, "failed to resample reference WAV to 24 kHz");
+    }
+
+    AudioFeatures speech_features;
+    if (!compute_s3_log_mel(audio_16k.samples, speech_features)) {
+        return set_error(error, "failed to compute speech tokenizer log-Mel features");
+    }
+
+    AudioFeatures campplus_features;
+    if (!compute_campplus_fbank(audio_16k.samples, campplus_features)) {
+        return set_error(error, "failed to compute CampPlus fbank features");
+    }
+    if (!subtract_feature_column_mean(campplus_features, error)) {
+        return false;
+    }
+    std::vector<int32_t> speech_tokens;
+    std::vector<float> speaker_embedding;
+    if (!prepare_prompt_bundle_gguf(speech_features, campplus_features, speech_tokenizer_gguf,
+                                    campplus_gguf, num_threads, speech_tokens, speaker_embedding, error)) {
+        return false;
+    }
+
+    AudioFeatures prompt_mel_ct;
+    if (!compute_token2wav_prompt_mel(audio_24k.samples, prompt_mel_ct)) {
+        return set_error(error, "failed to compute Token2Wav prompt Mel features");
+    }
+    const int64_t expected_prompt_mel_frames = static_cast<int64_t>(speech_tokens.size()) * 2;
+    if (!replicate_pad_features(prompt_mel_ct, static_cast<int>(expected_prompt_mel_frames), error)) {
+        return false;
+    }
+    return assemble_prompt_bundle(speech_tokens, prompt_mel_ct, speaker_embedding, out, error);
+}
+
+bool Token2WavFrontend::compute_s3_log_mel(const std::vector<float> & audio_16k, AudioFeatures & out) {
+    out = AudioFeatures();
+    if (!valid_audio(audio_16k)) {
+        return false;
+    }
+
+    constexpr int sample_rate = 16000;
+    constexpr int n_fft = 400;
+    constexpr int hop = 160;
+    constexpr int n_mels = 128;
+    constexpr int center_padding = n_fft / 2;
+
+    const int frame_count = 1 + static_cast<int>(
+                                      (audio_16k.size() + 2 * center_padding - n_fft) /
+                                      static_cast<size_t>(hop));
+    if (frame_count <= 1) {
+        return false;
+    }
+
+    const auto window = hann_window(n_fft);
+    const auto plan = make_dft_plan(n_fft);
+    const auto filters = make_librosa_mel_filterbank(sample_rate, n_fft, n_mels, 0.0f, 8000.0f);
+    const int output_frames = frame_count - 1;
+    std::vector<float> values(static_cast<size_t>(n_mels) * output_frames, 0.0f);
+    std::vector<float> frame(static_cast<size_t>(n_fft));
+    float global_max_log = -std::numeric_limits<float>::infinity();
+
+    for (int t = 0; t < output_frames; ++t) {
+        const int offset = t * hop - center_padding;
+        for (int n = 0; n < n_fft; ++n) {
+            frame[static_cast<size_t>(n)] = reflect_sample(audio_16k, offset + n) * window[static_cast<size_t>(n)];
+        }
+        const auto power = dft_power(frame, plan);
+        for (int m = 0; m < n_mels; ++m) {
+            float mel = 0.0f;
+            const size_t filter_base = static_cast<size_t>(m) * (n_fft / 2 + 1);
+            for (int k = 0; k < n_fft / 2; ++k) {
+                mel += filters[filter_base + k] * power[static_cast<size_t>(k)];
+            }
+            const float log_mel = std::log10(std::max(mel, 1e-10f));
+            values[static_cast<size_t>(m) * output_frames + t] = log_mel;
+            global_max_log = std::max(global_max_log, log_mel);
+        }
+    }
+    for (float & value : values) {
+        value = (std::max(value, global_max_log - 8.0f) + 4.0f) / 4.0f;
+    }
+
+    set_features(out, n_mels, output_frames, std::move(values));
+    return true;
+}
+
+bool Token2WavFrontend::compute_token2wav_prompt_mel(const std::vector<float> & audio_24k,
+                                                      AudioFeatures & out) {
+    out = AudioFeatures();
+    if (!valid_audio(audio_24k)) {
+        return false;
+    }
+
+    constexpr int sample_rate = 24000;
+    constexpr int n_fft = 1920;
+    constexpr int hop = 480;
+    constexpr int n_mels = 80;
+    constexpr int pad = (n_fft - hop) / 2;
+
+    const int padded_size = static_cast<int>(audio_24k.size()) + 2 * pad;
+    if (padded_size < n_fft) {
+        return false;
+    }
+    const int frames = 1 + (padded_size - n_fft) / hop;
+    const auto window = hann_window(n_fft);
+    const auto plan = make_dft_plan(n_fft);
+    const auto filters = make_librosa_mel_filterbank(sample_rate, n_fft, n_mels, 0.0f, 8000.0f);
+    std::vector<float> values(static_cast<size_t>(n_mels) * frames, 0.0f);
+    std::vector<float> frame(static_cast<size_t>(n_fft));
+
+    for (int t = 0; t < frames; ++t) {
+        const int offset = t * hop - pad;
+        for (int n = 0; n < n_fft; ++n) {
+            frame[static_cast<size_t>(n)] = reflect_sample(audio_24k, offset + n) * window[static_cast<size_t>(n)];
+        }
+        const auto magnitude = dft_magnitude(frame, plan);
+        for (int m = 0; m < n_mels; ++m) {
+            float mel = 0.0f;
+            const size_t filter_base = static_cast<size_t>(m) * (n_fft / 2 + 1);
+            for (int k = 0; k <= n_fft / 2; ++k) {
+                mel += filters[filter_base + k] * magnitude[static_cast<size_t>(k)];
+            }
+            values[static_cast<size_t>(m) * frames + t] = std::log(std::max(mel, 1e-5f));
+        }
+    }
+
+    set_features(out, n_mels, frames, std::move(values));
+    return true;
+}
+
+bool Token2WavFrontend::compute_campplus_fbank(const std::vector<float> & audio_16k,
+                                                AudioFeatures & out) {
+    out = AudioFeatures();
+    if (!valid_audio(audio_16k)) {
+        return false;
+    }
+
+    constexpr int sample_rate = 16000;
+    constexpr int window_size = 400;
+    constexpr int window_shift = 160;
+    constexpr int padded_window_size = 512;
+    constexpr int n_mels = 80;
+    constexpr float low_freq = 20.0f;
+    constexpr float high_freq = 8000.0f;
+
+    if (audio_16k.size() < static_cast<size_t>(window_size)) {
+        return false;
+    }
+    const int frames = 1 + static_cast<int>((audio_16k.size() - window_size) / window_shift);
+    const auto window = povey_window(window_size);
+    const auto plan = make_dft_plan(padded_window_size);
+    const float mel_min = 1127.0f * std::log(1.0f + low_freq / 700.0f);
+    const float mel_max = 1127.0f * std::log(1.0f + high_freq / 700.0f);
+    const float mel_delta = (mel_max - mel_min) / static_cast<float>(n_mels + 1);
+    const float fft_bin_width = static_cast<float>(sample_rate) / padded_window_size;
+    std::vector<float> filters(static_cast<size_t>(n_mels) * (padded_window_size / 2 + 1), 0.0f);
+    for (int m = 0; m < n_mels; ++m) {
+        const float left_mel = mel_min + static_cast<float>(m) * mel_delta;
+        const float center_mel = left_mel + mel_delta;
+        const float right_mel = center_mel + mel_delta;
+        for (int k = 0; k <= padded_window_size / 2; ++k) {
+            const float hz = fft_bin_width * static_cast<float>(k);
+            const float mel = 1127.0f * std::log(1.0f + hz / 700.0f);
+            const float up = (mel - left_mel) / (center_mel - left_mel);
+            const float down = (right_mel - mel) / (right_mel - center_mel);
+            filters[static_cast<size_t>(m) * (padded_window_size / 2 + 1) + k] =
+                std::max(0.0f, std::min(up, down));
+        }
+    }
+
+    std::vector<float> values(static_cast<size_t>(frames) * n_mels, 0.0f);
+    std::vector<float> frame(static_cast<size_t>(padded_window_size), 0.0f);
+    for (int t = 0; t < frames; ++t) {
+        const size_t offset = static_cast<size_t>(t * window_shift);
+        float mean = 0.0f;
+        for (int n = 0; n < window_size; ++n) {
+            mean += audio_16k[offset + static_cast<size_t>(n)];
+        }
+        mean /= static_cast<float>(window_size);
+        float previous = 0.0f;
+        for (int n = 0; n < window_size; ++n) {
+            const float centered = audio_16k[offset + static_cast<size_t>(n)] - mean;
+            if (n == 0) {
+                frame[static_cast<size_t>(n)] = (centered - 0.97f * centered) * window[static_cast<size_t>(n)];
+            } else {
+                frame[static_cast<size_t>(n)] = (centered - 0.97f * previous) * window[static_cast<size_t>(n)];
+            }
+            previous = centered;
+        }
+        std::fill(frame.begin() + window_size, frame.end(), 0.0f);
+        const auto power = dft_power(frame, plan);
+        for (int m = 0; m < n_mels; ++m) {
+            float energy = 0.0f;
+            const size_t filter_base = static_cast<size_t>(m) * (padded_window_size / 2 + 1);
+            for (int k = 0; k < padded_window_size / 2; ++k) {
+                energy += filters[filter_base + k] * power[static_cast<size_t>(k)];
+            }
+            values[static_cast<size_t>(t) * n_mels + m] =
+                std::log(std::max(energy, std::numeric_limits<float>::epsilon()));
+        }
+    }
+
+    set_features(out, n_mels, frames, std::move(values));
+    return true;
+}
+
+}  // namespace flow
+}  // namespace omni

--- a/tools/omni/token2wav/token2wav-frontend.h
+++ b/tools/omni/token2wav/token2wav-frontend.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace omni {
+namespace flow {
+
+struct AudioFeatures {
+    int32_t              channels = 0;
+    int32_t              frames   = 0;
+    std::vector<float>   values;
+};
+
+struct AudioBuffer {
+    int32_t            sample_rate = 0;
+    std::vector<float> samples;
+};
+
+struct FrontendPromptBundle {
+    std::vector<int32_t> prompt_tokens_bt;
+    std::vector<float>   prompt_mel_btc;
+    std::vector<float>   spk_bc;
+
+    int64_t B              = 1;
+    int64_t T_prompt_token = 0;
+    int64_t T_prompt_mel   = 0;
+};
+
+class Token2WavFrontend {
+  public:
+    static constexpr size_t kMaxReferenceWavBytes = 64ULL * 1024ULL * 1024ULL;
+    static constexpr uint32_t kMaxReferenceAudioDurationSeconds = 30;
+
+    // Decode an audio file as mono float32 while preserving the source sample rate.
+    static bool load_wav_mono(const std::string & path, AudioBuffer & out);
+
+    // Resample mono audio with the StepAudio2-compatible windowed-sinc kernel.
+    static bool resample_mono(const AudioBuffer & input, int32_t target_sample_rate, AudioBuffer & out);
+
+    // Compute the 16 kHz speech-tokenizer log-Mel input in [channel, frame] layout.
+    static bool compute_s3_log_mel(const std::vector<float> & audio_16k, AudioFeatures & out);
+
+    // Compute the 24 kHz Token2Wav prompt Mel input in [channel, frame] layout.
+    static bool compute_token2wav_prompt_mel(const std::vector<float> & audio_24k, AudioFeatures & out);
+
+    // Compute the 16 kHz Kaldi fbank input in [frame, channel] layout.
+    static bool compute_campplus_fbank(const std::vector<float> & audio_16k, AudioFeatures & out);
+
+    // Assemble the native model outputs into the PromptBundle contract used by
+    // Token2Mel. speech_tokens does not include the three pre-lookahead tokens.
+    static bool assemble_prompt_bundle(const std::vector<int32_t> & speech_tokens,
+                                       const AudioFeatures &          prompt_mel_ct,
+                                       const std::vector<float> &     speaker_embedding,
+                                       FrontendPromptBundle &         out,
+                                       std::string *                  error = nullptr);
+
+    // Validate the output shapes accepted from the GGUF frontend models.
+    // Rank-1 tensors represent an already-squeezed batch; rank-2 tensors
+    // must have B=1.
+    static bool validate_speech_tokenizer_output_shape(const std::vector<int64_t> & shape,
+                                                       std::string *                  error = nullptr);
+    static bool validate_campplus_output_shape(const std::vector<int64_t> & shape,
+                                               std::string *                  error = nullptr);
+
+    // Run the native WAV frontend using the two GGUF frontend models.
+    static bool prepare_prompt_bundle(const std::string & ref_wav_path,
+                                      const std::string & speech_tokenizer_gguf,
+                                      const std::string & campplus_gguf,
+                                      FrontendPromptBundle & out,
+                                      std::string *            error = nullptr,
+                                      int                      num_threads = 1);
+};
+
+}  // namespace flow
+}  // namespace omni

--- a/tools/omni/token2wav/token2wav-impl.cpp
+++ b/tools/omni/token2wav/token2wav-impl.cpp
@@ -9437,9 +9437,17 @@ bool Token2Mel::push_tokens(const int32_t * tokens, int64_t n_tokens, bool is_fi
         const int64_t B           = 1;
         const int64_t C           = kMelChannels;
         const int64_t T           = (int64_t) mel_chunk_bct.size() / (B * C);
-        const int64_t max_valid_T = n_tokens * 2;
+        // The fixed graph is padded to 28 tokens. Python's non-final
+        // streaming path drops the three-token right lookahead; the final
+        // window keeps all real tokens.
+        const int64_t real_tokens = is_final
+                                        ? n_tokens
+                                        : std::max<int64_t>(0, n_tokens - kPreLookahead);
+        const int64_t max_valid_T = real_tokens * 2;
         const int64_t valid_T     = std::min<int64_t>(T, max_valid_T);
-        if (valid_T < T && valid_T > 0) {
+        if (valid_T == 0) {
+            mel_chunk_bct.clear();
+        } else if (valid_T < T) {
             std::vector<float> cropped((size_t) B * (size_t) C * (size_t) valid_T);
             for (int64_t b = 0; b < B; ++b) {
                 for (int64_t c = 0; c < C; ++c) {
@@ -9556,7 +9564,8 @@ bool Token2MelSession::feed_window(const int32_t *      tokens,
                                    int64_t              n_tokens,
                                    bool                 is_final,
                                    std::vector<float> & mel_bct_out) {
-    // 窗口接口（预期是外部输入和内部消费逻辑一致，外面传几个，内部使用几个）：外部提供<=25 tokens + prelook，每次调用只推理一次并返回该次mel（已完成读入python前转置）(BCT,f32)
+    // Window interface used by the runtime: receive up to 25 generated
+    // tokens and let Token2Mel add its internal three-token padding.
     mel_bct_out.clear();
 
     return t2m.push_tokens(tokens, n_tokens, is_final, mel_bct_out);
@@ -9642,6 +9651,25 @@ void fade_in_out_b1(std::vector<float> &       wave_inout,
         wave_inout[(size_t) i] =
             wave_inout[(size_t) i] * window_2n[(size_t) i] + prev_tail[(size_t) i] * window_2n[(size_t) (i + n)];
     }
+}
+
+void trim_stream_wave_b1(std::vector<float> & wave_inout,
+                         bool                is_first,
+                         bool                is_final,
+                         int64_t             cache_len) {
+    if (is_final || cache_len <= 0) {
+        return;
+    }
+
+    const size_t trim = std::min(
+        wave_inout.size(), static_cast<size_t>(cache_len));
+    std::vector<float> trimmed;
+    if (is_first) {
+        trimmed.assign(static_cast<size_t>(cache_len), 0.0f);
+    }
+    trimmed.insert(trimmed.end(), wave_inout.begin(),
+                   wave_inout.end() - trim);
+    wave_inout.swap(trimmed);
 }
 
 }  // namespace token2wav_utils
@@ -9781,7 +9809,8 @@ bool Token2Wav::push_tokens_window(const int32_t *      tokens,
     }
     const auto t_voc1 = clock::now();
 
-    if (!voc_speech_cache_bt_.empty()) {
+    const bool is_first_stream_chunk = voc_speech_cache_bt_.empty();
+    if (!is_first_stream_chunk) {
         token2wav_utils::fade_in_out_b1(wave_bt_out, voc_speech_cache_bt_, voc_speech_window_, (int64_t) kSourceCacheLen);
     }
 
@@ -9806,10 +9835,9 @@ bool Token2Wav::push_tokens_window(const int32_t *      tokens,
         voc_speech_cache_bt_.swap(next_speech_cache);
     }
 
-    if (!is_final && (int64_t) wave_bt_out.size() > (int64_t) kSourceCacheLen) {
-        wave_bt_out.resize(wave_bt_out.size() - (size_t) kSourceCacheLen);
-        out_T_audio = (int64_t) wave_bt_out.size();
-    }
+    token2wav_utils::trim_stream_wave_b1(
+        wave_bt_out, is_first_stream_chunk, is_final, kSourceCacheLen);
+    out_T_audio = (int64_t) wave_bt_out.size();
 
     const double voc_ms   = std::chrono::duration<double, std::milli>(t_voc1 - t_voc0).count();
     const double total_ms = std::chrono::duration<double, std::milli>(clock::now() - t_total0).count();

--- a/tools/omni/token2wav/token2wav-impl.h
+++ b/tools/omni/token2wav/token2wav-impl.h
@@ -2190,6 +2190,13 @@ void fade_in_out_b1(std::vector<float> &       wave_inout,
                     const std::vector<float> & window_2n,
                     int64_t                    n);
 
+// Match StepAudio2's first non-final streaming chunk handling: prepend one
+// source-cache of silence after trimming the unavailable right context.
+void trim_stream_wave_b1(std::vector<float> & wave_inout,
+                         bool                is_first,
+                         bool                is_final,
+                         int64_t             cache_len);
+
 }  // namespace token2wav_utils
 
 class Token2Wav {

--- a/tools/omni/token2wav/token2wav-impl.h
+++ b/tools/omni/token2wav/token2wav-impl.h
@@ -2298,6 +2298,11 @@ struct Token2WavSession {
                                     int                 n_timesteps = 10,
                                     float               temperature = 1.0f);
 
+    // Restore a precomputed prompt bundle without reloading model weights.
+    bool reset_to_prompt_bundle(const std::string & prompt_bundle_dir,
+                                int                 n_timesteps = 10,
+                                float               temperature = 1.0f);
+
     bool feed_tokens(const int32_t * tokens, int64_t n_tokens, bool is_final, std::vector<float> & wave_bt_out);
 
     bool feed_tokens(const std::vector<int32_t> & tokens, bool is_final, std::vector<float> & wave_bt_out) {

--- a/tools/omni/token2wav/token2wav-impl.h
+++ b/tools/omni/token2wav/token2wav-impl.h
@@ -2277,6 +2277,20 @@ struct Token2WavSession {
                                  float               temperature         = 1.0f,
                                  const std::string & coreml_model_path  = "");
 
+    // Prepare a PromptBundle from a reference WAV with the native GGUF
+    // frontend, then install it into the existing Token2Wav stream.
+    bool set_prompt_wav(const std::string & ref_wav_path,
+                        const std::string & speech_tokenizer_gguf,
+                        const std::string & campplus_gguf,
+                        int                 frontend_threads = 1,
+                        int                 n_timesteps       = 10,
+                        float               temperature       = 1.0f);
+
+    // Restore the static voice cache without reloading model weights.
+    bool reset_to_prompt_cache_gguf(const std::string & prompt_cache_gguf_path,
+                                    int                 n_timesteps = 10,
+                                    float               temperature = 1.0f);
+
     bool feed_tokens(const int32_t * tokens, int64_t n_tokens, bool is_final, std::vector<float> & wave_bt_out);
 
     bool feed_tokens(const std::vector<int32_t> & tokens, bool is_final, std::vector<float> & wave_bt_out) {

--- a/tools/omni/token2wav/token2wav.cpp
+++ b/tools/omni/token2wav/token2wav.cpp
@@ -1,4 +1,5 @@
 #include "token2wav.h"
+#include "token2wav-frontend.h"
 #include "token2wav-profile.h"
 
 #include <chrono>
@@ -60,6 +61,56 @@ bool Token2WavSession::init_from_prompt_bundle(const std::string & encoder_gguf,
     if (!t2w.start_stream_with_prompt(pb, n_timesteps, temperature)) {
         return false;
     }
+    return true;
+}
+
+bool Token2WavSession::set_prompt_wav(const std::string & ref_wav_path,
+                                      const std::string & speech_tokenizer_gguf,
+                                      const std::string & campplus_gguf,
+                                      int                 frontend_threads,
+                                      int                 n_timesteps,
+                                      float               temperature) {
+    FrontendPromptBundle native_prompt;
+    std::string error;
+    if (!Token2WavFrontend::prepare_prompt_bundle(ref_wav_path, speech_tokenizer_gguf, campplus_gguf,
+                                                  native_prompt, &error, frontend_threads)) {
+        std::fprintf(stderr,
+                     "Token2WavSession.set_prompt_wav: native frontend failed for %s: %s\n",
+                     ref_wav_path.c_str(), error.empty() ? "unknown error" : error.c_str());
+        return false;
+    }
+
+    Token2Mel::PromptBundle prompt;
+    prompt.prompt_tokens_bt = std::move(native_prompt.prompt_tokens_bt);
+    prompt.prompt_mel_btc   = std::move(native_prompt.prompt_mel_btc);
+    prompt.spk_bc            = std::move(native_prompt.spk_bc);
+    prompt.B                 = native_prompt.B;
+    prompt.T_prompt_token   = native_prompt.T_prompt_token;
+    prompt.T_prompt_mel     = native_prompt.T_prompt_mel;
+
+    if (!t2w.start_stream_with_prompt(prompt, n_timesteps, temperature)) {
+        std::fprintf(stderr,
+                     "Token2WavSession.set_prompt_wav: setup_cache failed for %s\n",
+                     ref_wav_path.c_str());
+        return false;
+    }
+
+    pending_.clear();
+    wave_tmp_.clear();
+    return true;
+}
+
+bool Token2WavSession::reset_to_prompt_cache_gguf(const std::string & prompt_cache_gguf_path,
+                                                  int                 n_timesteps,
+                                                  float               temperature) {
+    if (!t2w.start_stream_with_prompt_cache_gguf(prompt_cache_gguf_path, n_timesteps, temperature)) {
+        std::fprintf(stderr, "Token2WavSession.reset_to_prompt_cache_gguf: failed to load cache: %s\n",
+                     prompt_cache_gguf_path.c_str());
+        return false;
+    }
+
+    pending_.clear();
+    wave_tmp_.clear();
     return true;
 }
 

--- a/tools/omni/token2wav/token2wav.cpp
+++ b/tools/omni/token2wav/token2wav.cpp
@@ -114,12 +114,32 @@ bool Token2WavSession::reset_to_prompt_cache_gguf(const std::string & prompt_cac
     return true;
 }
 
+bool Token2WavSession::reset_to_prompt_bundle(const std::string & prompt_bundle_dir,
+                                              int                 n_timesteps,
+                                              float               temperature) {
+    Token2Mel::PromptBundle prompt;
+    if (!Token2Mel::load_prompt_bundle_dir(prompt_bundle_dir, prompt)) {
+        std::fprintf(stderr, "Token2WavSession.reset_to_prompt_bundle: failed to load bundle: %s\n",
+                     prompt_bundle_dir.c_str());
+        return false;
+    }
+    if (!t2w.start_stream_with_prompt(prompt, n_timesteps, temperature)) {
+        std::fprintf(stderr, "Token2WavSession.reset_to_prompt_bundle: failed to install bundle: %s\n",
+                     prompt_bundle_dir.c_str());
+        return false;
+    }
+
+    pending_.clear();
+    wave_tmp_.clear();
+    return true;
+}
+
 bool Token2WavSession::feed_window(const int32_t *      tokens,
                                    int64_t              n_tokens,
                                    bool                 is_final,
                                    std::vector<float> & wave_bt_out) {
-    // 推理送入token第一种（vector返回，持续写到vector中。调用方持有wave_bt_out，返回后数据还在）
-    // 在外部做好25token+下一个chunk的3个token，送入28token
+    // The caller supplies a 28-token window (25 main tokens plus 3 lookahead
+    // tokens); a final window may contain fewer tokens.
     wave_bt_out.clear();
     int64_t T_audio = 0;
     if (!t2w.push_tokens_window(tokens, n_tokens, is_final, wave_bt_out, T_audio)) {

--- a/tools/server/protocol.cpp
+++ b/tools/server/protocol.cpp
@@ -284,8 +284,10 @@ ParsedSessionInit parse_session_init(const json & msg) {
     // voice (reference audio)
     if (p.contains("voice") && p.at("voice").is_object()) {
         const json & v = p.at("voice");
-        out.ref_audio_b64 = json_str_any(v, {"ref_audio", "ref_audio_base64"});
-        out.tts_ref_audio_b64 = json_str_any(v, {"tts_ref_audio", "tts_ref_audio_base64"});
+        out.ref_audio_b64 = strip_data_url_prefix(
+            json_str_any(v, {"ref_audio", "ref_audio_base64"}));
+        out.tts_ref_audio_b64 = strip_data_url_prefix(
+            json_str_any(v, {"tts_ref_audio", "tts_ref_audio_base64"}));
         if (out.tts_ref_audio_b64.empty() && !out.ref_audio_b64.empty()) {
             out.tts_ref_audio_b64 = out.ref_audio_b64;
         }

--- a/tools/server/server-omni.cpp
+++ b/tools/server/server-omni.cpp
@@ -151,6 +151,7 @@ int main(int argc, char ** argv) {
         std::string token2wav_device = data.value("token2wav_device", "gpu:0");
         std::string output_dir = data.value("output_dir", "./tools/omni/output");
         std::string voice_audio = data.value("voice_audio", "");
+        std::string tts_ref_audio = data.value("tts_ref_audio", voice_audio);
 
         // validate key files
         auto check_file = [&](const std::string & role, const std::string & path) -> bool {
@@ -197,6 +198,14 @@ int main(int argc, char ** argv) {
         // voice clone / assistant prompt
         if (data.contains("voice_clone_prompt")) octx->omni_voice_clone_prompt = data["voice_clone_prompt"];
         if (data.contains("assistant_prompt")) octx->omni_assistant_prompt = data["assistant_prompt"];
+        octx->ref_audio_path = voice_audio;
+        if (use_tts && !tts_ref_audio.empty()) {
+            if (!omni_set_tts_reference_audio(octx, tts_ref_audio)) {
+                omni_free(octx);
+                res_error(res, format_error_response("tts_voice_prepare_failed"));
+                return;
+            }
+        }
 
         {
             std::lock_guard<std::mutex> lock(state.octx_mutex);

--- a/tools/server/ws_handler.cpp
+++ b/tools/server/ws_handler.cpp
@@ -171,9 +171,21 @@ static void stop_reusable_octx_threads(omni_context * octx) {
 // Wipe per-session state on a reused context: stop threads, reset counters/flags,
 // clear LLM/TTS/whisper KV caches, so the next session starts clean on the same
 // loaded model. Used by the shared-octx reuse path in create_session_octx.
-static void reset_octx_for_session(omni_context * octx, const ParsedSessionInit & init,
+static bool reset_octx_for_session(omni_context * octx, const ParsedSessionInit & init,
                                    const std::string & output_dir) {
     stop_reusable_octx_threads(octx);
+
+    if (init.use_tts && init.tts_ref_audio_b64.empty()) {
+        if (!omni_reset_tts_reference_audio(octx)) {
+            LOG_ERR("reset_octx_for_session: failed to restore default TTS voice\n");
+            return false;
+        }
+    } else if (octx->tts_ref_audio_owned && !octx->tts_ref_audio_path.empty()) {
+        fs::remove(octx->tts_ref_audio_path);
+    }
+    octx->tts_ref_audio_path.clear();
+    octx->tts_ref_audio_owned = false;
+    octx->ref_audio_path.clear();
 
     const bool duplex_mode = (init.mode == "full_duplex");
     octx->async = true;
@@ -226,6 +238,7 @@ static void reset_octx_for_session(omni_context * octx, const ParsedSessionInit 
     if (!init.system_prompt.empty()) {
         octx->omni_assistant_prompt = init.system_prompt;
     }
+    return true;
 }
 
 // Apply the optional opaque init.config (sampling/decoding knobs, §6) onto the
@@ -533,7 +546,12 @@ static omni_context * create_session_octx(common_params & params, const ParsedSe
     // Reuse the server-owned context if it matches this session's mode (avoids
     // reloading the model); otherwise tear it down and build a fresh one.
     if (shared_octx && shared_octx->duplex_mode == duplex_mode && shared_octx->use_tts == use_tts) {
-        reset_octx_for_session(shared_octx, init, output_dir);
+        if (!reset_octx_for_session(shared_octx, init, output_dir)) {
+            LOG_ERR("create_session_octx: failed to reset reused context\n");
+            omni_free(shared_octx);
+            shared_octx = nullptr;
+            return nullptr;
+        }
         apply_session_config(p, shared_octx, init);
         LOG_INF("create_session_octx: reused shared octx, duplex=%d, output_dir=%s\n",
                 duplex_mode, output_dir.c_str());
@@ -653,13 +671,50 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
         return;
     }
 
+    std::string voice_wav;
+    std::string tts_voice_wav;
+    if (!parsed_init.ref_audio_b64.empty()) {
+        voice_wav = TempMediaFiles::write_audio_wav(
+            parsed_init.ref_audio_b64, temp_dir, msg_counter++);
+        if (voice_wav.empty()) {
+            fail_fast(session_id, "voice_audio_decode_failed");
+            return;
+        }
+        octx->ref_audio_path = voice_wav;
+    }
+    if (parsed_init.use_tts && !parsed_init.tts_ref_audio_b64.empty()) {
+        const bool reuse_ref_audio = !voice_wav.empty() &&
+                                     parsed_init.tts_ref_audio_b64 == parsed_init.ref_audio_b64;
+        tts_voice_wav = reuse_ref_audio
+                            ? voice_wav
+                            : TempMediaFiles::write_audio_wav(
+                                  parsed_init.tts_ref_audio_b64, temp_dir, msg_counter++);
+        if (tts_voice_wav.empty()) {
+            if (!voice_wav.empty()) {
+                fs::remove(voice_wav);
+            }
+            fail_fast(session_id, "tts_voice_audio_decode_failed");
+            return;
+        }
+        octx->tts_ref_audio_path = tts_voice_wav;
+        octx->tts_ref_audio_owned = true;
+        if (!omni_set_tts_reference_audio(octx, tts_voice_wav)) {
+            if (!voice_wav.empty()) {
+                fs::remove(voice_wav);
+            }
+            if (tts_voice_wav != voice_wav) {
+                fs::remove(tts_voice_wav);
+            }
+            octx->tts_ref_audio_path.clear();
+            octx->tts_ref_audio_owned = false;
+            fail_fast(session_id, "tts_voice_prepare_failed");
+            return;
+        }
+    }
+
     // Full-duplex requires index=0 prefill before the first frame. This
     // initializes the system prompt and starts the duplex encoder/LLM pipeline.
     if (parsed_init.mode == "full_duplex" || !parsed_init.ref_audio_b64.empty()) {
-        std::string voice_wav;
-        if (!parsed_init.ref_audio_b64.empty()) {
-            voice_wav = TempMediaFiles::write_audio_wav(parsed_init.ref_audio_b64, temp_dir, msg_counter++);
-        }
         if (!parsed_init.ref_audio_b64.empty() && voice_wav.empty()) {
             fail_fast(session_id, "voice_audio_decode_failed");
             return;
@@ -671,7 +726,10 @@ void handle_ws_backend(httplib::ws::WebSocket & ws,
             fail_fast(session_id, "voice_prefill_failed");
             return;
         }
-        if (!voice_wav.empty()) fs::remove(voice_wav);
+        if (!voice_wav.empty() &&
+            (!octx->tts_ref_audio_owned || octx->tts_ref_audio_path != voice_wav)) {
+            fs::remove(voice_wav);
+        }
         if (octx->llm_thread_info) {
             octx->llm_thread_info->start = std::chrono::steady_clock::now();
         }


### PR DESCRIPTION
## Overview

This PR adds native C++ GGUF voice cloning to the Omni runtime.

The implementation adds a native Token2Wav frontend using the GGUF speech tokenizer and CAM++ models, connects reference-audio conditioning to `omni_set_tts_reference_audio()`, and exposes the voice reference fields through the Legacy HTTP and WebSocket paths. The runtime uses the native C++ backend; it does not add a Python online voice-cloning fallback or an ONNX Runtime dependency.

The streaming path follows the Python base window contract: 25 main audio tokens with 3 lookahead tokens in the fixed 28-token graph. The PR also preserves the actual default prompt source during context reuse and prevents simplex lookahead text from being emitted twice.

## Validation

- `llama-omni-server` builds successfully with the native GGUF frontend.
- `test-token2wav-frontend` passes.
- `test-tts-quality-contract` passes.
- Legacy HTTP reference-audio conditioning passes with valid mono PCM16 24 kHz WAV output.
- Turn-based WebSocket reference-audio conditioning and default voice context reuse pass.
- A private CUDA end-to-end run sent 28 full-duplex frames and produced finite, non-silent native T2W audio with observed speak/listen states, continuous input during playback, no worker errors, and no playback gap within speak turns.

`test-token2wav-session` requires external model assets and was skipped in the local asset-free environment; model-backed session coverage was completed in the private CUDA validation environment.

The existing upstream full-duplex response lifecycle can emit asynchronous audio after `response.done` or omit a terminal event. That behavior is unchanged by this PR and is reported separately from native voice-cloning correctness.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. AI was used for code review, debugging assistance, and test orchestration. The contributor reviewed the implementation and is responsible for the submitted changes.
